### PR TITLE
Added possibility to read non escapable sequences

### DIFF
--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -65,7 +65,7 @@ namespace Parlot
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other)
-            => ReadFirstThenOthers(first, other, out _); 
+            => ReadFirstThenOthers(first, other, out _);
 
         public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other, out TokenResult result)
         {
@@ -143,7 +143,7 @@ namespace Parlot
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ReadInteger() => ReadInteger(out _);
-        
+
         public bool ReadInteger(out TokenResult result)
         {
             // perf: fast path to prevent a copy of the position
@@ -198,7 +198,7 @@ namespace Parlot
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadNonWhiteSpace() => ReadNonWhiteSpace(out _); 
+        public bool ReadNonWhiteSpace() => ReadNonWhiteSpace(out _);
 
         public bool ReadNonWhiteSpace(out TokenResult result)
         {
@@ -206,7 +206,7 @@ namespace Parlot
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadNonWhiteSpaceOrNewLine() => ReadNonWhiteSpaceOrNewLine(out _); 
+        public bool ReadNonWhiteSpaceOrNewLine() => ReadNonWhiteSpaceOrNewLine(out _);
 
         public bool ReadNonWhiteSpaceOrNewLine(out TokenResult result)
         {
@@ -241,8 +241,8 @@ namespace Parlot
         /// Reads the specific expected text.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadText(string text, StringComparer comparer) => ReadText(text, comparer, out _); 
-        
+        public bool ReadText(string text, StringComparer comparer) => ReadText(text, comparer, out _);
+
         /// <summary>
         /// Reads the specific expected text.
         /// </summary>
@@ -261,7 +261,7 @@ namespace Parlot
             int start = Cursor.Offset;
             Cursor.Advance(text.Length);
             result = TokenResult.Succeed(Buffer, start, Cursor.Offset);
-            
+
             return true;
         }
 
@@ -470,6 +470,52 @@ namespace Parlot
 
             result = TokenResult.Succeed(Buffer, start.Offset, Cursor.Offset);
 
+            return true;
+        }
+
+        /// <summary>
+        /// Reads a sequence token enclosed in arbritrary start and end characters.
+        /// </summary>
+        /// <remarks>
+        /// This method doesn't escape the string, but only validates its content is syntactically correct.
+        /// The resulting Span contains the original quotes.
+        /// </remarks>
+        public bool ReadNonEscapableSequence(char startSequenceChar, char endSequenceChar, out TokenResult result)
+        {
+            var startChar = Cursor.Current;
+
+            if (startChar != startSequenceChar)
+            {
+                result = TokenResult.Fail();
+                return false;
+            }
+
+            // Fast path if there aren't any escape char until next quote
+            var startOffset = Cursor.Offset + 1;
+
+            int nextQuote;
+            do
+            {
+                nextQuote = Cursor.Buffer.IndexOf(endSequenceChar, startOffset);
+
+                if (nextQuote == -1)
+                {
+                    // There is no end sequence character, not a valid escapable sequence
+                    result = TokenResult.Fail();
+                    return false;
+                }
+            }
+            while(Cursor.Buffer.Length>nextQuote+1 && Cursor.Buffer[nextQuote+1]==endSequenceChar);
+
+            var start = Cursor.Position;
+
+            Cursor.Advance();
+            
+
+// If the next escape if not before the next quote, we can return the string as-is
+            Cursor.Advance(nextQuote + 1 - startOffset);
+
+            result = TokenResult.Succeed(Buffer, start.Offset, Cursor.Offset);
             return true;
         }
     }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -517,11 +517,8 @@ namespace Parlot
 
             var start = Cursor.Position;
 
-            Cursor.Advance();
-            
-
-// If the next escape if not before the next quote, we can return the string as-is
-            Cursor.Advance(nextQuote + 1 - startOffset);
+            // If the next escape if not before the next quote, we can return the string as-is
+            Cursor.Advance(nextQuote + 2 - startOffset);
 
             result = TokenResult.Succeed(Buffer, start.Offset, Cursor.Offset);
             return true;

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -492,20 +492,28 @@ namespace Parlot
 
             // Fast path if there aren't any escape char until next quote
             var startOffset = Cursor.Offset + 1;
+            var lastQuote = startOffset;
 
-            int nextQuote;
+            int nextQuote ;
             do
             {
-                nextQuote = Cursor.Buffer.IndexOf(endSequenceChar, startOffset);
+                nextQuote = Cursor.Buffer.IndexOf(endSequenceChar, lastQuote + 1);
 
                 if (nextQuote == -1)
                 {
-                    // There is no end sequence character, not a valid escapable sequence
-                    result = TokenResult.Fail();
-                    return false;
+                    if(startOffset == lastQuote)
+                    {
+                        // There is no end sequence character, not a valid escapable sequence
+                        result = TokenResult.Fail();
+                        return false;
+                    }
+                    nextQuote = lastQuote - 1;
+                    break;
                 }
+
+                lastQuote = nextQuote + 1;
             }
-            while(Cursor.Buffer.Length>nextQuote+1 && Cursor.Buffer[nextQuote+1]==endSequenceChar);
+            while(Cursor.Buffer.Length > lastQuote && Cursor.Buffer[lastQuote] == endSequenceChar);
 
             var start = Cursor.Position;
 

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -48,11 +48,15 @@ namespace Parlot.Tests
         [InlineData("'Lorem ipsum'", "'Lorem ipsum'")]
         [InlineData("'Lorem \n ipsum'", "'Lorem \n ipsum'")]
         [InlineData("'Lorem '' ipsum'", "'Lorem '' ipsum'")]
+        [InlineData("'Lorem ' ipsum", "'Lorem '")]
+        [InlineData("'Lorem '' i''ps''um'", "'Lorem '' i''ps''um'")]
         [InlineData(@"""Lorem """" ipsum""", "\"Lorem \"\" ipsum\"")]
+        [InlineData("[mytable]", "[mytable]")]
+        [InlineData(@"""Lorem """""""" ipsum""", "\"Lorem \"\"\"\" ipsum\"")]
         public void ShouldReadNonEscapableString(string text, string expected)
         {
             Scanner s = new(text);
-            var success = s.ReadNonEscapableSequence(text[0], text[text.Length - 1], out var result);
+            var success = s.ReadNonEscapableSequence(expected[0], expected[expected.Length - 1], out var result);
             Assert.True(success);
             Assert.Equal(expected, result.GetText());
         }

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -48,17 +48,37 @@ namespace Parlot.Tests
         [InlineData("'Lorem ipsum'", "'Lorem ipsum'")]
         [InlineData("'Lorem \n ipsum'", "'Lorem \n ipsum'")]
         [InlineData("'Lorem '' ipsum'", "'Lorem '' ipsum'")]
+        [InlineData("'Lorem ipsum", "")]
+        [InlineData("Lorem ' ipsum", "")]
         [InlineData("'Lorem ' ipsum", "'Lorem '")]
+        [InlineData("Lorem ' ipsum'", "")]
         [InlineData("'Lorem '' i''ps''um'", "'Lorem '' i''ps''um'")]
         [InlineData(@"""Lorem """" ipsum""", "\"Lorem \"\" ipsum\"")]
         [InlineData("[mytable]", "[mytable]")]
+        [InlineData("[myta[ble]", "[myta[ble]")]
+        [InlineData("[myta]]ble]", "[myta]]ble]")]
         [InlineData(@"""Lorem """""""" ipsum""", "\"Lorem \"\"\"\" ipsum\"")]
         public void ShouldReadNonEscapableString(string text, string expected)
         {
             Scanner s = new(text);
-            var success = s.ReadNonEscapableSequence(expected[0], expected[expected.Length - 1], out var result);
-            Assert.True(success);
-            Assert.Equal(expected, result.GetText());
+            char start, end;
+            if(expected.Length==0)
+            {
+                start=end='\'';
+            }
+            else
+            {
+                start=expected[0];
+                end=expected[expected.Length - 1];
+            }
+            var success = s.ReadNonEscapableSequence(start, end, out var result);
+            if(expected.Length==0)
+                Assert.False(success);
+            else
+            {
+                Assert.True(success);
+                Assert.Equal(expected, result.GetText());
+            }
         }
 
         [Theory]

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -45,9 +45,10 @@ namespace Parlot.Tests
         }
 
         [Theory]
+        [InlineData("'Lorem ipsum'", "'Lorem ipsum'")]
         [InlineData("'Lorem \n ipsum'", "'Lorem \n ipsum'")]
         [InlineData("'Lorem '' ipsum'", "'Lorem '' ipsum'")]
-        [InlineData(@"""Lorem """""""" ipsum""", "\"Lorem \"\" ipsum\"")]
+        [InlineData(@"""Lorem """" ipsum""", "\"Lorem \"\" ipsum\"")]
         public void ShouldReadNonEscapableString(string text, string expected)
         {
             Scanner s = new(text);

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -45,6 +45,18 @@ namespace Parlot.Tests
         }
 
         [Theory]
+        [InlineData("'Lorem \n ipsum'", "'Lorem \n ipsum'")]
+        [InlineData("'Lorem '' ipsum'", "'Lorem '' ipsum'")]
+        [InlineData(@"""Lorem """""""" ipsum""", "\"Lorem \"\" ipsum\"")]
+        public void ShouldReadNonEscapableString(string text, string expected)
+        {
+            Scanner s = new(text);
+            var success = s.ReadNonEscapableSequence(text[0], text[text.Length - 1], out var result);
+            Assert.True(success);
+            Assert.Equal(expected, result.GetText());
+        }
+
+        [Theory]
         [InlineData("'Lorem \\w ipsum'")]
         [InlineData("'Lorem \\u12 ipsum'")]
         [InlineData("'Lorem \\xg ipsum'")]


### PR DESCRIPTION
Hi Seb,

I was missing the possibility to read string like in SQL where you escape using a double single quote (or as in C# when using the @string notation)

Please let me know if you need more that just the implementation.

PS: sorry for all the other changes, I have automated formatting when saving.