### PR TITLE
Pattern matching for chars

### DIFF
--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -1,11 +1,21 @@
-﻿namespace Parlot.Fluent
+﻿using System;
+
+namespace Parlot.Fluent
 {
     public sealed class CharLiteral : Parser<char>
     {
+        private readonly Func<char, bool> _predicate;
+
         public CharLiteral(char c, bool skipWhiteSpace = true)
         {
             Char = c;
             SkipWhiteSpace = skipWhiteSpace;
+        }
+
+        public CharLiteral(Func<char, bool> predicate, bool skipWhiteSpace = true)
+        {
+            _predicate = predicate;
+            SkipWhiteSpace = skipWhiteSpace;            
         }
 
         public char Char { get; }
@@ -22,6 +32,14 @@
             }
 
             var start = context.Scanner.Cursor.Offset;
+
+            if (_predicate != null && _predicate(context.Scanner.Cursor.Current))
+            {
+                result.Set(start, context.Scanner.Cursor.Offset, context.Scanner.Cursor.Current);
+                context.Scanner.Cursor.Advance();
+
+                return true;
+            }
 
             if (context.Scanner.ReadChar(Char))
             {

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -1,21 +1,11 @@
-﻿using System;
-
-namespace Parlot.Fluent
+﻿namespace Parlot.Fluent
 {
     public sealed class CharLiteral : Parser<char>
     {
-        private readonly Func<char, bool> _predicate;
-
         public CharLiteral(char c, bool skipWhiteSpace = true)
         {
             Char = c;
             SkipWhiteSpace = skipWhiteSpace;
-        }
-
-        public CharLiteral(Func<char, bool> predicate, bool skipWhiteSpace = true)
-        {
-            _predicate = predicate;
-            SkipWhiteSpace = skipWhiteSpace;            
         }
 
         public char Char { get; }
@@ -32,15 +22,6 @@ namespace Parlot.Fluent
             }
 
             var start = context.Scanner.Cursor.Offset;
-
-            if (_predicate != null && _predicate(context.Scanner.Cursor.Current))
-            {
-                var current = context.Scanner.Cursor.Current;
-                context.Scanner.Cursor.Advance();
-                result.Set(start, context.Scanner.Cursor.Offset, current);
-
-                return true;
-            }
 
             if (context.Scanner.ReadChar(Char))
             {

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -35,8 +35,9 @@ namespace Parlot.Fluent
 
             if (_predicate != null && _predicate(context.Scanner.Cursor.Current))
             {
-                result.Set(start, context.Scanner.Cursor.Offset, context.Scanner.Cursor.Current);
+                var current = context.Scanner.Cursor.Current;
                 context.Scanner.Cursor.Advance();
+                result.Set(start, context.Scanner.Cursor.Offset, current);
 
                 return true;
             }

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -93,6 +93,11 @@ namespace Parlot.Fluent
         /// Builds a parser that matches the specified char.
         /// </summary>
         public Parser<char> Char(char c) => new CharLiteral(c, skipWhiteSpace: false);
+
+        /// <summary>
+        /// Builds a parser that matches a char against a predicate.
+        /// </summary>
+        public Parser<char> Char(Func<char, bool> predicate) => new CharLiteral(predicate, skipWhiteSpace: false);        
         
         /// <summary>
         /// Builds a parser that matches an integer.
@@ -131,6 +136,11 @@ namespace Parlot.Fluent
         /// Builds a parser that matches the specified char.
         /// </summary>
         public Parser<char> Char(char c) => new CharLiteral(c);
+
+        /// <summary>
+        /// Builds a parser that matches a char against a predicate.
+        /// </summary>
+        public Parser<char> Char(Func<char, bool> predicate) => new CharLiteral(predicate);        
 
         /// <summary>
         /// Builds a parser that matches an integer.

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -60,7 +60,7 @@ namespace Parlot.Fluent
         /// Builds a parser that matches any chars before a specific parser.
         /// </summary>
         public static Parser<TextSpan> AnyCharBefore<T>(Parser<T> parser, bool canBeEmpty = false, bool failOnEof = false, bool consumeDelimiter = false) => new TextBefore<T>(parser, canBeEmpty, failOnEof, consumeDelimiter);
-        
+
         /// <summary>
         /// Ensure the specified parser follows the previous one. The previous parser's result is then ignored.
         /// </summary>
@@ -95,11 +95,6 @@ namespace Parlot.Fluent
         public Parser<char> Char(char c) => new CharLiteral(c, skipWhiteSpace: false);
 
         /// <summary>
-        /// Builds a parser that matches a char against a predicate.
-        /// </summary>
-        public Parser<char> Char(Func<char, bool> predicate) => new CharLiteral(predicate, skipWhiteSpace: false);        
-        
-        /// <summary>
         /// Builds a parser that matches an integer.
         /// </summary>
         public Parser<long> Integer() => new IntegerLiteral(skipWhiteSpace: false);
@@ -118,6 +113,14 @@ namespace Parlot.Fluent
         /// Builds a parser that matches an identifier.
         /// </summary>
         public Parser<TextSpan> Identifier(Func<char, bool> extraStart = null, Func<char, bool> extraPart = null) => new Identifier(extraStart, extraPart, skipWhiteSpace: false);
+
+        /// <summary>
+        /// Builds a parser that matches a char against a predicate.
+        /// </summary>
+        /// <param name="predicate">The predicate to match against each char.</param>
+        /// <param name="minSize">The minimum number of matches required. Defaults to 1.</param>
+        /// <param name="maxSize">When the parser reaches the maximum number of matches it returns <see langword="True"/>. Defaults to 0, i.e. no maximum size.</param>
+        public Parser<TextSpan> Pattern(Func<char, bool> predicate, int minSize = 1, int maxSize = 0) => new PatternLiteral(predicate, minSize, maxSize, skipWhiteSpace: false);
     }
 
     public class TermBuilder
@@ -138,11 +141,6 @@ namespace Parlot.Fluent
         public Parser<char> Char(char c) => new CharLiteral(c);
 
         /// <summary>
-        /// Builds a parser that matches a char against a predicate.
-        /// </summary>
-        public Parser<char> Char(Func<char, bool> predicate) => new CharLiteral(predicate);        
-
-        /// <summary>
         /// Builds a parser that matches an integer.
         /// </summary>
         public Parser<long> Integer(NumberOptions numberOptions = NumberOptions.Default) => new IntegerLiteral(numberOptions);
@@ -161,5 +159,13 @@ namespace Parlot.Fluent
         /// Builds a parser that matches an identifier.
         /// </summary>
         public Parser<TextSpan> Identifier(Func<char, bool> extraStart = null, Func<char, bool> extraPart = null) => new Identifier(extraStart, extraPart);
+
+        /// <summary>
+        /// Builds a parser that matches a char against a predicate.
+        /// </summary>
+        /// <param name="predicate">The predicate to match against each char.</param>
+        /// <param name="minSize">The minimum number of matches required. Defaults to 1.</param>
+        /// <param name="maxSize">When the parser reaches the maximum number of matches it returns <see langword="True"/>. Defaults to 0, i.e. no maximum size.</param>
+        public Parser<TextSpan> Pattern(Func<char, bool> predicate, int minSize = 1, int maxSize = 0) => new PatternLiteral(predicate, minSize, maxSize);
     }
 }

--- a/src/Parlot/Fluent/PatternLiteral.cs
+++ b/src/Parlot/Fluent/PatternLiteral.cs
@@ -1,0 +1,56 @@
+﻿using System;
+
+namespace Parlot.Fluent
+{
+    public sealed class PatternLiteral : Parser<TextSpan>
+    {
+        private readonly Func<char, bool> _predicate;
+        private readonly int _minSize;
+        private readonly int _maxSize;
+        private readonly bool _skipWhiteSpace;
+
+        public PatternLiteral(Func<char, bool> predicate, int minSize = 1, int maxSize = 0, bool skipWhiteSpace = true)
+        {
+            _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
+            _minSize = minSize;
+            _maxSize = maxSize;
+            _skipWhiteSpace = skipWhiteSpace;
+        }
+
+        public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
+        {
+            context.EnterParser(this);
+
+            if (_skipWhiteSpace)
+            {
+                context.SkipWhiteSpace();
+            }
+
+            if (context.Scanner.Cursor.Eof || !_predicate(context.Scanner.Cursor.Current))
+            {
+                return false;
+            }
+
+            var start = context.Scanner.Cursor.Offset;
+
+            context.Scanner.Cursor.Advance();
+            var found = 1;
+
+            while (!context.Scanner.Cursor.Eof && (_maxSize > 0 ? found < _maxSize : true) && _predicate(context.Scanner.Cursor.Current))
+            {
+                context.Scanner.Cursor.Advance();
+                found++;
+            }
+
+            if (found >= _minSize)
+            {
+                var end = context.Scanner.Cursor.Offset;
+                result.Set(start, end, new TextSpan(context.Scanner.Buffer, start, end - start));
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+}

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -101,6 +101,28 @@ namespace Parlot.Tests
             Assert.False(Literals.Char('a').TryParse("B", out _));
         }
 
+        [Fact]
+        public void CharLiteralPredicate()
+        {
+            Assert.True(Literals.Char(c => c == 'a').TryParse("a", out _));
+            Assert.False(Literals.Char(c => c == 'a').TryParse("b", out _));
+            Assert.True(Literals.Char(c => c == 'a' || c == 'b').TryParse("b", out _));
+            Assert.True(Literals.Char(c => Character.IsHexDigit(c)).TryParse("b", out _));
+            Assert.True(Literals.Char(c => Character.IsHexDigit(c)).TryParse("B", out _));
+            Assert.False(Literals.Char(c => Character.IsHexDigit(c)).TryParse("X", out _));
+        }
+
+        [Fact]
+        public void TermCharLiteralPredicate()
+        {
+            Assert.True(Terms.Char(c => c == 'a').TryParse(" a", out _));
+            Assert.False(Terms.Char(c => c == 'a').TryParse(" b", out _));
+            Assert.True(Terms.Char(c => c == 'a' || c == 'b').TryParse(" b", out _));
+            Assert.True(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" b", out _));
+            Assert.True(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" B", out _));
+            Assert.False(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" X", out _));
+        }                
+
         [Theory]
         [InlineData("'a\nb' ", "a\nb")]
         [InlineData("'a\r\nb' ", "a\r\nb")]

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -104,22 +104,22 @@ namespace Parlot.Tests
         [Fact]
         public void CharLiteralPredicate()
         {
-            Assert.True(Literals.Char(c => c == 'a').TryParse("a", out _));
-            Assert.False(Literals.Char(c => c == 'a').TryParse("b", out _));
-            Assert.True(Literals.Char(c => c == 'a' || c == 'b').TryParse("b", out _));
-            Assert.True(Literals.Char(c => Character.IsHexDigit(c)).TryParse("b", out _));
-            Assert.True(Literals.Char(c => Character.IsHexDigit(c)).TryParse("B", out _));
+            Assert.Equal('a', Literals.Char(c => c == 'a').Parse("a"));
+            Assert.Equal('b', Literals.Char(c => c == 'a' || c == 'b').Parse("b"));
+            Assert.Equal('b', Literals.Char(c => Character.IsHexDigit(c)).Parse("b"));
+            Assert.Equal('B', Literals.Char(c => Character.IsHexDigit(c)).Parse("B"));
             Assert.False(Literals.Char(c => Character.IsHexDigit(c)).TryParse("X", out _));
+            Assert.False(Literals.Char(c => c == 'a').TryParse("b", out _));
         }
 
         [Fact]
         public void TermCharLiteralPredicate()
         {
-            Assert.True(Terms.Char(c => c == 'a').TryParse(" a", out _));
+            Assert.Equal('a', Terms.Char(c => c == 'a').Parse(" a"));
+            Assert.Equal('b', Terms.Char(c => c == 'a' || c == 'b').Parse(" b"));
+            Assert.Equal('b', Terms.Char(c => Character.IsHexDigit(c)).Parse(" b"));
+            Assert.Equal('B', Terms.Char(c => Character.IsHexDigit(c)).Parse(" B"));
             Assert.False(Terms.Char(c => c == 'a').TryParse(" b", out _));
-            Assert.True(Terms.Char(c => c == 'a' || c == 'b').TryParse(" b", out _));
-            Assert.True(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" b", out _));
-            Assert.True(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" B", out _));
             Assert.False(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" X", out _));
         }                
 

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -101,27 +101,24 @@ namespace Parlot.Tests
             Assert.False(Literals.Char('a').TryParse("B", out _));
         }
 
-        [Fact]
-        public void CharLiteralPredicate()
+        [Theory]
+        [InlineData("a", "a")]
+        [InlineData("abc", "abc")]
+        [InlineData(" abc", "abc")]
+        public void ShouldReadPatterns(string text, string expected)
         {
-            Assert.Equal('a', Literals.Char(c => c == 'a').Parse("a"));
-            Assert.Equal('b', Literals.Char(c => c == 'a' || c == 'b').Parse("b"));
-            Assert.Equal('b', Literals.Char(c => Character.IsHexDigit(c)).Parse("b"));
-            Assert.Equal('B', Literals.Char(c => Character.IsHexDigit(c)).Parse("B"));
-            Assert.False(Literals.Char(c => Character.IsHexDigit(c)).TryParse("X", out _));
-            Assert.False(Literals.Char(c => c == 'a').TryParse("b", out _));
+            Assert.Equal(expected, Terms.Pattern(c => Character.IsHexDigit(c)).Parse(text).ToString());
         }
 
         [Fact]
-        public void TermCharLiteralPredicate()
+        public void ShouldReadPatternsWithSizes()
         {
-            Assert.Equal('a', Terms.Char(c => c == 'a').Parse(" a"));
-            Assert.Equal('b', Terms.Char(c => c == 'a' || c == 'b').Parse(" b"));
-            Assert.Equal('b', Terms.Char(c => Character.IsHexDigit(c)).Parse(" b"));
-            Assert.Equal('B', Terms.Char(c => Character.IsHexDigit(c)).Parse(" B"));
-            Assert.False(Terms.Char(c => c == 'a').TryParse(" b", out _));
-            Assert.False(Terms.Char(c => Character.IsHexDigit(c)).TryParse(" X", out _));
-        }                
+            Assert.False(Terms.Pattern(c => Character.IsHexDigit(c), minSize: 3).TryParse("ab", out _));
+            Assert.Equal("abc", Terms.Pattern(c => Character.IsHexDigit(c), minSize: 3).Parse("abc".ToString()));
+            Assert.Equal("abc", Terms.Pattern(c => Character.IsHexDigit(c), maxSize: 3).Parse("abcd").ToString());
+            Assert.Equal("abc", Terms.Pattern(c => Character.IsHexDigit(c), minSize: 3, maxSize: 3).Parse("abcd").ToString());
+            Assert.False(Terms.Pattern(c => Character.IsHexDigit(c), minSize: 3, maxSize: 2).TryParse("ab", out _));
+        }
 
         [Theory]
         [InlineData("'a\nb' ", "a\nb")]
@@ -198,11 +195,11 @@ namespace Parlot.Tests
             var i = Literals.Text("i:");
             var s = Literals.Text("s:");
 
-            var parser = d.Or(i).Or(s).Switch((context, result) => 
-            { 
-                switch (result) 
-                { 
-                    case "d:": return Literals.Decimal().Then<object>(x => x); 
+            var parser = d.Or(i).Or(s).Switch((context, result) =>
+            {
+                switch (result)
+                {
+                    case "d:": return Literals.Decimal().Then<object>(x => x);
                     case "i:": return Literals.Integer().Then<object>(x => x);
                     case "s:": return Literals.String().Then<object>(x => x);
                 }
@@ -226,14 +223,14 @@ namespace Parlot.Tests
             var i = Literals.Text("i:");
             var s = Literals.Text("s:");
 
-            var parser = d.Or(i).Or(s).Switch((context, result) => 
-            { 
-                switch (result) 
-                { 
-                    case "d:": return Literals.Decimal().Then(x => x.ToString()); 
-                    case "i:": return Literals.Integer().Then(x => x.ToString()); 
-                    case "s:": return Literals.String().Then(x => x.ToString()); 
-                } 
+            var parser = d.Or(i).Or(s).Switch((context, result) =>
+            {
+                switch (result)
+                {
+                    case "d:": return Literals.Decimal().Then(x => x.ToString());
+                    case "i:": return Literals.Integer().Then(x => x.ToString());
+                    case "s:": return Literals.String().Then(x => x.ToString());
+                }
                 return null;
             });
 


### PR DESCRIPTION
Related to https://github.com/sebastienros/parlot/issues/22

Actually found myself just wanting to capture hex codes.

Figured that with `OneOrMany(Literals.Char(c => Character.IsHexDigit))` you can end up with a list of chars.

But this could also be applied the `Terms.Text` and use `ReadWhile` to return a `TextSpan`, which would be nicer.

Let me know