### PR TITLE
Support '-' in Identifiers

### DIFF
--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -16,7 +16,7 @@ namespace Parlot
                 (ch >= 'a' && ch <= 'f');
 
         public static bool IsIdentifierStart(char ch)
-            => (ch == '$') || (ch == '_') ||
+            => (ch == '$') || (ch == '_') || (ch == '-') ||
                (ch >= 'A' && ch <= 'Z') ||
                (ch >= 'a' && ch <= 'z');
 


### PR DESCRIPTION
This fixes https://github.com/sebastienros/shortcodes/issues/21 

This adds support for `-` in shortcode arguments and identifiers.