### PR TITLE
Some performance tuning

### DIFF
--- a/src/Parlot/CharToStringTable.cs
+++ b/src/Parlot/CharToStringTable.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.CompilerServices;
-using System.Text;
+﻿using System.Runtime.CompilerServices;
 
 namespace Parlot
 {
@@ -11,23 +8,24 @@ namespace Parlot
     /// </summary>
     internal static class CharToStringTable
     {
-        private static readonly int Size = 256;
-        private static readonly string[] Table = new string[Size];
+        private const int _size = 256;
+        private static readonly string[] _table = new string[_size];
 
         static CharToStringTable()
         {
-            for (int i = 0; i < Size; i++)
+            for (int i = 0; i < _size; i++)
             {
-                Table[i] = ((char)i).ToString();
+                _table[i] = ((char)i).ToString();
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string GetString(char c)
         {
-            if (c < Size)
+            string[] table = _table;
+            if (c < (uint) table.Length)
             {
-                return Table[c];
+                return table[c];
             }
 
             return c.ToString();

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -5,20 +5,21 @@ namespace Parlot
 {
     public class Cursor
     {
-        public static readonly char NullChar = '\0';
+        public const char NullChar = '\0';
 
         private readonly int _textLength;
         private char _current;
         private int _offset;
         private int _line;
         private int _column;
+        private readonly string _buffer;
 
         public Cursor(string buffer, TextPosition position)
         {
-            Buffer = buffer;
-            _textLength = buffer.Length;
+            _buffer = buffer;
+            _textLength = _buffer.Length;
             Eof = _textLength == 0;
-            _current = _textLength == 0 ? NullChar : Buffer[position.Offset];
+            _current = _textLength == 0 ? NullChar : _buffer[position.Offset];
             _offset = 0;
             _line = 1;
             _column = 1;
@@ -28,12 +29,11 @@ namespace Parlot
         {
         }
 
-        public TextPosition Position => new (_offset, _line, _column);
+        public TextPosition Position => new(_offset, _line, _column);
 
         /// <summary>
         /// Advances the cursor.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance(int count = 1)
         {
             if (Eof)
@@ -53,7 +53,7 @@ namespace Parlot
                     return;
                 }
 
-                var c = Buffer[_offset];
+                var c = _buffer[_offset];
 
                 if (_current == '\n')
                 {
@@ -86,14 +86,14 @@ namespace Parlot
             _column = position.Column;
 
             // Eof might have been recorded
-            if (_offset >= Buffer.Length)
+            if (_offset >= _buffer.Length)
             {
                 _current = NullChar;
                 Eof = true;
             }
             else
             {
-                _current = Buffer[position.Offset];
+                _current = _buffer[position.Offset];
                 Eof = false;
             }
         }
@@ -104,12 +104,12 @@ namespace Parlot
         public char Current => _current;
 
         /// <summary>
-        /// Returns the cursor's position in the buffer.
+        /// Returns the cursor's position in the _buffer.
         /// </summary>
         public int Offset => _offset;
 
         /// <summary>
-        /// Evaluates a char forward in the buffer.
+        /// Evaluates a char forward in the _buffer.
         /// </summary>
         public char PeekNext(int index = 1)
         {
@@ -120,11 +120,12 @@ namespace Parlot
                 return NullChar;
             }
 
-            return Buffer[nextIndex];
+            return _buffer[nextIndex];
         }
         
         public bool Eof { get; private set; }
-        public string Buffer { get; private set; }
+
+        public string Buffer => _buffer;
 
         /// <summary>
         /// Whether a char is at the current position.
@@ -149,7 +150,7 @@ namespace Parlot
         {
             if (s == null)
             {
-                throw new ArgumentNullException(nameof(s));
+                ThrowHelper.ThrowArgumentNullException(nameof(s));
             }
 
             if (Eof)
@@ -183,7 +184,7 @@ namespace Parlot
         {
             if (chars == null)
             {
-                throw new ArgumentNullException(nameof(chars));
+                ThrowHelper.ThrowArgumentNullException(nameof(chars));
             }
 
             if (Eof)
@@ -212,7 +213,6 @@ namespace Parlot
         /// <summary>
         /// Whether a string is at the current position.
         /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s)
         {
             if (s.Length == 0)
@@ -237,14 +237,14 @@ namespace Parlot
                 return false;
             }
             
-            if (length > 1 && Buffer[_offset + 1] != s[1])
+            if (length > 1 && _buffer[_offset + 1] != s[1])
             {
                 return false;
             }
 
             for (var i = 2; i < length; i++)
             {
-                if (s[i] != Buffer[_offset + i])
+                if (s[i] != _buffer[_offset + i])
                 {
                     return false;
                 }
@@ -286,7 +286,7 @@ namespace Parlot
 
             if (length > 1)
             {
-                a = CharToStringTable.GetString(Buffer[_offset + 1]);
+                a = CharToStringTable.GetString(_buffer[_offset + 1]);
                 b = CharToStringTable.GetString(s[1]);
 
                 if (comparer.Compare(a, b) != 0)
@@ -297,7 +297,7 @@ namespace Parlot
 
             for (var i = 2; i < length; i++)
             {
-                a = CharToStringTable.GetString(Buffer[_offset + i]);
+                a = CharToStringTable.GetString(_buffer[_offset + i]);
                 b = CharToStringTable.GetString(s[i]);
 
                 if (comparer.Compare(a, b) != 0)

--- a/src/Parlot/Fluent/OneOf.cs
+++ b/src/Parlot/Fluent/OneOf.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Parlot.Fluent
+﻿namespace Parlot.Fluent
 {
     /// <summary>
     /// OneOf the inner choices when not all parsers return the same type.
@@ -9,16 +6,18 @@ namespace Parlot.Fluent
     /// </summary>
     public sealed class OneOf : Parser<ParseResult<object>>
     {
-        public OneOf(IList<IParser> parsers)
+        private readonly IParser[] _parsers;
+
+        public OneOf(IParser[] parsers)
         {
-            Parsers = parsers ?? throw new ArgumentNullException(nameof(parsers));
+            _parsers = parsers;
         }
 
-        public IList<IParser> Parsers { get; }
+        public IParser[] Parsers => _parsers;
 
         public override bool Parse(ParseContext context, ref ParseResult<ParseResult<object>> result)
         {
-            if (Parsers.Count == 0)
+            if (_parsers.Length == 0)
             {
                 return false;
             }
@@ -27,9 +26,9 @@ namespace Parlot.Fluent
 
             var start = context.Scanner.Cursor.Position;
 
-            for (var i = 0; i < Parsers.Count; i++)
+            foreach (var parser in _parsers)
             {
-                if (Parsers[i].Parse(context, ref parsed))
+                if (parser.Parse(context, ref parsed))
                 {
                     result.Set(parsed.Buffer, parsed.Start, parsed.End, parsed);
                     return true;
@@ -51,26 +50,29 @@ namespace Parlot.Fluent
     /// <typeparam name="T"></typeparam>
     public sealed class OneOf<T> : Parser<T>
     {
-        public OneOf(IList<IParser<T>> parsers)
+        private readonly IParser<T>[] _parsers;
+
+        public OneOf(IParser<T>[] parsers)
         {
-            Parsers = parsers;
+            _parsers = parsers;
         }
-        public IList<IParser<T>> Parsers { get; }
+
+        public IParser<T>[] Parsers => _parsers;
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)
         {
             context.EnterParser(this);
 
-            if (Parsers.Count == 0)
+            if (Parsers.Length == 0)
             {
                 return false;
             }
 
             var start = context.Scanner.Cursor.Position;
 
-            for (var i = 0; i < Parsers.Count; i++)
+            foreach (var parser in _parsers)
             {
-                if (Parsers[i].Parse(context, ref result))
+                if (parser.Parse(context, ref result))
                 {
                     return true;
                 }

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -6,16 +6,17 @@ namespace Parlot.Fluent
     public class ParseContext
     {
         private Dictionary<string, object> _properties;
-        private ParseResult<object> _whiteSpaceResult = new ParseResult<object>();
-        public ParseContext(Scanner scanner)
-        {
-            Scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
-        }
+        private ParseResult<object> _whiteSpaceResult;
 
         /// <summary>
         /// The scanner used for the parsing session.
         /// </summary>
-        public Scanner Scanner { get; }
+        public readonly Scanner Scanner;
+
+        public ParseContext(Scanner scanner)
+        {
+            Scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
+        }
 
         /// <summary>
         /// A custom collection of objects that can be shared across parsers.

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -31,6 +31,6 @@ namespace Parlot
     
     public static class ParseResultExtensions
     {
-        public static ReadOnlySpan<char> GetSpan<T>(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.Length);
+        public static ReadOnlySpan<char> GetSpan<T>(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.End - result.Start);
     }
 }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,4 +1,6 @@
-﻿namespace Parlot
+﻿using System;
+
+namespace Parlot
 {
     public struct ParseResult<T>
     {
@@ -29,6 +31,6 @@
     
     public static class ParseResultExtensions
     {
-        public ReadOnlySpan<char> GetSpan() => Buffer.AsSpan(Start.Offset, Length);
+        public ReadOnlySpan<char> GetSpan => Buffer.AsSpan(Start.Offset, Length);
     }
 }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -31,6 +31,6 @@ namespace Parlot
     
     public static class ParseResultExtensions
     {
-        public static ReadOnlySpan<char> GetSpan(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.Length);
+        public static ReadOnlySpan<char> GetSpan<T>(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.Length);
     }
 }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,38 +1,32 @@
-﻿using System;
-
-namespace Parlot
+﻿namespace Parlot
 {
     public struct ParseResult<T>
     {
-        public ParseResult(string buffer, TextPosition start, TextPosition end, T value)
+        public ParseResult(string buffer, in TextPosition start, in TextPosition end, T value)
         {
             Buffer = buffer;
             Start = start;
             End = end;
-            Length = end - start;
             Value = value;
         }
 
-        public void Set(string buffer, TextPosition start, TextPosition end, T value)
+        public void Set(string buffer, in TextPosition start, in TextPosition end, T value)
         {
             Buffer = buffer;
             Start = start;
             End = end;
-            Length = end - start;
             Value = value;
         }
 
-        public TextPosition Start { get; private set; }
-
-        public TextPosition End { get; private set; }
-
-        public int Length { get; private set; }
-        public string Buffer { get; private set; }
-
-        public string Text => Buffer?.Substring(Start.Offset, Length);
-
-        public ReadOnlySpan<char> Span => Buffer.AsSpan(Start.Offset, Length);
-
-        public T Value { get; private set; }
+        public TextPosition Start;
+        public TextPosition End;
+        public string Buffer;
+        public T Value;
+    }
+    
+    // if really needed, allows less fields if can be computed, no need to methods
+    internal static class ParseResultExtensions
+    {
+        public static int GetLength<T>(this ParseResult<T> result) => result.End - result.Start;
     }
 }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -31,6 +31,6 @@ namespace Parlot
     
     public static class ParseResultExtensions
     {
-        public ReadOnlySpan<char> GetSpan => Buffer.AsSpan(Start.Offset, Length);
+        public static ReadOnlySpan<char> GetSpan(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.Length);
     }
 }

--- a/src/Parlot/Fluent/Parsers.OneOf.cs
+++ b/src/Parlot/Fluent/Parsers.OneOf.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 
 namespace Parlot.Fluent
 {
@@ -10,7 +9,7 @@ namespace Parlot.Fluent
             if (parser is OneOf<T> oneOf)
             {
                 // Return a single OneOf instance with this new one
-                return new OneOf<T>(oneOf.Parsers.Concat(new[] { or }).ToArray());
+                return new OneOf<T>(oneOf.Parsers.Append(or).ToArray());
             }
             else
             {
@@ -23,7 +22,7 @@ namespace Parlot.Fluent
             if (parser is OneOf oneOf)
             {
                 // Return a single OneOf instance with this new one
-                return new OneOf(oneOf.Parsers.Concat(new[] { or }).ToArray());
+                return new OneOf(oneOf.Parsers.Append(or).ToArray());
             }
             else
             {

--- a/src/Parlot/Fluent/Parsers.Sequence.cs
+++ b/src/Parlot/Fluent/Parsers.Sequence.cs
@@ -10,7 +10,7 @@ namespace Parlot.Fluent
             if (parser is Sequence sequence)
             {
                 // Return a single OneOf instance with this new one
-                return new Sequence(sequence._parsers.Concat(new[] { and }).ToArray());
+                return new Sequence(sequence.Parsers.Append(and).ToArray());
             }
             else
             {

--- a/src/Parlot/Fluent/Sequence.cs
+++ b/src/Parlot/Fluent/Sequence.cs
@@ -252,32 +252,34 @@ namespace Parlot.Fluent
 
     public sealed class Sequence : Parser<IList<ParseResult<object>>>
     {
-        internal readonly IParser[] _parsers;
+        private readonly IParser[] _parsers;
+
         public Sequence(IParser[] parsers)
         {
             _parsers = parsers;
         }
 
+        public IParser[] Parsers => _parsers;
+
         public override bool Parse(ParseContext context, ref ParseResult<IList<ParseResult<object>>> result)
         {
             context.EnterParser(this);
 
-            if (_parsers.Length == 0)
+            IParser[] parsers = _parsers;
+
+            if (parsers.Length == 0)
             {
                 return true;
             }
 
-            var results = new List<ParseResult<object>>(_parsers.Length);
-
+            var results = new List<ParseResult<object>>(parsers.Length);
             var success = true;
-
             var parsed = new ParseResult<object>();
-
             var start = context.Scanner.Cursor.Position;
 
-            for (var i = 0; i < _parsers.Length; i++)
+            for (var i = 0; i < (uint) parsers.Length; i++)
             {
-                if (!_parsers[i].Parse(context, ref parsed))
+                if (!parsers[i].Parse(context, ref parsed))
                 {
                     success = false;
                     break;

--- a/src/Parlot/Fluent/TextSpan.cs
+++ b/src/Parlot/Fluent/TextSpan.cs
@@ -2,14 +2,13 @@
 
 namespace Parlot.Fluent
 {
-    public struct TextSpan : IEquatable<string>
+    public readonly struct TextSpan : IEquatable<string>, IEquatable<TextSpan>
     {
         public TextSpan(string value)
         {
             Buffer = value;
             Offset = 0;
             Length = value.Length;
-            _text = value;
         }
 
         public TextSpan(string buffer, int offset, int count)
@@ -17,21 +16,17 @@ namespace Parlot.Fluent
             Buffer = buffer;
             Offset = offset;
             Length = count;
-            _text = null;
         }
 
-        private string _text;
-        public int Length { get; private set; }
-        public int Offset { get; private set; }
-        public string Buffer { get; private set; }
-
-        public string Text => _text ??= Buffer?.Substring(Offset, Length);
+        public readonly int Length;
+        public readonly int Offset;
+        public readonly string Buffer;
 
         public ReadOnlySpan<char> Span => Buffer.AsSpan(Offset, Length);
 
         public override string ToString()
         {
-            return Text;
+            return Buffer?.Substring(Offset, Length);
         }
 
         public bool Equals(string other)
@@ -47,6 +42,11 @@ namespace Parlot.Fluent
             }
 
             return Span.SequenceEqual(other);
+        }
+
+        public bool Equals(TextSpan other)
+        {
+            return Span.SequenceEqual(other.Span);
         }
     }
 }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -2,13 +2,15 @@
 
 namespace Parlot
 {
+    using System.Runtime.CompilerServices;
+
     /// <summary>
     /// This class is used to return tokens extracted from the input buffer.
     /// </summary>
     public class Scanner
     {
         public readonly string Buffer;
-        public Cursor Cursor;
+        public readonly Cursor Cursor;
 
         /// <summary>
         /// Scans some text.
@@ -24,6 +26,7 @@ namespace Parlot
         /// Reads any whitespace without generating a token.
         /// </summary>
         /// <returns>Whether some white space was read.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool SkipWhiteSpaceOrNewLine()
         {
             if (!Character.IsWhiteSpaceOrNewLine(Cursor.Current))
@@ -31,6 +34,12 @@ namespace Parlot
                 return false;
             }
 
+            return SkipWhiteSpaceOrNewLineUnlikely();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool SkipWhiteSpaceOrNewLineUnlikely()
+        {
             Cursor.Advance();
 
             while (Character.IsWhiteSpaceOrNewLine(Cursor.Current))
@@ -41,6 +50,7 @@ namespace Parlot
             return true;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool SkipWhiteSpace()
         {
             if (!Character.IsWhiteSpace(Cursor.Current))
@@ -48,6 +58,12 @@ namespace Parlot
                 return false;
             }
 
+            return SkipWhiteSpaceUnlikely();
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private bool SkipWhiteSpaceUnlikely()
+        {
             Cursor.Advance();
 
             while (Character.IsWhiteSpace(Cursor.Current))

--- a/src/Parlot/TextPosition.cs
+++ b/src/Parlot/TextPosition.cs
@@ -3,9 +3,9 @@ namespace Parlot
     /// <summary>
     /// Represents a position in a text buffer.
     /// </summary>
-    public struct TextPosition
+    public readonly struct TextPosition
     {
-        public static TextPosition Start = new(0, 1, 1);
+        public static readonly TextPosition Start = new(0, 1, 1);
 
         public TextPosition(int offset, int line, int column)
         {
@@ -14,11 +14,11 @@ namespace Parlot
             Column = column;
         }
 
-        public int Offset { get; }
-        public int Line { get; }
-        public int Column { get; }
+        public readonly int Offset;
+        public readonly int Line;
+        public readonly int Column;
 
-        public static int operator -(TextPosition left, TextPosition right)
+        public static int operator -(in TextPosition left, in TextPosition right)
         {
             return left.Offset - right.Offset;
         }

--- a/src/Parlot/ThrowHelper.cs
+++ b/src/Parlot/ThrowHelper.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Parlot
+{
+    using System.Diagnostics.CodeAnalysis;
+
+    internal static class ThrowHelper
+    {
+        [DoesNotReturn]
+        public static void ThrowArgumentNullException(string paramName)
+        {
+            throw new ArgumentNullException(paramName);
+        }
+    }
+}

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -1,5 +1,4 @@
 using Parlot.Fluent;
-using System;
 using Xunit;
 using static Parlot.Fluent.Parsers;
 
@@ -171,7 +170,7 @@ namespace Parlot.Tests
             Assert.Equal((long)123, resultI);
 
             Assert.True(parser.TryParse("s:'123'", out var resultS));
-            Assert.Equal("123", ((TextSpan)resultS).Text);
+            Assert.Equal("123", ((TextSpan)resultS).ToString());
         }
 
         [Fact]
@@ -210,7 +209,7 @@ namespace Parlot.Tests
         [InlineData("abc=3", "abc")]
         public void IdentifierShouldParseValidIdentifiers(string text, string identifier)
         {
-            Assert.Equal(identifier, Literals.Identifier().Parse(text).Text);
+            Assert.Equal(identifier, Literals.Identifier().Parse(text).ToString());
         }
 
         [Theory]
@@ -219,7 +218,7 @@ namespace Parlot.Tests
         [InlineData("  ")]
         public void IdentifierShouldNotParseInvalidIdentifiers(string text)
         {
-            Assert.Null(Literals.Identifier().Parse(text).Text);
+            Assert.Null(Literals.Identifier().Parse(text).ToString());
         }
 
         [Theory]
@@ -232,7 +231,7 @@ namespace Parlot.Tests
             static bool start(char c) => c == '-' || c == '/';
             static bool part(char c) => c == '@' || c == '*';
 
-            Assert.Equal(text, Literals.Identifier(start, part).Parse(text).Text);
+            Assert.Equal(text, Literals.Identifier(start, part).Parse(text).ToString());
         }
 
         [Fact]

--- a/test/Parlot.Tests/Json/JsonParser.cs
+++ b/test/Parlot.Tests/Json/JsonParser.cs
@@ -22,7 +22,7 @@ namespace Parlot.Tests.Json
 
             var jsonString =
                 String
-                    .Then<IJson>(static s => new JsonString(s.Text));
+                    .Then<IJson>(static s => new JsonString(s.ToString()));
 
             var json = Deferred<IJson>();
 
@@ -32,7 +32,7 @@ namespace Parlot.Tests.Json
 
             var jsonMember =
                 String.And(Colon).And(json)
-                    .Then(static member => new KeyValuePair<string, IJson>(member.Item1.Text, member.Item3));
+                    .Then(static member => new KeyValuePair<string, IJson>(member.Item1.ToString(), member.Item3));
 
             var jsonObject =
                 Between(LBrace, Separated(Comma, jsonMember), RBrace)


### PR DESCRIPTION
Wanted so see what's this new shiny thing a saw things that might improve perf, so here's some.

* improve array access by having array as local using uint access to avoid bound checks  when needed / using foreach if possible
* prefer read-only structs, get/set properties and methods are bad for structs as they cause copying for CLR to be safe
   * generally should make structs less class-like, it's kind of either or with the properties and methods, extension methods can help with structs
* tried to make some property access inlined

To further improve performance, some suggestions:

* Ditch the `IParser`/`IParser<T>` and always use abstract class access, interface dispatch is more costly, these are called a lot
* Consider if possible for benchmarks to use TextSpan instead of string for getting JSON properties, it might make the parsers con-comparable though, the `ToString()` needed for materializing properties isn't awfully nice. I did try this with custom Marvin hasher for `ROS` (`netstandard2.1` doesn't have `GetHashCode` for `ROS`)
* traversing the string with pointers instead of index might be faster, haven't tried it out though

``` ini

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
AMD Ryzen 7 2700X, 1 CPU, 16 logical and 8 physical cores
.NET Core SDK=5.0.101
  [Host]   : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT
  ShortRun : .NET Core 5.0.1 (CoreCLR 5.0.120.57516, CoreFX 5.0.120.57516), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```

## Parlot.Benchmarks.ExprBench

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |ParlotRawSmall|784.8 ns|308.0 ns|0.1411|0.0000|0.0000|592 B|
| **New** |	| **759.9 ns (-3%)** | **305.91 ns** | **0.1411 (0%)** | **0.0000** | **0.0000** | **592 B (0%)** |
| Old |ParlotFluentSmall|2,623.9 ns|320.7 ns|0.1755|0.0000|0.0000|744 B|
| **New** |	| **1,975.2 ns (-25%)** | **54.83 ns** | **0.1755 (0%)** | **0.0000** | **0.0000** | **736 B (-1%)** |
| Old |PidginSmall|14,292.6 ns|376.3 ns|0.1831|0.0000|0.0000|816 B|
| **New** |	| **14,645.4 ns (+2%)** | **1,034.18 ns** | **0.1831 (0%)** | **0.0000** | **0.0000** | **816 B (0%)** |
| Old |ParlotRawBig|3,909.5 ns|1,367.0 ns|0.6447|0.0000|0.0000|2712 B|
| **New** |	| **4,059.4 ns (+4%)** | **106.52 ns** | **0.6485 (+1%)** | **0.0000** | **0.0000** | **2712 B (0%)** |
| Old |ParlotFluentBig|13,842.5 ns|2,039.8 ns|0.7477|0.0000|0.0000|3136 B|
| **New** |	| **10,241.6 ns (-26%)** | **599.34 ns** | **0.7477 (0%)** | **0.0000** | **0.0000** | **3128 B (0%)** |
| Old |PidginBig|72,480.7 ns|1,090.6 ns|0.8545|0.0000|0.0000|4072 B|
| **New** |	| **72,651.2 ns (0%)** | **2,222.91 ns** | **0.8545 (0%)** | **0.0000** | **0.0000** | **4072 B (0%)** |


## Parlot.Benchmarks.JsonBench

| **Diff**|Method|Mean|Error|Gen 0|Gen 1|Gen 2|Allocated|
|------- |-------|-------:|-------|-------:|-------:|-------:|-------:|
| Old |BigJson_Parlot|367.6 μs|2.37 μs|24.9023|3.4180|0.0000|101.84 KB|
| **New** |	| **292.0 μs (-21%)** | **3.01 μs** | **24.9023 (0%)** | **3.4180 (0%)** | **0.0000** | **101.84 KB (0%)** |
| Old |BigJson_Pidgin|556.1 μs|6.77 μs|24.4141|2.9297|0.0000|101.7 KB|
| **New** |	| **553.3 μs (-1%)** | **3.96 μs** | **24.4141 (0%)** | **2.9297 (0%)** | **0.0000** | **101.7 KB (0%)** |
| Old |BigJson_Sprache|3,595.3 μs|254.49 μs|1308.5938|50.7813|0.0000|5349.63 KB|
| **New** |	| **3,511.6 μs (-2%)** | **39.13 μs** | **1308.5938 (0%)** | **50.7813 (0%)** | **0.0000** | **5349.63 KB (0%)** |
| Old |BigJson_Superpower|2,133.4 μs|148.34 μs|222.6563|3.9063|0.0000|913.43 KB|
| **New** |	| **2,144.2 μs (+1%)** | **126.62 μs** | **222.6563 (0%)** | **3.9063 (0%)** | **0.0000** | **913.43 KB (0%)** |
| Old |LongJson_Parlot|289.6 μs|2.72 μs|25.3906|0.4883|0.0000|104.39 KB|
| **New** |	| **236.2 μs (-18%)** | **1.35 μs** | **25.3906 (0%)** | **0.2441 (-50%)** | **0.0000** | **104.38 KB (0%)** |
| Old |LongJson_Pidgin|491.8 μs|12.61 μs|25.3906|3.9063|0.0000|104.25 KB|
| **New** |	| **485.2 μs (-1%)** | **4.95 μs** | **25.3906 (0%)** | **2.4414 (-38%)** | **0.0000** | **104.25 KB (0%)** |
| Old |LongJson_Sprache|2,847.4 μs|161.38 μs|1054.6875|11.7188|0.0000|4311.36 KB|
| **New** |	| **2,895.6 μs (+2%)** | **161.87 μs** | **1054.6875 (0%)** | **11.7188 (0%)** | **0.0000** | **4311.36 KB (0%)** |
| Old |LongJson_Superpower|1,734.5 μs|34.44 μs|171.8750|3.9063|0.0000|706.79 KB|
| **New** |	| **1,730.9 μs (0%)** | **103.56 μs** | **171.8750 (0%)** | **3.9063 (0%)** | **0.0000** | **706.79 KB (0%)** |
| Old |DeepJson_Parlot|248.6 μs|35.45 μs|20.0195|0.4883|0.0000|82.39 KB|
| **New** |	| **198.4 μs (-20%)** | **3.77 μs** | **20.0195 (0%)** | **0.2441 (-50%)** | **0.0000** | **82.38 KB (0%)** |
| Old |DeepJson_Pidgin|573.1 μs|49.33 μs|45.8984|0.9766|0.0000|187.79 KB|
| **New** |	| **567.8 μs (-1%)** | **20.04 μs** | **45.8984 (0%)** | **0.9766 (0%)** | **0.0000** | **187.79 KB (0%)** |
| Old |DeepJson_Sprache|3,190.5 μs|37.78 μs|562.5000|226.5625|0.0000|2946.56 KB|
| **New** |	| **3,211.3 μs (+1%)** | **261.43 μs** | **554.6875 (-1%)** | **218.7500 (-3%)** | **0.0000** | **2946.56 KB (0%)** |
| Old |WideJson_Parlot|204.9 μs|3.67 μs|11.7188|0.2441|0.0000|48.56 KB|
| **New** |	| **178.0 μs (-13%)** | **4.43 μs** | **11.7188 (0%)** | **0.7324 (+200%)** | **0.0000** | **48.55 KB (0%)** |
| Old |WideJson_Pidgin|290.6 μs|4.36 μs|11.7188|0.9766|0.0000|48.42 KB|
| **New** |	| **293.6 μs (+1%)** | **2.93 μs** | **11.7188 (0%)** | **0.9766 (0%)** | **0.0000** | **48.42 KB (0%)** |
| Old |WideJson_Sprache|1,676.3 μs|123.49 μs|683.5938|11.7188|0.0000|2797.28 KB|
| **New** |	| **1,635.4 μs (-2%)** | **113.14 μs** | **683.5938 (0%)** | **11.7188 (0%)** | **0.0000** | **2797.28 KB (0%)** |
| Old |WideJson_Superpower|1,108.5 μs|65.53 μs|111.3281|3.9063|0.0000|459.74 KB|
| **New** |	| **1,104.4 μs (0%)** | **14.52 μs** | **111.3281 (0%)** | **3.9063 (0%)** | **0.0000** | **459.74 KB (0%)** |


