### PR TITLE
Enable nullable reference types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,9 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Rider
+/.idea
+
+# BenchmarkDotNet results
+BenchmarkDotNet.Artifacts*

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -150,41 +150,26 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MatchAnyOf(string s)
         {
-            if (s == null)
+            if (s is null)
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(s));
             }
-
+            
             if (Eof)
             {
                 return false;
             }
 
-            var length = s.Length;
-
-            if (length == 0)
-            {
-                return true;
-            }
-
-            for (var i = 0; i < length; i++)
-            {
-                if (s[i] == _current)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return s!.Length == 0 || s.IndexOf(_current) > -1;
         }
 
         /// <summary>
         /// Whether any char of an array is at the current position.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MatchAny(params char[] chars)
+        public bool MatchAny(params char[]? chars)
         {
-            if (chars == null)
+            if (chars is null)
             {
                 ThrowHelper.ThrowArgumentNullException(nameof(chars));
             }
@@ -194,22 +179,7 @@ namespace Parlot
                 return false;
             }
 
-            var length = chars.Length;
-
-            if (length == 0)
-            {
-                return true;
-            }
-
-            for (var i = 0; i < length; i++)
-            {
-                if (chars[i] == _current)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return chars!.Length == 0 || Array.IndexOf(chars, _current) > -1;
         }
 
         /// <summary>

--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -4,7 +4,7 @@ namespace Parlot.Fluent
 {
     public sealed class Deferred<T> : Parser<T>
     {
-        public Parser<T> Parser { get; set; }
+        public Parser<T>? Parser { get; set; }
 
         public Deferred()
         {
@@ -17,7 +17,12 @@ namespace Parlot.Fluent
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)
         {
-            return Parser.Parse(context, ref result);
+            if (Parser is null)
+            {
+                ThrowHelper.ThrowArgumentNullException(nameof(Parser));
+            }
+            
+            return Parser!.Parse(context, ref result);
         }
     }
 }

--- a/src/Parlot/Fluent/Else.cs
+++ b/src/Parlot/Fluent/Else.cs
@@ -4,8 +4,8 @@ namespace Parlot.Fluent
 {
     public sealed class Else<T, U> : Parser<U>
     {
-        private readonly Func<T, U> _action1;
-        private readonly Func<ParseContext, T, U> _action2;
+        private readonly Func<T, U>? _action1;
+        private readonly Func<ParseContext, T, U>? _action2;
         private readonly Parser<T> _parser;
 
         public Else(Parser<T> parser, Func<T, U> action)

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -4,11 +4,11 @@ namespace Parlot.Fluent
 {
     public sealed class Identifier : Parser<TextSpan>
     {
-        private readonly Func<char, bool> _extraStart;
-        private readonly Func<char, bool> _extraPart;
+        private readonly Func<char, bool>? _extraStart;
+        private readonly Func<char, bool>? _extraPart;
         private readonly bool _skipWhiteSpace;
 
-        public Identifier(Func<char, bool> extraStart = null, Func<char, bool> extraPart = null, bool skipWhiteSpace = true)
+        public Identifier(Func<char, bool>? extraStart = null, Func<char, bool>? extraPart = null, bool skipWhiteSpace = true)
         {
             _extraStart = extraStart;
             _extraPart = extraPart;

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -13,19 +13,19 @@ namespace Parlot.Fluent
 
         public ParseContext(Scanner scanner)
         {
-            Scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
+            Scanner = scanner;
         }
 
         /// <summary>
         /// Delegate that is executed whenever a parser is invoked.
         /// </summary>
-        public Action<object, ParseContext> OnEnterParser { get; set; }
+        public Action<object, ParseContext>? OnEnterParser { get; set; }
 
         /// <summary>
         /// The parser that is used to parse whitespaces and comments.
         /// This can also include comments.
         /// </summary>
-        public Parser<TextSpan> WhiteSpaceParser { get; set;}
+        public Parser<TextSpan>? WhiteSpaceParser { get; set;}
 
         public void SkipWhiteSpace()
         {

--- a/src/Parlot/Fluent/Parser.cs
+++ b/src/Parlot/Fluent/Parser.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Parlot.Fluent
 {
@@ -49,7 +50,7 @@ namespace Parlot.Fluent
 
     public static class ParserExtensions
     {
-        public static T Parse<T>(this Parser<T> parser, string text)
+        public static T? Parse<T>(this Parser<T> parser, string text)
         {
             var context = new ParseContext(new Scanner(text));
 
@@ -65,19 +66,31 @@ namespace Parlot.Fluent
             return default;
         }
 
-        public static bool TryParse<TResult>(this Parser<TResult> parser, string text, out TResult value)
+        public static bool TryParse<TResult>(
+            this Parser<TResult> parser, 
+            string text,
+            [NotNullWhen(true)] out TResult? value)
         {
             return parser.TryParse(text, out value, out _);
         }
 
-        public static bool TryParse<TResult>(this Parser<TResult> parser, string text, out TResult value, out ParseError error)
+        public static bool TryParse<TResult>(
+            this Parser<TResult> parser, 
+            string text,
+            [NotNullWhen(true)] out TResult? value,
+            out ParseError? error)
         {
             return TryParse(parser, new ParseContext(new Scanner(text)), out value, out error);
         }
 
-        public static bool TryParse<TResult>(this Parser<TResult> parser, ParseContext context, out TResult value, out ParseError error)
+        public static bool TryParse<TResult>(
+            this Parser<TResult> parser, 
+            ParseContext context,
+            [NotNullWhen(true)] out TResult? value,
+            out ParseError? error)
         {
             error = null;
+            value = default;
 
             try
             {
@@ -87,21 +100,20 @@ namespace Parlot.Fluent
 
                 if (success)
                 {
-                    value = localResult.Value;
+                    value = localResult.Value!;
                     return true;
                 }
             }
             catch (ParseException e)
             {
-                error = new ParseError
-                {
-                    Message = e.Message,
-                    Position = e.Position
-                };
+                error = new ParseError(e);
             }
 
-            value = default;
             return false;
         }
+        
+#if NETSTANDARD2_0
+        private class NotNullWhenAttribute : Attribute { public NotNullWhenAttribute(bool _) { } }
+#endif
     }
 }

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -19,7 +19,7 @@ namespace Parlot.Fluent
         /// <summary>
         /// Builds a parser that looks for zero or many times a parser separated by another one.
         /// </summary>
-        public static Parser<List<T>> Separated<U, T>(Parser<U> separator, Parser<T> parser) => new Separated<U, T>(separator, parser);
+        public static Parser<List<T?>?> Separated<U, T>(Parser<U> separator, Parser<T> parser) => new Separated<U, T>(separator, parser);
 
         /// <summary>
         /// Builds a parser that looks for zero or one time the specified parser.
@@ -107,7 +107,7 @@ namespace Parlot.Fluent
         /// <summary>
         /// Builds a parser that matches an identifier.
         /// </summary>
-        public Parser<TextSpan> Identifier(Func<char, bool> extraStart = null, Func<char, bool> extraPart = null) => new Identifier(extraStart, extraPart, skipWhiteSpace: false);
+        public Parser<TextSpan> Identifier(Func<char, bool>? extraStart = null, Func<char, bool>? extraPart = null) => new Identifier(extraStart, extraPart, skipWhiteSpace: false);
     }
 
     public class TermBuilder
@@ -140,6 +140,6 @@ namespace Parlot.Fluent
         /// <summary>
         /// Builds a parser that matches an identifier.
         /// </summary>
-        public Parser<TextSpan> Identifier(Func<char, bool> extraStart = null, Func<char, bool> extraPart = null) => new Identifier(extraStart, extraPart);
+        public Parser<TextSpan> Identifier(Func<char, bool>? extraStart = null, Func<char, bool>? extraPart = null) => new Identifier(extraStart, extraPart);
     }
 }

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Parlot.Fluent
 {
-    public sealed class Separated<U, T> : Parser<List<T>>
+    public sealed class Separated<U, T> : Parser<List<T?>?>
     {
         private readonly Parser<U> _separator;
         private readonly Parser<T> _parser;
@@ -28,11 +28,11 @@ namespace Parlot.Fluent
             }
         }
 
-        public override bool Parse(ParseContext context, ref ParseResult<List<T>> result)
+        public override bool Parse(ParseContext context, ref ParseResult<List<T?>?> result)
         {
             context.EnterParser(this);
 
-            List<T> results = null;
+            List<T?>? results = null;
 
             var start = 0;
             var end = 0;
@@ -59,7 +59,7 @@ namespace Parlot.Fluent
                 }
 
                 end = parsed.End;
-                results ??= new List<T>();
+                results ??= new List<T?>();
                 results.Add(parsed.Value);
 
                 if (_separatorIsChar)
@@ -80,7 +80,7 @@ namespace Parlot.Fluent
                 }
             }
 
-            result = new ParseResult<List<T>>(start, end, results);
+            result = new ParseResult<List<T?>?>(start, end, results);
             return true;
         }
     }

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -4,12 +4,12 @@ namespace Parlot.Fluent
 {
     public sealed class TextLiteral : Parser<string>
     {
-        private readonly StringComparer _comparer;
+        private readonly StringComparer? _comparer;
         private readonly bool _skipWhiteSpace;
 
-        public TextLiteral(string text, StringComparer comparer = null,  bool skipWhiteSpace = true)
+        public TextLiteral(string text, StringComparer? comparer = null,  bool skipWhiteSpace = true)
         {
-            Text = text ?? throw new ArgumentNullException(nameof(text));
+            Text = text;
             _comparer = comparer;
             _skipWhiteSpace = skipWhiteSpace;
         }

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -10,8 +10,8 @@ namespace Parlot.Fluent
     /// <typeparam name="U">The output parser type.</typeparam>
     public sealed class Then<T, U> : Parser<U>
     {
-        private readonly Func<T, U> _action1;
-        private readonly Func<ParseContext, T, U> _action2;
+        private readonly Func<T, U>? _action1;
+        private readonly Func<ParseContext, T, U>? _action2;
         private readonly Parser<T> _parser;
 
         public Then(Parser<T> parser)

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -9,6 +9,7 @@
     <DebugType>pdbonly</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>$(NoWarn);1591</NoWarn>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Parlot/ParseError.cs
+++ b/src/Parlot/ParseError.cs
@@ -2,7 +2,18 @@
 {
     public class ParseError
     {
-        public string Message { get; set; }
-        public TextPosition Position { get; set; }
+        public ParseError(ParseException parseException)
+            : this(parseException.Message, parseException.Position)
+        {
+        }
+
+        public ParseError(string message, in TextPosition position)
+        {
+            Message = message;
+            Position = position;
+        }
+
+        public string Message { get; }
+        public TextPosition Position { get; }
     }
 }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -74,7 +74,7 @@ namespace Parlot
             return true;
         }
 
-        public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other, TokenResult result = null)
+        public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other, TokenResult? result = null)
         {
             if (!first(Cursor.Current))
             {
@@ -95,14 +95,14 @@ namespace Parlot
             return true;
         }
 
-        public bool ReadIdentifier(TokenResult result = null)
+        public bool ReadIdentifier(TokenResult? result = null)
         {
             // perf: using Character.IsIdentifierStart instead of x => Character.IsIdentifierStart(x) induces some allocations
 
             return ReadFirstThenOthers(static x => Character.IsIdentifierStart(x), static x => Character.IsIdentifierPart(x), result);
         }
 
-        public bool ReadDecimal(TokenResult result = null)
+        public bool ReadDecimal(TokenResult? result = null)
         {
             // perf: fast path to prevent a copy of the position
 
@@ -142,7 +142,7 @@ namespace Parlot
             return true;
         }
 
-        public bool ReadInteger(TokenResult result = null)
+        public bool ReadInteger(TokenResult? result = null)
         {
             // perf: fast path to prevent a copy of the position
 
@@ -167,7 +167,7 @@ namespace Parlot
         /// <summary>
         /// Reads a token while the specific predicate is valid.
         /// </summary>
-        public bool ReadWhile(Func<char, bool> predicate, TokenResult result = null)
+        public bool ReadWhile(Func<char, bool> predicate, TokenResult? result = null)
         {
             if (Cursor.Eof || !predicate(Cursor.Current))
             {
@@ -189,7 +189,7 @@ namespace Parlot
             return true;
         }
 
-        public bool ReadNonWhiteSpace(TokenResult result = null)
+        public bool ReadNonWhiteSpace(TokenResult? result = null)
         {
             return ReadWhile(static x => !Character.IsWhiteSpace(x), result);
         }
@@ -197,7 +197,7 @@ namespace Parlot
         /// <summary>
         /// Reads the specified text.
         /// </summary>
-        public bool ReadChar(char c, TokenResult result = null)
+        public bool ReadChar(char c, TokenResult? result = null)
         {
             if (!Cursor.Match(c))
             {
@@ -224,7 +224,7 @@ namespace Parlot
         /// <summary>
         /// Reads the specific expected text.
         /// </summary>
-        public bool ReadText(string text, StringComparer comparer = null, TokenResult result = null)
+        public bool ReadText(string text, StringComparer? comparer = null, TokenResult? result = null)
         {
             // Default comparison is ordinal.
             // Use implementation of Match() that doesn't use any comparer in this case.
@@ -260,17 +260,17 @@ namespace Parlot
             return true;
         }
 
-        public bool ReadSingleQuotedString(TokenResult result = null)
+        public bool ReadSingleQuotedString(TokenResult? result = null)
         {
             return ReadQuotedString('\'', result);
         }
 
-        public bool ReadDoubleQuotedString(TokenResult result = null)
+        public bool ReadDoubleQuotedString(TokenResult? result = null)
         {
             return ReadQuotedString('\"', result);
         }
 
-        public bool ReadQuotedString(TokenResult result = null)
+        public bool ReadQuotedString(TokenResult? result = null)
         {
             var startChar = Cursor.Current;
 
@@ -290,7 +290,7 @@ namespace Parlot
         /// This method doesn't escape the string, but only validates its content is syntactically correct.
         /// The resulting Span contains the original quotes.
         /// </remarks>
-        private bool ReadQuotedString(char quoteChar, TokenResult result = null)
+        private bool ReadQuotedString(char quoteChar, TokenResult? result = null)
         {
             var startChar = Cursor.Current;
 

--- a/src/Parlot/ThrowHelper.cs
+++ b/src/Parlot/ThrowHelper.cs
@@ -1,19 +1,19 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Parlot
 {
-#if !NETSTANDARD2_0
-    using System.Diagnostics.CodeAnalysis;
-#endif
 
     internal static class ThrowHelper
     {
-#if !NETSTANDARD2_0
         [DoesNotReturn]
-#endif
         public static void ThrowArgumentNullException(string paramName)
         {
             throw new ArgumentNullException(paramName);
         }
+        
+#if NETSTANDARD2_0
+        private class DoesNotReturnAttribute : Attribute {}
+#endif
     }
 }

--- a/src/Parlot/TokenResult.cs
+++ b/src/Parlot/TokenResult.cs
@@ -4,7 +4,7 @@ namespace Parlot
 {
     public sealed class TokenResult
     {
-        private string _text;
+        private string? _text;
 
         public bool Success { get; private set; }
 
@@ -13,9 +13,10 @@ namespace Parlot
         public int End { get; private set; }
 
         public int Length { get; private set; }
-        public string Buffer { get; private set; }
 
-        public string Text => _text ??= Buffer?.Substring(Start, Length);
+        public string? Buffer { get; private set; }
+
+        public string? Text => _text ??= Buffer?.Substring(Start, Length);
 
 #if !NETSTANDARD2_0
         public ReadOnlySpan<char> Span => Buffer.AsSpan(Start, Length);


### PR DESCRIPTION
Should make it easier to reason with API maybe spot design problems for consumers. This is easier to enable earlier than later.