### PR TITLE
Use System.Memory with netstandard2.0 target

### DIFF
--- a/src/Parlot/Fluent/DecimalLiteral.cs
+++ b/src/Parlot/Fluent/DecimalLiteral.cs
@@ -33,14 +33,14 @@ namespace Parlot.Fluent
             if (context.Scanner.ReadDecimal())
             {
                 var end = context.Scanner.Cursor.Offset;
-#if NETSTANDARD2_0
+#if !SUPPORTS_SPAN_PARSE
                 var sourceToParse = context.Scanner.Buffer.Substring(start, end - start);
 #else
                 var sourceToParse = context.Scanner.Buffer.AsSpan(start, end - start);
 #endif
 
                 if (decimal.TryParse(sourceToParse, NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture, out var value))
-                { 
+                {
                     result.Set(start, end,  value);
                     return true;
                 }
@@ -105,7 +105,7 @@ namespace Parlot.Fluent
 #endif
 
             // TODO: NETSTANDARD2_1 code path
-            var block = 
+            var block =
                 Expression.IfThen(
                     context.ReadDecimal(),
                     Expression.Block(
@@ -114,8 +114,8 @@ namespace Parlot.Fluent
                         sliceExpression,
                         Expression.Assign(success,
                             Expression.Call(
-                                tryParseMethodInfo, 
-                                sourceToParse, 
+                                tryParseMethodInfo,
+                                sourceToParse,
                                 Expression.Constant(NumberStyles.AllowLeadingSign | NumberStyles.AllowDecimalPoint),
                                 Expression.Constant(CultureInfo.InvariantCulture),
                                 value)

--- a/src/Parlot/Fluent/IntegerLiteral.cs
+++ b/src/Parlot/Fluent/IntegerLiteral.cs
@@ -34,7 +34,7 @@ namespace Parlot.Fluent
             {
                 var end = context.Scanner.Cursor.Offset;
 
-#if NETSTANDARD2_0
+#if !SUPPORTS_SPAN_PARSE
                 var sourceToParse = context.Scanner.Buffer.Substring(start, end - start);
 #else
                 var sourceToParse = context.Scanner.Buffer.AsSpan(start, end - start);

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -13,10 +13,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
-    <DefineConstants>$(DefineConstants);SUPPORTS_READONLYSPAN;SUPPORTS_CODENALYSIS</DefineConstants>
+    <DefineConstants>$(DefineConstants);SUPPORTS_SPAN_PARSE;SUPPORTS_CODENALYSIS</DefineConstants>
   </PropertyGroup>
 </Project>

--- a/src/Parlot/TextSpan.cs
+++ b/src/Parlot/TextSpan.cs
@@ -22,9 +22,7 @@ namespace Parlot
         public readonly int Offset;
         public readonly string Buffer;
 
-#if SUPPORTS_READONLYSPAN
         public ReadOnlySpan<char> Span => Buffer == null ? ReadOnlySpan<char>.Empty : Buffer.AsSpan(Offset, Length);
-#endif
 
         public override string ToString()
         {
@@ -38,46 +36,12 @@ namespace Parlot
                 return Buffer == null;
             }
 
-#if NETSTANDARD2_0
-            if (Length != other.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < Length; i++)
-            {
-                if (Buffer[Offset + i] != other[i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-#else
-            return Span.SequenceEqual(other);
-#endif
+            return Span.SequenceEqual(other.AsSpan());
         }
 
         public bool Equals(TextSpan other)
         {
-#if NETSTANDARD2_0
-            if (Length != other.Length)
-            {
-                return false;
-            }
-
-            for (var i = 0; i < Length; i++)
-            {
-                if (Buffer[Offset + i] != other.Buffer[other.Offset + i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
-#else
             return Span.SequenceEqual(other.Span);
-#endif
         }
 
         public static implicit operator TextSpan(string s)

--- a/src/Parlot/TokenResult.cs
+++ b/src/Parlot/TokenResult.cs
@@ -1,13 +1,12 @@
-﻿using System;
-
-namespace Parlot
+﻿namespace Parlot
 {
+    using System;
     using System.Runtime.CompilerServices;
 
     public readonly struct TokenResult
     {
         private readonly string _buffer;
-        
+
         public readonly int Start;
         public readonly int Length;
 
@@ -20,9 +19,7 @@ namespace Parlot
 
         public string GetText() => _buffer.Substring(Start, Length);
 
-#if SUPPORTS_READONLYSPAN
         public ReadOnlySpan<char> Span => _buffer.AsSpan(Start, Length);
-#endif
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static TokenResult Succeed(string buffer, int start, int end)

--- a/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
+++ b/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Pidgin" Version="2.5.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Pidgin" Version="3.0.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
-    <PackageReference Include="Superpower" Version="2.3.0" />
+    <PackageReference Include="Superpower" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Parlot.Tests/Parlot.Tests.csproj
+++ b/test/Parlot.Tests/Parlot.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This simplifies code and I think such dependency is quite natural for parser library. Only a suggestion though. Also upgraded libs and run benchmarks to see where Parlot's at.


``` ini

BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK=6.0.101
  [Host]   : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT
  ShortRun : .NET 6.0.1 (6.0.121.56705), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

```
|                  Method |        Mean |      Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 | Allocated |
|------------------------ |------------:|-----------:|----------:|------:|--------:|---------:|---------:|----------:|
|          BigJson_Parlot |   132.35 μs |  22.934 μs |  1.257 μs |  1.00 |    0.00 |   6.1035 |   1.7090 |    102 KB |
|  BigJson_ParlotCompiled |   113.47 μs |   4.514 μs |  0.247 μs |  0.86 |    0.01 |   6.2256 |   2.0752 |    102 KB |
|          BigJson_Pidgin |   224.43 μs |  12.236 μs |  0.671 μs |  1.70 |    0.01 |   6.1035 |   1.4648 |    102 KB |
|         BigJson_Sprache | 1,511.30 μs |  79.740 μs |  4.371 μs | 11.42 |    0.14 | 322.2656 | 107.4219 |  5,274 KB |
|      BigJson_Superpower | 1,024.03 μs |  76.137 μs |  4.173 μs |  7.74 |    0.05 |  54.6875 |  15.6250 |    913 KB |
|                         |             |            |           |       |         |          |          |           |
|         LongJson_Parlot |   105.03 μs |   6.730 μs |  0.369 μs |  1.00 |    0.00 |   6.3477 |   1.5869 |    104 KB |
| LongJson_ParlotCompiled |    88.67 μs |   5.642 μs |  0.309 μs |  0.84 |    0.00 |   6.3477 |   1.5869 |    104 KB |
|         LongJson_Pidgin |   188.68 μs |  22.686 μs |  1.244 μs |  1.80 |    0.01 |   6.3477 |   1.7090 |    104 KB |
|        LongJson_Sprache | 1,304.92 μs | 217.296 μs | 11.911 μs | 12.42 |    0.15 | 259.7656 |  70.3125 |  4,245 KB |
|     LongJson_Superpower |   845.62 μs |  12.114 μs |  0.664 μs |  8.05 |    0.03 |  42.9688 |  10.7422 |    707 KB |
|                         |             |            |           |       |         |          |          |           |
|         DeepJson_Parlot |    86.60 μs |   4.453 μs |  0.244 μs |  1.00 |    0.00 |   5.0049 |   0.8545 |     82 KB |
| DeepJson_ParlotCompiled |    63.64 μs |   0.871 μs |  0.048 μs |  0.73 |    0.00 |   5.0049 |   1.0986 |     82 KB |
|         DeepJson_Pidgin |   269.30 μs |  23.575 μs |  1.292 μs |  3.11 |    0.01 |   9.2773 |   2.9297 |    153 KB |
|        DeepJson_Sprache | 1,031.54 μs | 134.960 μs |  7.398 μs | 11.91 |    0.05 | 175.7813 |  64.4531 |  2,898 KB |
|                         |             |            |           |       |         |          |          |           |
|         WideJson_Parlot |    78.25 μs |  17.981 μs |  0.986 μs |  1.00 |    0.00 |   2.9297 |   0.4883 |     49 KB |
| WideJson_ParlotCompiled |    74.11 μs |   9.759 μs |  0.535 μs |  0.95 |    0.02 |   2.9297 |   0.6104 |     49 KB |
|         WideJson_Pidgin |   125.94 μs |  19.652 μs |  1.077 μs |  1.61 |    0.03 |   2.9297 |   0.4883 |     48 KB |
|        WideJson_Sprache |   742.31 μs |  51.826 μs |  2.841 μs |  9.49 |    0.09 | 168.9453 |  41.9922 |  2,761 KB |
|     WideJson_Superpower |   518.36 μs |  31.894 μs |  1.748 μs |  6.62 |    0.06 |  27.3438 |   4.8828 |    460 KB |

