### PR TITLE
Perf optimizations

### DIFF
--- a/src/Parlot/Fluent/AndSkip.cs
+++ b/src/Parlot/Fluent/AndSkip.cs
@@ -2,14 +2,14 @@
 
 namespace Parlot.Fluent
 {
-    public sealed class AndSkip<T> : Parser<T>
+    public sealed class AndSkip<T, U> : Parser<T>
     {
         internal readonly IParser<T> _parser1;
-        internal readonly IParser _parser2;
+        internal readonly IParser<U> _parser2;
 
-        static ParseResult<object> _parseResult2 = new ParseResult<object>();
+        static ParseResult<U> _parseResult2 = new ParseResult<U>();
 
-        public AndSkip(IParser<T> parser1, IParser parser2)
+        public AndSkip(IParser<T> parser1, IParser<U> parser2)
         {
             _parser1 = parser1 ?? throw new ArgumentNullException(nameof(parser1));
             _parser2 = parser2 ?? throw new ArgumentNullException(nameof(parser2));

--- a/src/Parlot/Fluent/AndSkip.cs
+++ b/src/Parlot/Fluent/AndSkip.cs
@@ -19,6 +19,8 @@ namespace Parlot.Fluent
         {
             context.EnterParser(this);
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser1.Parse(context, ref result))
             {
                 if (_parser2.Parse(context, ref _parseResult2))
@@ -26,7 +28,7 @@ namespace Parlot.Fluent
                     return true;
                 }
 
-                context.Scanner.Cursor.ResetPosition(result.Start);
+                context.Scanner.Cursor.ResetPosition(start);
             }
 
             return false;

--- a/src/Parlot/Fluent/Between.cs
+++ b/src/Parlot/Fluent/Between.cs
@@ -2,11 +2,11 @@
 
 namespace Parlot.Fluent
 {
-    public sealed class Between<T> : Parser<T>
+    public sealed class Between<A, T, B> : Parser<T>
     {
         private readonly IParser<T> _parser;
-        private readonly IParser _before;
-        private readonly IParser _after;
+        private readonly IParser<A> _before;
+        private readonly IParser<B> _after;
 
         private readonly bool _beforeIsChar;
         private readonly char _beforeChar;
@@ -16,7 +16,7 @@ namespace Parlot.Fluent
         private readonly char _afterChar;
         private readonly bool _afterSkipWhiteSpace;
 
-        public Between(IParser before, IParser<T> parser, IParser after)
+        public Between(IParser<A> before, IParser<T> parser, IParser<B> after)
         {
             _before = before ?? throw new ArgumentNullException(nameof(before));
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
@@ -41,8 +41,6 @@ namespace Parlot.Fluent
         {
             context.EnterParser(this);
 
-            var parsed = new ParseResult<object>();
-
             if (_beforeIsChar)
             {
                 if (_beforeSkipWhiteSpace)
@@ -57,7 +55,9 @@ namespace Parlot.Fluent
             }
             else
             {
-                if (!_before.Parse(context, ref parsed))
+                var parsedA = new ParseResult<A>();
+
+                if (!_before.Parse(context, ref parsedA))
                 {
                     return false;
                 }
@@ -82,7 +82,9 @@ namespace Parlot.Fluent
             }
             else
             {
-                if (!_after.Parse(context, ref parsed))
+                var parsedB = new ParseResult<B>();
+
+                if (!_after.Parse(context, ref parsedB))
                 {
                     return false;
                 }

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -21,11 +21,11 @@
                 context.SkipWhiteSpace();
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             if (context.Scanner.ReadChar(Char))
             {
-                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Position, Name, Char);
+                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, Char);
                 return true;
             }
 

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -25,7 +25,7 @@
 
             if (context.Scanner.ReadChar(Char))
             {
-                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, Char);
+                result.Set(start, context.Scanner.Cursor.Offset,  Char);
                 return true;
             }
 

--- a/src/Parlot/Fluent/DecimalLiteral.cs
+++ b/src/Parlot/Fluent/DecimalLiteral.cs
@@ -23,7 +23,7 @@ namespace Parlot.Fluent
                 context.SkipWhiteSpace();
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             if ((_numberOptions & NumberOptions.AllowSign) == NumberOptions.AllowSign)
             {
@@ -36,9 +36,9 @@ namespace Parlot.Fluent
 
             if (context.Scanner.ReadDecimal())
             {
-                var end = context.Scanner.Cursor.Position;
+                var end = context.Scanner.Cursor.Offset;
 
-                if (decimal.TryParse(context.Scanner.Buffer.AsSpan(start.Offset, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
+                if (decimal.TryParse(context.Scanner.Buffer.AsSpan(start, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
                 {
                     result.Set(context.Scanner.Buffer, start, end, Name, value);
                     return true;

--- a/src/Parlot/Fluent/DecimalLiteral.cs
+++ b/src/Parlot/Fluent/DecimalLiteral.cs
@@ -40,7 +40,7 @@ namespace Parlot.Fluent
 
                 if (decimal.TryParse(context.Scanner.Buffer.AsSpan(start, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
                 {
-                    result.Set(context.Scanner.Buffer, start, end, Name, value);
+                    result.Set(start, end,  value);
                     return true;
                 }
             }

--- a/src/Parlot/Fluent/Else.cs
+++ b/src/Parlot/Fluent/Else.cs
@@ -31,13 +31,13 @@ namespace Parlot.Fluent
                 if (_action1 != null)
                 {
                     var value = _action1.Invoke(parsed.Value);
-                    result.Set(parsed.Buffer, parsed.Start, parsed.End, _parser.Name, value);
+                    result.Set(parsed.Start, parsed.End, value);
                 }
 
                 if (_action2 != null)
                 {
                     var value = _action2.Invoke(context, parsed.Value);
-                    result.Set(parsed.Buffer, parsed.Start, parsed.End, _parser.Name, value);
+                    result.Set(parsed.Start, parsed.End, value);
                 }
 
                 return true;

--- a/src/Parlot/Fluent/IParser.cs
+++ b/src/Parlot/Fluent/IParser.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 
 namespace Parlot.Fluent
 {
     public interface IParser
     {
-        string Name { get; set; }
         bool Parse(ParseContext context, ref ParseResult<object> result);
         public IParser Switch(Func<ParseContext, object, IParser> action) => new SwitchAnonymousToAnonymous(this, action);
         public IParser<T> Switch<T>(Func<ParseContext, object, IParser<T>> action) => new SwitchAnonymousToTyped<T>(this, action);
@@ -21,14 +19,12 @@ namespace Parlot.Fluent
         public IParser<T> Error(string message) => new Error<T>(this, message);
         public IParser<U> Error<U>(string message) => new Error<T, U>(this, message);
         public IParser<T> When(Func<T, bool> predicate) => new When<T>(this, predicate);
-        public IParser<T> Named(string name) { Name = name; return this; }
         public IParser<U> Switch<U>(Func<ParseContext, T, IParser<U>> action) => new SwitchTypedToTyped<T, U>(this, action);
         public IParser Switch(Func<ParseContext, T, IParser> action) => new SwitchTypedToAnonymous<T>(this, action);
     }
 
     public abstract class Parser<T> : IParser<T>
     {
-        public string Name { get; set; }
         public abstract bool Parse(ParseContext context, ref ParseResult<T> result);
 
         bool IParser.Parse(ParseContext context, ref ParseResult<object> result)
@@ -38,7 +34,7 @@ namespace Parlot.Fluent
 
             if (Parse(context, ref localResult))
             {
-                result = new ParseResult<object>(localResult.Buffer, localResult.Start, localResult.End, localResult.ParserName, localResult.Value);
+                result = new ParseResult<object>(localResult.Start, localResult.End, localResult.Value);
                 return true;
             }
             else

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -44,7 +44,7 @@ namespace Parlot.Fluent
 
             var end = context.Scanner.Cursor.Offset;
 
-            result.Set(context.Scanner.Buffer, start, end, Name, new TextSpan(context.Scanner.Buffer, start, end - start));
+            result.Set(start, end, new TextSpan(context.Scanner.Buffer, start, end - start));
             return true;
         }
     }

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -31,7 +31,7 @@ namespace Parlot.Fluent
                 return false;
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             // At this point we have an identifier, read while it's an identifier part.
 
@@ -42,9 +42,9 @@ namespace Parlot.Fluent
                 context.Scanner.Cursor.Advance();
             }
 
-            var end = context.Scanner.Cursor.Position;
+            var end = context.Scanner.Cursor.Offset;
 
-            result.Set(context.Scanner.Buffer, start, end, Name, new TextSpan(context.Scanner.Buffer, start.Offset, end - start));
+            result.Set(context.Scanner.Buffer, start, end, Name, new TextSpan(context.Scanner.Buffer, start, end - start));
             return true;
         }
     }

--- a/src/Parlot/Fluent/IntegerLiteral.cs
+++ b/src/Parlot/Fluent/IntegerLiteral.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Text;
 
 namespace Parlot.Fluent
 {
@@ -22,7 +23,7 @@ namespace Parlot.Fluent
                 context.SkipWhiteSpace();
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             if ((_numberOptions & NumberOptions.AllowSign) == NumberOptions.AllowSign)
             {
@@ -35,9 +36,9 @@ namespace Parlot.Fluent
 
             if (context.Scanner.ReadInteger())
             {
-                var end = context.Scanner.Cursor.Position;
+                var end = context.Scanner.Cursor.Offset;
 
-                if (long.TryParse(context.Scanner.Buffer.AsSpan(start.Offset, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
+                if (long.TryParse(context.Scanner.Buffer.AsSpan(start, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
                 {
                     result.Set(context.Scanner.Buffer, start, end, Name, value);
                     return true;

--- a/src/Parlot/Fluent/IntegerLiteral.cs
+++ b/src/Parlot/Fluent/IntegerLiteral.cs
@@ -40,7 +40,7 @@ namespace Parlot.Fluent
 
                 if (long.TryParse(context.Scanner.Buffer.AsSpan(start, end - start), NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
                 {
-                    result.Set(context.Scanner.Buffer, start, end, Name, value);
+                    result.Set(start, end,  value);
                     return true;
                 }
             }

--- a/src/Parlot/Fluent/Not.cs
+++ b/src/Parlot/Fluent/Not.cs
@@ -15,12 +15,14 @@ namespace Parlot.Fluent
         {
             context.EnterParser(this);
 
+            var start = context.Scanner.Cursor.Position;
+
             if (!_parser.Parse(context, ref result))
             {
                 return true;
             }
 
-            context.Scanner.Cursor.ResetPosition(result.Start);
+            context.Scanner.Cursor.ResetPosition(start);
             return false;
         }
     }

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -26,7 +26,7 @@ namespace Parlot.Fluent
             var start = parsed.Start;
             var results = new List<T>();
 
-            TextPosition end;
+            int end = 0;
 
             do
             {

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -35,7 +35,7 @@ namespace Parlot.Fluent
 
             } while (_parser.Parse(context, ref parsed));
 
-            result = new ParseResult<List<T>>(context.Scanner.Buffer, start, end, Name, results);
+            result = new ParseResult<List<T>>(start, end, results);
             return true;
         }
     }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,33 +1,23 @@
 ﻿namespace Parlot
 {
-    public interface IParseResult
+    public struct ParseResult<T>
     {
-    }
-
-    public struct ParseResult<T> : IParseResult
-    {
-        public ParseResult(string buffer, int start, int end, string parserName, T value)
+        public ParseResult(int start, int end, T value)
         {
-            Buffer = buffer;
             Start = start;
             End = end;
             Value = value;
-            ParserName = parserName;
         }
 
-        public void Set(string buffer, int start, int end, string parserName, T value)
+        public void Set(int start, int end, T value)
         {
-            Buffer = buffer;
             Start = start;
             End = end;
             Value = value;
-            ParserName = parserName;
         }
 
         public int Start;
         public int End;
-        public string Buffer;
         public T Value;
-        public string ParserName;
     }
 }

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,8 +1,10 @@
-﻿using System;
-
-namespace Parlot
+﻿namespace Parlot
 {
-    public struct ParseResult<T>
+    public interface IParseResult
+    {
+    }
+
+    public struct ParseResult<T> : IParseResult
     {
         public ParseResult(string buffer, int start, int end, string parserName, T value)
         {

--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -4,7 +4,7 @@ namespace Parlot
 {
     public struct ParseResult<T>
     {
-        public ParseResult(string buffer, in TextPosition start, in TextPosition end, string parserName, T value)
+        public ParseResult(string buffer, int start, int end, string parserName, T value)
         {
             Buffer = buffer;
             Start = start;
@@ -13,7 +13,7 @@ namespace Parlot
             ParserName = parserName;
         }
 
-        public void Set(string buffer, in TextPosition start, in TextPosition end, string parserName, T value)
+        public void Set(string buffer, int start, int end, string parserName, T value)
         {
             Buffer = buffer;
             Start = start;
@@ -22,15 +22,10 @@ namespace Parlot
             ParserName = parserName;
         }
 
-        public TextPosition Start;
-        public TextPosition End;
+        public int Start;
+        public int End;
         public string Buffer;
         public T Value;
         public string ParserName;
-    }
-    
-    public static class ParseResultExtensions
-    {
-        public static ReadOnlySpan<char> GetSpan<T>(this ParseResult<T> result) => result.Buffer.AsSpan(result.Start.Offset, result.End - result.Start);
     }
 }

--- a/src/Parlot/Fluent/Parsers.Sequence.cs
+++ b/src/Parlot/Fluent/Parsers.Sequence.cs
@@ -5,27 +5,12 @@ namespace Parlot.Fluent
 {
     public static partial class Parsers
     {
-        public static Sequence And(this IParser parser, IParser and)
-        {
-            if (parser is Sequence sequence)
-            {
-                // Return a single OneOf instance with this new one
-                return new Sequence(sequence.Parsers.Append(and).ToArray());
-            }
-            else
-            {
-                return new Sequence(new[] { parser, and });
-            }
-        }
-
         public static IParser<ValueTuple<T1, T2>> And<T1, T2>(this IParser<T1> parser, IParser<T2> and) => new Sequence<T1, T2>(parser, and);
         public static IParser<ValueTuple<T1, T2, T3>> And<T1, T2, T3>(this IParser<ValueTuple<T1, T2>> parser, IParser<T3> and) => new Sequence<T1, T2, T3>(parser, and);
         public static IParser<ValueTuple<T1, T2, T3, T4>> And<T1, T2, T3, T4>(this IParser<ValueTuple<T1, T2, T3>> parser, IParser<T4> and) => new Sequence<T1, T2, T3, T4>(parser, and);
         public static IParser<ValueTuple<T1, T2, T3, T4, T5>> And<T1, T2, T3, T4, T5>(this IParser<ValueTuple<T1, T2, T3, T4>> parser, IParser<T5> and) => new Sequence<T1, T2, T3, T4, T5>(parser, and);
         public static IParser<ValueTuple<T1, T2, T3, T4, T5, T6>> And<T1, T2, T3, T4, T5, T6>(this IParser<ValueTuple<T1, T2, T3, T4, T5>> parser, IParser<T6> and) => new Sequence<T1, T2, T3, T4, T5, T6>(parser, and);
         public static IParser<ValueTuple<T1, T2, T3, T4, T5, T6, T7>> And<T1, T2, T3, T4, T5, T6, T7>(this IParser<ValueTuple<T1, T2, T3, T4, T5, T6>> parser, IParser<T7> and) => new Sequence<T1, T2, T3, T4, T5, T6, T7>(parser, and);
-
-        public static Sequence Sequence(params IParser[] parsers) => new(parsers);
 
         public static IParser<ValueTuple<T1, T2>> Sequence<T1, T2>(IParser<T1> parser1, IParser<T2> parser2) => new Sequence<T1, T2>(parser1, parser2);
         public static IParser<ValueTuple<T1, T2, T3>> Sequence<T1, T2, T3>(IParser<T1> parser1, IParser<T2> parser2, IParser<T3> parser3) => parser1.And(parser2).And(parser3);

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -18,7 +18,7 @@ namespace Parlot.Fluent
         /// </summary>
         public static TermBuilder Terms => new();
 
-        public static IParser<List<T>> Separated<T>(IParser separator, IParser<T> parser) => new Separated<T>(separator, parser);
+        public static IParser<List<T>> Separated<U, T>(IParser<U> separator, IParser<T> parser) => new Separated<U, T>(separator, parser);
 
         // TODO: Decide between Bang and ZeroOrOne
         public static IParser<T> Bang<T>(IParser<T> parser) => new ZeroOrOne<T>(parser);
@@ -27,7 +27,6 @@ namespace Parlot.Fluent
         // TODO: Decide between Star and ZeroOrMany
         public static IParser<List<T>> Star<T>(IParser<T> parser) => new ZeroOrMany<T>(parser);
         public static IParser<List<T>> ZeroOrMany<T>(IParser<T> parser) => new ZeroOrMany<T>(parser);
-        public static IParser<List<ParseResult<object>>> ZeroOrMany(IParser parser) => new ZeroOrMany(parser);
 
         // TODO: Decide between Plus and OneOrMany
         public static IParser<List<T>> Plus<T>(IParser<T> parser) => new OneOrMany<T>(parser);
@@ -36,11 +35,10 @@ namespace Parlot.Fluent
         public static IParser<T> Not<T>(IParser<T> parser) => new Not<T>(parser);
         public static IDeferredParser<T> Deferred<T>() => new Deferred<T>();
         public static IDeferredParser<T> Recursive<T>(Func<Deferred<T>, IParser<T>> parser) => new Deferred<T>(parser);
-        public static IParser<T> Between<T>(IParser before, IParser<T> parser, IParser after) => new Between<T>(before, parser, after);
+        public static IParser<T> Between<A, T, B>(IParser<A> before, IParser<T> parser, IParser<B> after) => new Between<A, T, B>(before, parser, after);
         public static IParser<TextSpan> AnyCharBefore<T>(IParser<T> parser, bool canBeEmpty = false, bool failOnEof = false, bool consumeDelimiter = false) => new TextBefore<T>(parser, canBeEmpty, failOnEof, consumeDelimiter);
-        public static IParser<TextSpan> AnyCharBefore(IParser parser, bool canBeEmpty = false, bool failOnEof = false, bool consumeDelimiter = false) => new TextBefore(parser, canBeEmpty, failOnEof, consumeDelimiter);
-        public static IParser<U> SkipAnd<U>(this IParser parser, IParser<U> and) => new SkipAnd<U>(parser, and);
-        public static IParser<U> AndSkip<U>(this IParser<U> parser, IParser and) => new AndSkip<U>(parser, and);
+        public static IParser<U> SkipAnd<T, U>(this IParser<T> parser, IParser<U> and) => new SkipAnd<T, U>(parser, and);
+        public static IParser<T> AndSkip<T, U>(this IParser<T> parser, IParser<U> and) => new AndSkip<T, U>(parser, and);
 
     }
 

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -3,16 +3,16 @@ using System.Collections.Generic;
 
 namespace Parlot.Fluent
 {
-    public sealed class Separated<T> : Parser<List<T>>
+    public sealed class Separated<U, T> : Parser<List<T>>
     {
-        private readonly IParser _separator;
+        private readonly IParser<U> _separator;
         private readonly IParser<T> _parser;
 
         private readonly bool _separatorIsChar;
         private readonly char _separatorChar;
         private readonly bool _separatorWhiteSpace;
 
-        public Separated(IParser separator, IParser<T> parser)
+        public Separated(IParser<U> separator, IParser<T> parser)
         {
             _separator = separator ?? throw new ArgumentNullException(nameof(separator));
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
@@ -39,7 +39,7 @@ namespace Parlot.Fluent
 
             var first = true;
             var parsed = new ParseResult<T>();
-            var separatorResult = new ParseResult<object>();
+            var separatorResult = new ParseResult<U>();
 
             while (true)
             {

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -34,8 +34,8 @@ namespace Parlot.Fluent
 
             List<T> results = null;
 
-            var start = TextPosition.Start;
-            var end = TextPosition.Start;
+            var start = 0;
+            var end = 0;
 
             var first = true;
             var parsed = new ParseResult<T>();

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -80,7 +80,7 @@ namespace Parlot.Fluent
                 }
             }
 
-            result = new ParseResult<List<T>>(context.Scanner.Buffer, start, end, Name, results);
+            result = new ParseResult<List<T>>(start, end, results);
             return true;
         }
     }

--- a/src/Parlot/Fluent/Sequence.cs
+++ b/src/Parlot/Fluent/Sequence.cs
@@ -27,7 +27,7 @@ namespace Parlot.Fluent
 
                 if (_parser2.Parse(context, ref parseResult2))
                 {
-                    result.Set(parseResult1.Buffer, parseResult1.Start, parseResult2.End, _parser2.Name, new ValueTuple<T1, T2>(parseResult1.Value, parseResult2.Value));
+                    result.Set(parseResult1.Start, parseResult2.End, new ValueTuple<T1, T2>(parseResult1.Value, parseResult2.Value));
                     return true;
                 }
 
@@ -72,7 +72,7 @@ namespace Parlot.Fluent
                         lastResult.Value
                         );
                         
-                    result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
+                    result.Set(tupleResult.Start, lastResult.End, tuple);
                     return true;
                 }
             }
@@ -115,7 +115,7 @@ namespace Parlot.Fluent
                         lastResult.Value
                         );
 
-                    result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
+                    result.Set(tupleResult.Start, lastResult.End, tuple);
                     return true;
                 }
             }
@@ -159,7 +159,7 @@ namespace Parlot.Fluent
                         lastResult.Value
                         );
 
-                    result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
+                    result.Set(tupleResult.Start, lastResult.End, tuple);
                     return true;
                 }
             }
@@ -204,7 +204,7 @@ namespace Parlot.Fluent
                         lastResult.Value
                         );
 
-                    result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
+                    result.Set(tupleResult.Start, lastResult.End, tuple);
                     return true;
                 }
 
@@ -252,7 +252,7 @@ namespace Parlot.Fluent
                         lastResult.Value
                         );
 
-                    result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
+                    result.Set(tupleResult.Start, lastResult.End, tuple);
                     return true;
                 }
 
@@ -304,7 +304,7 @@ namespace Parlot.Fluent
 
             if (success)
             {
-                result.Set(results[0].Buffer, results[0].Start, results[^1].End, Name, results);
+                result.Set(results[0].Start, results[^1].End, results);
                 return true;
             }
             else

--- a/src/Parlot/Fluent/Sequence.cs
+++ b/src/Parlot/Fluent/Sequence.cs
@@ -19,6 +19,8 @@ namespace Parlot.Fluent
 
             var parseResult1 = new ParseResult<T1>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser1.Parse(context, ref parseResult1))
             {
                 var parseResult2 = new ParseResult<T2>();
@@ -29,7 +31,7 @@ namespace Parlot.Fluent
                     return true;
                 }
 
-                context.Scanner.Cursor.ResetPosition(parseResult1.Start);
+                context.Scanner.Cursor.ResetPosition(start);
             }
 
             return false;
@@ -56,6 +58,8 @@ namespace Parlot.Fluent
 
             var tupleResult = new ParseResult<ValueTuple<T1, T2>>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser.Parse(context, ref tupleResult))
             {
                 var lastResult = new ParseResult<T3>();
@@ -71,9 +75,9 @@ namespace Parlot.Fluent
                     result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
                     return true;
                 }
-
-                context.Scanner.Cursor.ResetPosition(tupleResult.Start);
             }
+
+            context.Scanner.Cursor.ResetPosition(start);
 
             return false;
         }
@@ -96,6 +100,8 @@ namespace Parlot.Fluent
 
             var tupleResult = new ParseResult<ValueTuple<T1, T2, T3>>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser.Parse(context, ref tupleResult))
             {
                 var lastResult = new ParseResult<T4>();
@@ -112,9 +118,9 @@ namespace Parlot.Fluent
                     result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
                     return true;
                 }
-
-                context.Scanner.Cursor.ResetPosition(tupleResult.Start);
             }
+
+            context.Scanner.Cursor.ResetPosition(start);
 
             return false;
         }
@@ -137,6 +143,8 @@ namespace Parlot.Fluent
 
             var tupleResult = new ParseResult<ValueTuple<T1, T2, T3, T4>>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser.Parse(context, ref tupleResult))
             {
                 var lastResult = new ParseResult<T5>();
@@ -154,9 +162,9 @@ namespace Parlot.Fluent
                     result.Set(tupleResult.Buffer, tupleResult.Start, lastResult.End, _lastParser.Name, tuple);
                     return true;
                 }
-
-                context.Scanner.Cursor.ResetPosition(tupleResult.Start);
             }
+
+            context.Scanner.Cursor.ResetPosition(start);
 
             return false;
         }
@@ -179,6 +187,8 @@ namespace Parlot.Fluent
 
             var tupleResult = new ParseResult<ValueTuple<T1, T2, T3, T4, T5>>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser.Parse(context, ref tupleResult))
             {
                 var lastResult = new ParseResult<T6>();
@@ -198,8 +208,9 @@ namespace Parlot.Fluent
                     return true;
                 }
 
-                context.Scanner.Cursor.ResetPosition(tupleResult.Start);
             }
+
+            context.Scanner.Cursor.ResetPosition(start);
 
             return false;
         }
@@ -223,6 +234,8 @@ namespace Parlot.Fluent
 
             var tupleResult = new ParseResult<ValueTuple<T1, T2, T3, T4, T5, T6>>();
 
+            var start = context.Scanner.Cursor.Position;
+
             if (_parser.Parse(context, ref tupleResult))
             {
                 var lastResult = new ParseResult<T7>();
@@ -243,8 +256,9 @@ namespace Parlot.Fluent
                     return true;
                 }
 
-                context.Scanner.Cursor.ResetPosition(tupleResult.Start);
             }
+
+            context.Scanner.Cursor.ResetPosition(start);
 
             return false;
         }

--- a/src/Parlot/Fluent/SkipAnd.cs
+++ b/src/Parlot/Fluent/SkipAnd.cs
@@ -27,7 +27,7 @@ namespace Parlot.Fluent
 
                 if (_parser2.Parse(context, ref parseResult2))
                 {
-                    result.Set(parseResult2.Buffer, start.Offset, parseResult2.End, _parser2.Name ?? Name, parseResult2.Value);
+                    result.Set(start.Offset, parseResult2.End, parseResult2.Value);
                     return true;
                 }
 

--- a/src/Parlot/Fluent/SkipAnd.cs
+++ b/src/Parlot/Fluent/SkipAnd.cs
@@ -2,14 +2,14 @@
 
 namespace Parlot.Fluent
 {
-    public sealed class SkipAnd<T> : Parser<T>
+    public sealed class SkipAnd<A, T> : Parser<T>
     {
-        internal readonly IParser _parser1;
+        internal readonly IParser<A> _parser1;
         internal readonly IParser<T> _parser2;
 
-        static ParseResult<object> _parseResult1 = new ParseResult<object>();
+        static ParseResult<A> _parseResult1 = new ParseResult<A>();
 
-        public SkipAnd(IParser parser1, IParser<T> parser2)
+        public SkipAnd(IParser<A> parser1, IParser<T> parser2)
         {
             _parser1 = parser1 ?? throw new ArgumentNullException(nameof(parser1));
             _parser2 = parser2 ?? throw new ArgumentNullException(nameof(parser2));

--- a/src/Parlot/Fluent/SkipAnd.cs
+++ b/src/Parlot/Fluent/SkipAnd.cs
@@ -27,7 +27,7 @@ namespace Parlot.Fluent
 
                 if (_parser2.Parse(context, ref parseResult2))
                 {
-                    result.Set(parseResult2.Buffer, start, parseResult2.End, _parser2.Name ?? Name, parseResult2.Value);
+                    result.Set(parseResult2.Buffer, start.Offset, parseResult2.End, _parser2.Name ?? Name, parseResult2.Value);
                     return true;
                 }
 

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -29,7 +29,7 @@ namespace Parlot.Fluent
                 context.SkipWhiteSpace();
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             var success = _quotes switch
             {
@@ -39,18 +39,18 @@ namespace Parlot.Fluent
                 _ => false
             };
 
-            var end = context.Scanner.Cursor.Position;
+            var end = context.Scanner.Cursor.Offset;
 
             if (success)
             {
                 // Remove quotes
-                var encoded = context.Scanner.Buffer.AsSpan(start.Offset + 1, end - start - 2);
+                var encoded = context.Scanner.Buffer.AsSpan(start + 1, end - start - 2);
                 var decoded = Character.DecodeString(encoded);
 
                 // Don't create a new string if the decoded string is the same, meaning is 
                 // has no escape sequences.
                 var span = decoded == encoded || decoded.SequenceEqual(encoded)
-                    ? new TextSpan(context.Scanner.Buffer, start.Offset + 1, encoded.Length)
+                    ? new TextSpan(context.Scanner.Buffer, start + 1, encoded.Length)
                     : new TextSpan(decoded.ToString());
 
                 result.Set(context.Scanner.Buffer, start, end, Name, span);

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -53,7 +53,7 @@ namespace Parlot.Fluent
                     ? new TextSpan(context.Scanner.Buffer, start + 1, encoded.Length)
                     : new TextSpan(decoded.ToString());
 
-                result.Set(context.Scanner.Buffer, start, end, Name, span);
+                result.Set(start, end,  span);
                 return true;
             }
             else

--- a/src/Parlot/Fluent/Switch.cs
+++ b/src/Parlot/Fluent/Switch.cs
@@ -35,7 +35,7 @@ namespace Parlot.Fluent
 
             if (nextParser.Parse(context, ref parsed))
             {
-                result.Set(parsed.Buffer, parsed.Start, parsed.End, nextParser.Name, parsed.Value);
+                result.Set(parsed.Start, parsed.End, parsed.Value);
                 return true;
             }
 
@@ -76,7 +76,7 @@ namespace Parlot.Fluent
 
             if (nextParser.Parse(context, ref parsed))
             {
-                result.Set(parsed.Buffer, parsed.Start, parsed.End, nextParser.Name, parsed.Value);
+                result.Set(parsed.Start, parsed.End, parsed.Value);
                 return true;
             }
 
@@ -117,7 +117,7 @@ namespace Parlot.Fluent
 
             if (nextParser.Parse(context, ref parsed))
             {
-                result.Set(parsed.Buffer, parsed.Start, parsed.End, nextParser.Name, parsed.Value);
+                result.Set(parsed.Start, parsed.End, parsed.Value);
                 return true;
             }
 
@@ -158,7 +158,7 @@ namespace Parlot.Fluent
 
             if (nextParser.Parse(context, ref parsed))
             {
-                result.Set(parsed.Buffer, parsed.Start, parsed.End, nextParser.Name, parsed.Value);
+                result.Set(parsed.Start, parsed.End, parsed.Value);
                 return true;
             }
 

--- a/src/Parlot/Fluent/TextBefore.cs
+++ b/src/Parlot/Fluent/TextBefore.cs
@@ -61,7 +61,7 @@
                         context.Scanner.Cursor.ResetPosition(end);
                     }
 
-                    result.Set(context.Scanner.Buffer, start.Offset, end.Offset, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
+                    result.Set(start.Offset, end.Offset, new TextSpan(context.Scanner.Buffer, start.Offset, length));
                     return true;
                 }
 
@@ -140,7 +140,7 @@
                         context.Scanner.Cursor.ResetPosition(end);
                     }
 
-                    result.Set(context.Scanner.Buffer, start.Offset, end.Offset, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
+                    result.Set(start.Offset, end.Offset, new TextSpan(context.Scanner.Buffer, start.Offset, length));
                     return true;
                 }
 

--- a/src/Parlot/Fluent/TextBefore.cs
+++ b/src/Parlot/Fluent/TextBefore.cs
@@ -41,11 +41,13 @@
 
             while (true)
             {
+                var previous = context.Scanner.Cursor.Position;
+
                 var delimiterFound = _delimiter.Parse(context, ref parsed);
 
                 if (delimiterFound || (!_failOnEof && context.Scanner.Cursor.Eof))
                 {
-                    var end = (!delimiterFound && context.Scanner.Cursor.Eof) ? context.Scanner.Cursor.Position : parsed.Start;
+                    var end = (!delimiterFound && context.Scanner.Cursor.Eof) ? context.Scanner.Cursor.Position : previous;
 
                     var length = end - start;
 
@@ -59,7 +61,7 @@
                         context.Scanner.Cursor.ResetPosition(end);
                     }
 
-                    result.Set(context.Scanner.Buffer, start, end, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
+                    result.Set(context.Scanner.Buffer, start.Offset, end.Offset, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
                     return true;
                 }
 
@@ -118,11 +120,13 @@
 
             while (true)
             {
+                var previous = context.Scanner.Cursor.Position;
+
                 var delimiterFound = _delimiter.Parse(context, ref parsed);
 
                 if (delimiterFound || (!_failOnEof && context.Scanner.Cursor.Eof))
                 {
-                    var end = (!delimiterFound && context.Scanner.Cursor.Eof) ? context.Scanner.Cursor.Position : parsed.Start;
+                    var end = (!delimiterFound && context.Scanner.Cursor.Eof) ? context.Scanner.Cursor.Position : previous;
 
                     var length = end - start;
 
@@ -136,7 +140,7 @@
                         context.Scanner.Cursor.ResetPosition(end);
                     }
 
-                    result.Set(context.Scanner.Buffer, start, end, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
+                    result.Set(context.Scanner.Buffer, start.Offset, end.Offset, Name, new TextSpan(context.Scanner.Buffer, start.Offset, length));
                     return true;
                 }
 

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -25,11 +25,11 @@ namespace Parlot.Fluent
                 context.SkipWhiteSpace();
             }
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             if (context.Scanner.ReadText(Text, _comparer))
             {
-                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Position, Name, Text);
+                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, Text);
                 return true;
             }
             else

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -29,7 +29,7 @@ namespace Parlot.Fluent
 
             if (context.Scanner.ReadText(Text, _comparer))
             {
-                result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, Text);
+                result.Set(start, context.Scanner.Cursor.Offset,  Text);
                 return true;
             }
             else

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -36,12 +36,12 @@ namespace Parlot.Fluent
             {
                 if (_action1 != null)
                 {
-                    result.Set(parsed.Buffer, parsed.Start, parsed.End, _parser.Name, _action1.Invoke(parsed.Value));
+                    result.Set(parsed.Start, parsed.End, _action1.Invoke(parsed.Value));
                 }
 
                 if (_action2 != null)
                 {
-                    result.Set(parsed.Buffer, parsed.Start, parsed.End, _parser.Name, _action2.Invoke(context, parsed.Value));
+                    result.Set(parsed.Start, parsed.End, _action2.Invoke(context, parsed.Value));
                 }
 
                 return true;

--- a/src/Parlot/Fluent/WhiteSpaceLiteral.cs
+++ b/src/Parlot/Fluent/WhiteSpaceLiteral.cs
@@ -26,7 +26,7 @@
 
             var end = context.Scanner.Cursor.Offset;
 
-            result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, new TextSpan(context.Scanner.Buffer, start, end - start));
+            result.Set(start, context.Scanner.Cursor.Offset,  new TextSpan(context.Scanner.Buffer, start, end - start));
             return true;
         }
     }

--- a/src/Parlot/Fluent/WhiteSpaceLiteral.cs
+++ b/src/Parlot/Fluent/WhiteSpaceLiteral.cs
@@ -13,7 +13,7 @@
         {
             context.EnterParser(this);
 
-            var start = context.Scanner.Cursor.Position;
+            var start = context.Scanner.Cursor.Offset;
 
             if (_includeNewLines)
             {
@@ -24,9 +24,9 @@
                 context.Scanner.SkipWhiteSpace();
             }
 
-            var end = context.Scanner.Cursor.Position;
+            var end = context.Scanner.Cursor.Offset;
 
-            result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Position, Name, new TextSpan(context.Scanner.Buffer, start.Offset, end - start));
+            result.Set(context.Scanner.Buffer, start, context.Scanner.Cursor.Offset, Name, new TextSpan(context.Scanner.Buffer, start, end - start));
             return true;
         }
     }

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -34,7 +34,7 @@ namespace Parlot.Fluent
                 results.Add(parsed);
             }
 
-            result = new ParseResult<List<ParseResult<object>>>(context.Scanner.Buffer, start, end, _parser.Name, results);
+            result = new ParseResult<List<ParseResult<object>>>(start, end, results);
             return true;
         }
     }
@@ -71,7 +71,7 @@ namespace Parlot.Fluent
                 results.Add(parsed.Value);
             }
 
-            result = new ParseResult<List<T>>(context.Scanner.Buffer, start, end, _parser.Name, results);
+            result = new ParseResult<List<T>>(start, end, results);
             return true;
         }
     }

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -17,8 +17,8 @@ namespace Parlot.Fluent
 
             var results = new List<ParseResult<object>>();
 
-            var start = TextPosition.Start;
-            var end = TextPosition.Start;
+            var start = 0;
+            var end = 0;
 
             var first = true;
             var parsed = new ParseResult<object>();
@@ -53,8 +53,8 @@ namespace Parlot.Fluent
 
             var results = new List<T>();
 
-            var start = TextPosition.Start;
-            var end = TextPosition.Start;
+            var start = 0;
+            var end = 0;
 
             var first = true;
             var parsed = new ParseResult<T>();

--- a/src/Parlot/ITokenResult.cs
+++ b/src/Parlot/ITokenResult.cs
@@ -12,12 +12,12 @@ namespace Parlot
         /// <summary>
         /// The start of the token.
         /// </summary>
-        TextPosition Start { get; }
+        int Start { get; }
 
         /// <summary>
         /// The end of the token.
         /// </summary>
-        TextPosition End { get; }
+        int End { get; }
 
         /// <summary>
         /// The length of the token.
@@ -38,7 +38,7 @@ namespace Parlot
         /// <summary>
         /// Sets the result.
         /// </summary>
-        ITokenResult Succeed(string buffer, in TextPosition start, in TextPosition end);
+        ITokenResult Succeed(string buffer, int start, int end);
 
         /// <summary>
         /// Initializes the token result.

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -82,7 +82,7 @@ namespace Parlot
                 return false;
             }
 
-            var start = Cursor.Position;
+            var start = Cursor.Offset;
 
             // At this point we have an identifier, read while it's an identifier part.
 
@@ -90,7 +90,7 @@ namespace Parlot
 
             ReadWhile(other, null);
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start, Cursor.Offset);
 
             return true;
         }
@@ -138,7 +138,7 @@ namespace Parlot
                 } while (!Cursor.Eof && Character.IsDecimalDigit(Cursor.Current));
             }
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start.Offset, Cursor.Offset);
             return true;
         }
 
@@ -152,7 +152,7 @@ namespace Parlot
                 return false;
             }
 
-            var start = Cursor.Position;
+            var start = Cursor.Offset;
 
             do
             {
@@ -160,7 +160,7 @@ namespace Parlot
 
             } while (!Cursor.Eof && Character.IsDecimalDigit(Cursor.Current));
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start, Cursor.Offset);
             return true;
         }
 
@@ -175,7 +175,7 @@ namespace Parlot
                 return false;
             }
 
-            var start = Cursor.Position;
+            var start = Cursor.Offset;
 
             Cursor.Advance();
 
@@ -184,7 +184,7 @@ namespace Parlot
                 Cursor.Advance();
             }
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start, Cursor.Offset);
 
             return true;
         }
@@ -207,11 +207,11 @@ namespace Parlot
 
             if (result != null)
             {
-                var start = Cursor.Position;
+                var start = Cursor.Offset;
 
                 Cursor.Advance();
 
-                result?.Succeed(Buffer, start, Cursor.Position);
+                result?.Succeed(Buffer, start, Cursor.Offset);
             }
             else
             {
@@ -245,17 +245,17 @@ namespace Parlot
                 }
             }
 
-            var start = TextPosition.Start;
+            var start = 0;
 
             // perf: don't allocate a new TextPosition if we don't need to return it
             if (result != null)
             {
-                start = Cursor.Position;
+                start = Cursor.Offset;
             }
 
             Cursor.Advance(text.Length);
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start, Cursor.Offset);
             
             return true;
         }
@@ -323,7 +323,7 @@ namespace Parlot
             {
                 Cursor.Advance(nextQuote + 1 - startOffset);
 
-                result?.Succeed(Buffer, start, Cursor.Position);
+                result?.Succeed(Buffer, start.Offset, Cursor.Offset);
                 return true;
             }
 
@@ -417,7 +417,7 @@ namespace Parlot
 
             Cursor.Advance();
 
-            result?.Succeed(Buffer, start, Cursor.Position);
+            result?.Succeed(Buffer, start.Offset, Cursor.Offset);
 
             return true;
         }

--- a/src/Parlot/TokenResult.cs
+++ b/src/Parlot/TokenResult.cs
@@ -8,18 +8,18 @@ namespace Parlot
 
         public bool Success { get; private set; }
 
-        public TextPosition Start { get; private set; }
+        public int Start { get; private set; }
 
-        public TextPosition End { get; private set; }
+        public int End { get; private set; }
 
         public int Length { get; private set; }
         public string Buffer { get; private set; }
 
-        public string Text => _text ??= Buffer?.Substring(Start.Offset, Length);
+        public string Text => _text ??= Buffer?.Substring(Start, Length);
 
-        public ReadOnlySpan<char> Span => Buffer.AsSpan(Start.Offset, Length);
+        public ReadOnlySpan<char> Span => Buffer.AsSpan(Start, Length);
 
-        public ITokenResult Succeed(string buffer, in TextPosition start, in TextPosition end)
+        public ITokenResult Succeed(string buffer, int start, int end)
         {
             Success = true;
             Buffer = buffer;
@@ -36,8 +36,8 @@ namespace Parlot
             Success = false;
             Buffer = null;
             _text = null;
-            Start = TextPosition.Start;
-            End = TextPosition.Start;
+            Start = 0;
+            End = 0;
             Length = 0;
 
             return this;


### PR DESCRIPTION
Removed some `TextPosition` and replaced by `int` when possible.
Strongly-typed some parsers to prevent some conversion allocations and intermediate `Parse<object>` callse

Using Fluid benchmarks:

Before

|         Method |      Mean |    Error |   StdDev |   Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|--------------- |----------:|---------:|---------:|--------:|--------:|--------:|----------:|
|          Parse |  11.04 us | 0.189 us | 0.158 us |  0.7477 |       - |       - |    3.1 KB |

After

|         Method |       Mean |      Error |     StdDev |      Gen 0 |   Gen 1 |   Gen 2 | Allocated |
|--------------- |-----------:|-----------:|-----------:|--------:|--------:|--------:|----------:|
|          Parse |   8.534 us |  0.1417 us |  0.1326 us |    0.7019 |       - |       - |   2.87 KB |
