### PR TITLE
Perf optimizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,68 +136,104 @@ In this benchmark Parlot Fluent is more than 10 times faster than Pidgin, and Pa
 When compiled the Parlot grammar shows even better results, without losing its simplicity.
 
 ```
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=6.0.100-preview.4.21216.15
-  [Host]   : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
-  ShortRun : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=6.0.100
+  [Host]   : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
+  ShortRun : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
 
 Job=ShortRun  IterationCount=3  LaunchCount=1
 WarmupCount=3
 
-|              Method |        Mean |       Error |      StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
-|-------------------- |------------:|------------:|------------:|------:|--------:|-------:|------:|------:|----------:|
-| ParlotCompiledSmall |    769.6 ns |    709.4 ns |    38.89 ns |  1.70 |    0.08 | 0.1564 |     - |     - |     656 B |
-|   ParlotFluentSmall |    931.7 ns |    622.3 ns |    34.11 ns |  2.06 |    0.10 | 0.1564 |     - |     - |     656 B |
-|         PidginSmall | 11,668.0 ns | 10,591.9 ns |   580.58 ns | 25.77 |    1.64 | 0.1831 |     - |     - |     816 B |
-|                     |             |             |             |       |         |        |       |       |           |
-|   ParlotCompiledBig |  4,357.3 ns |  2,429.2 ns |   133.15 ns |  1.94 |    0.09 | 0.6866 |     - |     - |    2888 B |
-|     ParlotFluentBig |  5,312.8 ns |  3,441.7 ns |   188.65 ns |  2.36 |    0.06 | 0.6866 |     - |     - |    2888 B |
-|           PidginBig | 60,793.9 ns | 24,192.2 ns | 1,326.06 ns | 27.02 |    0.11 | 0.8545 |     - |     - |    4072 B |
-
+|              Method |        Mean |       Error |    StdDev | Ratio | RatioSD |  Gen 0 |  Gen 1 | Allocated |
+|-------------------- |------------:|------------:|----------:|------:|--------:|-------:|-------:|----------:|
+| ParlotCompiledSmall |    565.9 ns |   105.51 ns |   5.78 ns |  1.00 |    0.00 | 0.1049 |      - |     664 B |
+|   ParlotFluentSmall |    850.6 ns |   146.17 ns |   8.01 ns |  1.50 |    0.03 | 0.1049 |      - |     664 B |
+|         PidginSmall | 10,082.3 ns |   554.19 ns |  30.38 ns | 17.82 |    0.18 | 0.1221 |      - |     832 B |
+|                     |             |             |           |       |         |        |        |           |
+|   ParlotCompiledBig |  3,103.0 ns |    67.98 ns |   3.73 ns |  1.00 |    0.00 | 0.4616 | 0.0038 |   2,896 B |
+|     ParlotFluentBig |  4,464.1 ns |   237.26 ns |  13.01 ns |  1.44 |    0.00 | 0.4578 |      - |   2,896 B |
+|           PidginBig | 48,469.4 ns | 2,248.38 ns | 123.24 ns | 15.62 |    0.05 | 0.6104 |      - |   4,152 B |
 ```
 
 ### JSON Benchmarks
 
 This benchmark was taken from the Pidgin repository and demonstrates how to perform simple JSON document parsing. It exercises the parsers with different kinds of documents. Pidgin, Sprache, Superpower and Parlot are compared. The programming models are all based on parser combinator.
-
-The results show that Sprache and Superpower are the slowest and most allocating ones. Parlot provides the best performance in all scenarios, being at least 2 times faster than the second fastest. The allocations of Parlot are also better or equivalent to the ones of Pidgin.
+For reference Newtonsoft.Json is also added to show the differences with a dedicated parser.
+The results show that Sprache and Superpower are the slowest and most allocating ones. Parlot provides the best performance in all scenarios, being at least 2 times faster than the second fastest. The allocations of Parlot are also better or equivalent to the ones of Pidgin. This simple implementation is also faster than Newtonsoft, though it is far for being as rigourus.
 
 ```
-BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
-Intel Core i7-1065G7 CPU 1.30GHz, 1 CPU, 8 logical and 4 physical cores
-.NET Core SDK=6.0.100-preview.4.21216.15
-  [Host]   : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
-  ShortRun : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=6.0.100
+  [Host]   : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
+  ShortRun : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
 
 Job=ShortRun  IterationCount=3  LaunchCount=1
 WarmupCount=3
 
-|                  Method |       Mean |       Error |   StdDev | Ratio | RatioSD |     Gen 0 |    Gen 1 | Gen 2 |  Allocated |
-|------------------------ |-----------:|------------:|---------:|------:|--------:|----------:|---------:|------:|-----------:|
-|  BigJson_ParlotCompiled |   203.8 us |    34.68 us |  1.90 us |  0.85 |    0.02 |   24.9023 |   1.2207 |     - |  101.79 KB |
-|          BigJson_Parlot |   239.2 us |    47.22 us |  2.59 us |  1.00 |    0.00 |   24.9023 |   7.0801 |     - |  101.79 KB |
-|          BigJson_Pidgin |   470.1 us |    79.16 us |  4.34 us |  1.97 |    0.00 |   24.9023 |   7.3242 |     - |   101.7 KB |
-|         BigJson_Sprache | 3,348.1 us | 1,216.50 us | 66.68 us | 14.00 |    0.29 | 1308.5938 |   3.9063 |     - | 5349.63 KB |
-|      BigJson_Superpower | 2,059.3 us | 1,215.90 us | 66.65 us |  8.61 |    0.23 |  222.6563 |  66.4063 |     - |  913.43 KB |
-|                         |            |             |          |       |         |           |          |       |            |
-| LongJson_ParlotCompiled |   150.6 us |    57.08 us |  3.13 us |  0.89 |    0.02 |   25.3906 |   6.3477 |     - |  104.34 KB |
-|         LongJson_Parlot |   168.4 us |    27.75 us |  1.52 us |  1.00 |    0.00 |   25.3906 |   6.3477 |     - |  104.34 KB |
-|         LongJson_Pidgin |   391.9 us |    71.57 us |  3.92 us |  2.33 |    0.00 |   25.3906 |   6.3477 |     - |  104.25 KB |
-|        LongJson_Sprache | 2,443.5 us |   662.89 us | 36.34 us | 14.51 |    0.12 | 1054.6875 |   3.9063 |     - | 4311.36 KB |
-|     LongJson_Superpower | 1,646.8 us |   279.91 us | 15.34 us |  9.78 |    0.13 |  171.8750 |  42.9688 |     - |  706.79 KB |
-|                         |            |             |          |       |         |           |          |       |            |
-| DeepJson_ParlotCompiled |   109.3 us |     3.72 us |  0.20 us |  0.70 |    0.01 |   20.1416 |   0.6104 |     - |   82.33 KB |
-|         DeepJson_Parlot |   155.9 us |    26.57 us |  1.46 us |  1.00 |    0.00 |   20.0195 |   0.2441 |     - |   82.33 KB |
-|         DeepJson_Pidgin |   491.7 us |    87.57 us |  4.80 us |  3.15 |    0.01 |   49.8047 |   1.9531 |     - |  205.29 KB |
-|        DeepJson_Sprache | 2,809.1 us |   412.98 us | 22.64 us | 18.02 |    0.13 |  550.7813 | 222.6563 |     - | 2946.57 KB |
-|                         |            |             |          |       |         |           |          |       |            |
-| WideJson_ParlotCompiled |   139.6 us |    76.79 us |  4.21 us |  0.93 |    0.01 |   11.7188 |   2.1973 |     - |   48.51 KB |
-|         WideJson_Parlot |   150.3 us |    58.06 us |  3.18 us |  1.00 |    0.00 |   11.7188 |   2.1973 |     - |   48.51 KB |
-|         WideJson_Pidgin |   248.5 us |    56.74 us |  3.11 us |  1.65 |    0.04 |   11.7188 |   1.9531 |     - |   48.42 KB |
-|        WideJson_Sprache | 1,559.7 us |   841.64 us | 46.13 us | 10.38 |    0.37 |  683.5938 |   3.9063 |     - | 2797.28 KB |
-|     WideJson_Superpower | 1,020.0 us |   275.34 us | 15.09 us |  6.79 |    0.04 |  111.3281 |   7.8125 |     - |  459.74 KB |
+|                  Method |        Mean |      Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 | Allocated |
+|------------------------ |------------:|-----------:|----------:|------:|--------:|---------:|---------:|----------:|
+|  BigJson_ParlotCompiled |   116.14 us |   8.945 us |  0.490 us |  1.00 |    0.00 |  16.1133 |   4.8828 |     99 KB |
+|          BigJson_Parlot |   140.77 us |  22.625 us |  1.240 us |  1.21 |    0.01 |  16.1133 |   4.1504 |     99 KB |
+|          BigJson_Pidgin |   271.31 us |  44.236 us |  2.425 us |  2.34 |    0.03 |  16.1133 |   3.9063 |     99 KB |
+|      BigJson_Newtonsoft |   194.95 us | 223.703 us | 12.262 us |  1.68 |    0.11 |  32.9590 |  13.9160 |    203 KB |
+|         BigJson_Sprache | 1,987.39 us | 121.528 us |  6.661 us | 17.11 |    0.06 | 859.3750 | 214.8438 |  5,272 KB |
+|      BigJson_Superpower | 1,447.51 us | 295.441 us | 16.194 us | 12.46 |    0.12 | 148.4375 |  39.0625 |    911 KB |
+|                         |             |            |           |       |         |          |          |           |
+| LongJson_ParlotCompiled |    95.59 us |  20.169 us |  1.106 us |  1.00 |    0.00 |  21.4844 |   7.0801 |    132 KB |
+|         LongJson_Parlot |   114.71 us |  12.814 us |  0.702 us |  1.20 |    0.01 |  21.4844 |   7.0801 |    132 KB |
+|         LongJson_Pidgin |   249.60 us |  48.135 us |  2.638 us |  2.61 |    0.00 |  21.4844 |   6.8359 |    132 KB |
+|     LongJson_Newtonsoft |   143.27 us | 109.147 us |  5.983 us |  1.50 |    0.05 |  32.9590 |  14.6484 |    203 KB |
+|        LongJson_Sprache | 1,719.26 us | 242.870 us | 13.313 us | 17.99 |    0.18 | 697.2656 | 197.2656 |  4,273 KB |
+|     LongJson_Superpower | 1,226.01 us | 232.482 us | 12.743 us | 12.83 |    0.18 | 119.1406 |  39.0625 |    735 KB |
+|                         |             |            |           |       |         |          |          |           |
+| DeepJson_ParlotCompiled |    65.61 us |   7.158 us |  0.392 us |  1.00 |    0.00 |  17.9443 |   4.6387 |    110 KB |
+|         DeepJson_Parlot |    88.90 us |  18.409 us |  1.009 us |  1.35 |    0.01 |  17.9443 |   4.2725 |    110 KB |
+|         DeepJson_Pidgin |   362.94 us |  44.256 us |  2.426 us |  5.53 |    0.06 |  36.6211 |  12.2070 |    225 KB |
+|     DeepJson_Newtonsoft |   110.57 us |  16.565 us |  0.908 us |  1.69 |    0.02 |  29.1748 |  11.5967 |    179 KB |
+|        DeepJson_Sprache | 1,543.61 us | 168.665 us |  9.245 us | 23.53 |    0.07 | 476.5625 | 193.3594 |  2,926 KB |
+|                         |             |            |           |       |         |          |          |           |
+| WideJson_ParlotCompiled |    54.11 us |   1.390 us |  0.076 us |  1.00 |    0.00 |   6.5918 |   1.0986 |     41 KB |
+|         WideJson_Parlot |    65.62 us |   3.511 us |  0.192 us |  1.21 |    0.00 |   6.5918 |   1.0986 |     41 KB |
+|         WideJson_Pidgin |   123.58 us |   7.182 us |  0.394 us |  2.28 |    0.01 |   6.5918 |   0.9766 |     41 KB |
+|     WideJson_Newtonsoft |    95.25 us |  19.982 us |  1.095 us |  1.76 |    0.02 |  17.3340 |   5.7373 |    107 KB |
+|        WideJson_Sprache |   949.33 us | 199.824 us | 10.953 us | 17.54 |    0.22 | 451.1719 |  89.8438 |  2,767 KB |
+|     WideJson_Superpower |   708.42 us | 123.153 us |  6.750 us | 13.09 |    0.11 |  73.2422 |  11.7188 |    452 KB |
 ```
+
+### Regular Expressions
+
+Regular expression can also be replaced by more formal parser definitions. The following benchmarks show how Parlot compares to them when checking if string matches
+an email with the pattern `[\w\.+-]+@[\w-]+\.[\w\.-]+`. Note that in the case of pattern matching Parlot can use the pattern matching mode and do less allocations.
+
+```
+BenchmarkDotNet=v0.13.1, OS=Windows 10.0.22000
+Intel Core i7-8700 CPU 3.20GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK=6.0.100
+  [Host]   : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
+  ShortRun : .NET 6.0.0 (6.0.21.52210), X64 RyuJIT
+
+Job=ShortRun  IterationCount=3  LaunchCount=1
+WarmupCount=3
+
+|              Method |     Mean |     Error |  StdDev | Ratio | RatioSD |  Gen 0 | Allocated |
+|-------------------- |---------:|----------:|--------:|------:|--------:|-------:|----------:|
+|  RegexEmailCompiled | 130.7 ns |  17.64 ns | 0.97 ns |  1.00 |    0.00 | 0.0331 |     208 B |
+|          RegexEmail | 269.5 ns | 131.09 ns | 7.19 ns |  2.06 |    0.07 | 0.0329 |     208 B |
+| ParlotEmailCompiled | 160.5 ns |  18.72 ns | 1.03 ns |  1.23 |    0.02 | 0.0215 |     136 B |
+|         ParlotEmail | 354.1 ns |  62.89 ns | 3.45 ns |  2.71 |    0.02 | 0.0520 |     328 B |
+```
+
+### Versions
+
+The benchmarks were executed with the following versions
+
+- Parlot 0.0.19
+- Pidgin 3.0.0
+- Sprache 2.3.1
+- Superpower 3.0.0
+- Newtonsoft.Json 13.0.1
 
 ### Usages
 

--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -73,7 +73,7 @@ namespace Parlot
         public static TextSpan DecodeString(TextSpan span)
         {
             // Nothing to do if the string doesn't have any escape char
-            if (span.Buffer.IndexOf('\\', span.Offset, span.Length) == -1)
+            if (span.Buffer.AsSpan(span.Offset, span.Length).IndexOf('\\') == -1)
             {
                 return span;
             }

--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -10,8 +10,8 @@ namespace Parlot.Compilation
     public static class ExpressionHelper
     {
         internal static MethodInfo ParserContext_SkipWhiteSpaceMethod = typeof(ParseContext).GetMethod(nameof(ParseContext.SkipWhiteSpace), Array.Empty<Type>());
-        internal static MethodInfo Scanner_ReadText = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadText), new[] { typeof(string), typeof(StringComparer), typeof(TokenResult) });
-        internal static MethodInfo Scanner_ReadText_NoResult = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadText), new[] { typeof(string), typeof(StringComparer) });
+        internal static MethodInfo Scanner_ReadText = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadText), new[] { typeof(string), typeof(StringComparison), typeof(TokenResult) });
+        internal static MethodInfo Scanner_ReadText_NoResult = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadText), new[] { typeof(string), typeof(StringComparison) });
         internal static MethodInfo Scanner_ReadChar = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadChar), new[] { typeof(char) });
         internal static MethodInfo Scanner_ReadDecimal = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDecimal), new Type[0] { });
         internal static MethodInfo Scanner_ReadInteger = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadInteger), new Type[0] { });

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -255,7 +255,9 @@ namespace Parlot
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s)
-        { 
+        {
+            // Equivalent to StringComparison.Orinal copmarison
+
             var sSpan = s.AsSpan();
             var bufferSpan = _buffer.AsSpan(_offset);
             
@@ -266,61 +268,14 @@ namespace Parlot
         /// Whether a string is at the current position.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool Match(string s, StringComparer comparer)
+        public bool Match(string s, StringComparison comparisonType)
         {
-            if (comparer == null)
-            {
-                return Match(s);
-            }
+            // StringComparison.Orinal is an optimized code path in Span.StartsWith
 
-            if (s.Length == 0)
-            {
-                return true;
-            }
+            var sSpan = s.AsSpan();
+            var bufferSpan = _buffer.AsSpan(_offset);
 
-            if (Eof)
-            {
-                return false;
-            }
-
-            var a = CharToStringTable.GetString(_current);
-            var b = CharToStringTable.GetString(s[0]);
-
-            if (comparer.Compare(a, b) != 0)
-            {
-                return false;
-            }
-
-            var length = s.Length;
-
-            if (_offset + length - 1 >= _textLength)
-            {
-                return false;
-            }
-
-            if (length > 1)
-            {
-                a = CharToStringTable.GetString(_buffer[_offset + 1]);
-                b = CharToStringTable.GetString(s[1]);
-
-                if (comparer.Compare(a, b) != 0)
-                {
-                    return false;
-                }
-            }
-
-            for (var i = 2; i < length; i++)
-            {
-                a = CharToStringTable.GetString(_buffer[_offset + i]);
-                b = CharToStringTable.GetString(s[i]);
-
-                if (comparer.Compare(a, b) != 0)
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return bufferSpan.StartsWith(sSpan, comparisonType);
         }
     }
 }

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -178,11 +178,6 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(char c)
         {
-            if (Eof)
-            {
-                return false;
-            }
-
             // Ordinal comparison
             return _current == c;
         }

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -37,7 +37,31 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Advance()
         {
-            Advance(1);
+            _offset++;
+
+            if (_offset >= _textLength)
+            {
+                Eof = true;
+                _column++;
+                _current = NullChar;
+                return;
+            }
+
+            var next = _buffer[_offset];
+
+            if (_current == '\n')
+            {
+                _line++;
+                _column = 1;
+            }
+            else if (next != '\r')
+            {
+                _column++;
+            }
+
+            // if c == '\r', don't increase the column count
+
+            _current = next;
         }
         
         /// <summary>
@@ -65,15 +89,14 @@ namespace Parlot
 
                 var next = _buffer[_offset];
 
-                // most probable first 
-                if (_current != '\n' && next != '\r')
-                {
-                    _column++;
-                }
-                else if (_current == '\n')
+                if (_current == '\n')
                 {
                     _line++;
                     _column = 1;
+                }
+                else if (next != '\r')
+                {
+                    _column++;
                 }
 
                 // if c == '\r', don't increase the column count
@@ -87,7 +110,6 @@ namespace Parlot
                 _offset = _textLength;
                 _column += 1;
             }
-
         }
 
         /// <summary>

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -258,44 +258,13 @@ namespace Parlot
         /// <summary>
         /// Whether a string is at the current position.
         /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s)
-        {
-            if (s.Length == 0)
-            {
-                return true;
-            }
-
-            if (Eof)
-            {
-                return false;
-            }
+        { 
+            var sSpan = s.AsSpan();
+            var bufferSpan = _buffer.AsSpan(_offset);
             
-            if (s[0] != _current)
-            {
-                return false;
-            }
-
-            var length = s.Length;
-
-            if (_offset + length - 1 >= _textLength)
-            {
-                return false;
-            }
-            
-            if (length > 1 && _buffer[_offset + 1] != s[1])
-            {
-                return false;
-            }
-
-            for (var i = 2; i < length; i++)
-            {
-                if (s[i] != _buffer[_offset + i])
-                {
-                    return false;
-                }
-            }
-
-            return true;
+            return bufferSpan.StartsWith(sSpan);
         }
 
         /// <summary>
@@ -304,6 +273,11 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s, StringComparer comparer)
         {
+            if (comparer == null)
+            {
+                return Match(s);
+            }
+
             if (s.Length == 0)
             {
                 return true;

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -16,11 +16,13 @@ namespace Parlot.Fluent
         {
             context.EnterParser(this);
 
-            var start = context.Scanner.Cursor.Offset;
+            var cursor = context.Scanner.Cursor;
 
-            if (context.Scanner.ReadChar(Char))
+            if (cursor.Match(Char))
             {
-                result.Set(start, context.Scanner.Cursor.Offset, Char);
+                var start = cursor.Offset;
+                cursor.Advance();
+                result.Set(start, cursor.Offset, Char);
                 return true;
             }
 

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -15,7 +15,7 @@ namespace Parlot.Fluent
 
         public bool CanSeek => true;
 
-        public char ExpectedChar => Char;
+        public char[] ExpectedChars => new [] { Char } ;
 
         public bool SkipWhitespace => false;
 

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -1,9 +1,10 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class CharLiteral : Parser<char>, ICompilable
+    public sealed class CharLiteral : Parser<char>, ICompilable, ISeekable
     {
         public CharLiteral(char c)
         {
@@ -11,6 +12,12 @@ namespace Parlot.Fluent
         }
 
         public char Char { get; }
+
+        public bool CanSeek => true;
+
+        public char ExpectedChar => Char;
+
+        public bool SkipWhitespace => false;
 
         public override bool Parse(ParseContext context, ref ParseResult<char> result)
         {

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -1,11 +1,12 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class OneOrMany<T> : Parser<List<T>>, ICompilable
+    public sealed class OneOrMany<T> : Parser<List<T>>, ICompilable, ISeekable
     {
         private readonly Parser<T> _parser;
 
@@ -13,6 +14,12 @@ namespace Parlot.Fluent
         {
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<List<T>> result)
         {

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -104,7 +104,7 @@ namespace Parlot.Fluent
         /// <summary>
         /// Builds a parser that matches the specified text.
         /// </summary>
-        public Parser<string> Text(string text, bool caseInsensitive = false) => new TextLiteral(text, comparer: caseInsensitive ? StringComparer.OrdinalIgnoreCase : null);
+        public Parser<string> Text(string text, bool caseInsensitive = false) => new TextLiteral(text, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
 
         /// <summary>
         /// Builds a parser that matches the specified char.
@@ -150,7 +150,7 @@ namespace Parlot.Fluent
         /// <summary>
         /// Builds a parser that matches the specified text.
         /// </summary>
-        public Parser<string> Text(string text, bool caseInsensitive = false) => Parsers.SkipWhiteSpace(new TextLiteral(text, comparer: caseInsensitive ? StringComparer.OrdinalIgnoreCase : null));
+        public Parser<string> Text(string text, bool caseInsensitive = false) => Parsers.SkipWhiteSpace(new TextLiteral(text, caseInsensitive ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal));
 
         /// <summary>
         /// Builds a parser that matches the specified char.

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -68,6 +68,7 @@ namespace Parlot.Fluent
 
         /// <summary>
         /// Builds a parser that captures the output of another parser.
+        /// This is used to provide pattern matching capabilities, and optimized copmiled parsers that then don't need to materialize each parser result.
         /// </summary>
         public static Parser<TextSpan> Capture<T>(Parser<T> parser) => new Capture<T>(parser);
 

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -1,11 +1,12 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class Separated<U, T> : Parser<List<T>>, ICompilable
+    public sealed class Separated<U, T> : Parser<List<T>>, ICompilable, ISeekable
     {
         private readonly Parser<U> _separator;
         private readonly Parser<T> _parser;
@@ -15,6 +16,12 @@ namespace Parlot.Fluent
             _separator = separator ?? throw new ArgumentNullException(nameof(separator));
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<List<T>> result)
         {

--- a/src/Parlot/Fluent/Sequence.cs
+++ b/src/Parlot/Fluent/Sequence.cs
@@ -1,10 +1,11 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Linq;
 
 namespace Parlot.Fluent
 {
-    public sealed class Sequence<T1, T2> : Parser<ValueTuple<T1, T2>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2> : Parser<ValueTuple<T1, T2>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         internal readonly Parser<T1> _parser1;
         internal readonly Parser<T2> _parser2;
@@ -13,6 +14,12 @@ namespace Parlot.Fluent
             _parser1 = parser1 ?? throw new ArgumentNullException(nameof(parser1));
             _parser2 = parser2 ?? throw new ArgumentNullException(nameof(parser2));
         }
+
+        public bool CanSeek => _parser1 is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser1 is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser1 is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2>> result)
         {
@@ -53,7 +60,7 @@ namespace Parlot.Fluent
         }
     }
 
-    public sealed class Sequence<T1, T2, T3> : Parser<ValueTuple<T1, T2, T3>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2, T3> : Parser<ValueTuple<T1, T2, T3>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         private readonly Parser<ValueTuple<T1, T2>> _parser;
         internal readonly Parser<T3> _lastParser;
@@ -66,6 +73,12 @@ namespace Parlot.Fluent
             _parser = parser;
             _lastParser = lastParser ?? throw new ArgumentNullException(nameof(lastParser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3>> result)
         {
@@ -113,7 +126,7 @@ namespace Parlot.Fluent
         }
     }
 
-    public sealed class Sequence<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T3, T4>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T3, T4>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         private readonly Parser<ValueTuple<T1, T2, T3>> _parser;
         internal readonly Parser<T4> _lastParser;
@@ -123,6 +136,12 @@ namespace Parlot.Fluent
             _parser = parser;
             _lastParser = lastParser ?? throw new ArgumentNullException(nameof(lastParser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4>> result)
         {
@@ -171,7 +190,7 @@ namespace Parlot.Fluent
         }
     }
 
-    public sealed class Sequence<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3, T4, T5>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3, T4, T5>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         private readonly Parser<ValueTuple<T1, T2, T3, T4>> _parser;
         internal readonly Parser<T5> _lastParser;
@@ -181,6 +200,12 @@ namespace Parlot.Fluent
             _parser = parser;
             _lastParser = lastParser ?? throw new ArgumentNullException(nameof(lastParser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4, T5>> result)
         {
@@ -230,7 +255,7 @@ namespace Parlot.Fluent
         }
     }
 
-    public sealed class Sequence<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         private readonly Parser<ValueTuple<T1, T2, T3, T4, T5>> _parser;
         internal readonly Parser<T6> _lastParser;        
@@ -240,6 +265,12 @@ namespace Parlot.Fluent
             _parser = parser;
             _lastParser = lastParser ?? throw new ArgumentNullException(nameof(lastParser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4, T5, T6>> result)
         {
@@ -291,7 +322,7 @@ namespace Parlot.Fluent
         }
     }
 
-    public sealed class Sequence<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ICompilable, ISkippableSequenceParser
+    public sealed class Sequence<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ICompilable, ISkippableSequenceParser, ISeekable
     {
         private readonly Parser<ValueTuple<T1, T2, T3, T4, T5, T6>> _parser;
         internal readonly Parser<T7> _lastParser;
@@ -301,6 +332,12 @@ namespace Parlot.Fluent
             _parser = parser;
             _lastParser = lastParser ?? throw new ArgumentNullException(nameof(lastParser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4, T5, T6, T7>> result)
         {

--- a/src/Parlot/Fluent/SkipWhiteSpace.cs
+++ b/src/Parlot/Fluent/SkipWhiteSpace.cs
@@ -27,6 +27,7 @@ namespace Parlot.Fluent
             }
 
             context.Scanner.Cursor.ResetPosition(start);
+
             return false;
         }
 

--- a/src/Parlot/Fluent/SkipWhiteSpace.cs
+++ b/src/Parlot/Fluent/SkipWhiteSpace.cs
@@ -15,7 +15,7 @@ namespace Parlot.Fluent
 
         public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
 
-        public char ExpectedChar => _parser is ISeekable seekable ? seekable.ExpectedChar : default;
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
 
         public bool SkipWhitespace => true;
 

--- a/src/Parlot/Fluent/SkipWhiteSpace.cs
+++ b/src/Parlot/Fluent/SkipWhiteSpace.cs
@@ -1,9 +1,10 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class SkipWhiteSpace<T> : Parser<T>, ICompilable
+    public sealed class SkipWhiteSpace<T> : Parser<T>, ICompilable, ISeekable
     {
         private readonly Parser<T> _parser;
 
@@ -11,6 +12,12 @@ namespace Parlot.Fluent
         {
             _parser = parser;
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char ExpectedChar => _parser is ISeekable seekable ? seekable.ExpectedChar : default;
+
+        public bool SkipWhitespace => true;
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)
         {

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -1,4 +1,5 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Linq.Expressions;
 
@@ -11,7 +12,7 @@ namespace Parlot.Fluent
         SingleOrDouble
     }
 
-    public sealed class StringLiteral : Parser<TextSpan>, ICompilable
+    public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
     {
         private readonly StringLiteralQuotes _quotes;
 
@@ -19,6 +20,12 @@ namespace Parlot.Fluent
         {
             _quotes = quotes;
         }
+
+        public bool CanSeek => true;
+
+        public char[] ExpectedChars => _quotes switch { StringLiteralQuotes.Single => new[] { '\'' }, StringLiteralQuotes.Double => new[] { '\"' }, StringLiteralQuotes.SingleOrDouble => new[] { '\'', '\"' }, _ => Array.Empty<char>() };
+
+        public bool SkipWhitespace => false;
 
         public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
         {

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -20,11 +20,13 @@ namespace Parlot.Fluent
         {
             context.EnterParser(this);
 
-            var start = context.Scanner.Cursor.Offset;
+            var cursor = context.Scanner.Cursor;
 
-            if (context.Scanner.ReadText(Text, _comparer))
+            if (cursor.Match(Text, _comparer))
             {
-                result.Set(start, context.Scanner.Cursor.Offset, Text);
+                var start = cursor.Offset;
+                cursor.Advance(Text.Length);
+                result.Set(start, cursor.Offset, Text);
                 return true;
             }
 

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -7,12 +7,12 @@ namespace Parlot.Fluent
 {
     public sealed class TextLiteral : Parser<string>, ICompilable, ISeekable
     {
-        private readonly StringComparer _comparer;
+        private readonly StringComparison _comparisonType;
 
-        public TextLiteral(string text, StringComparer comparer = null)
+        public TextLiteral(string text, StringComparison comparisonType)
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
-            _comparer = comparer;
+            _comparisonType = comparisonType;
         }
 
         public string Text { get; }
@@ -29,7 +29,7 @@ namespace Parlot.Fluent
 
             var cursor = context.Scanner.Cursor;
 
-            if (cursor.Match(Text, _comparer))
+            if (cursor.Match(Text, _comparisonType))
             {
                 var start = cursor.Offset;
                 cursor.Advance(Text.Length);
@@ -64,7 +64,7 @@ namespace Parlot.Fluent
                     Expression.Field(context.ParseContext, "Scanner"),
                     ExpressionHelper.Scanner_ReadText_NoResult,
                     Expression.Constant(Text, typeof(string)),
-                    Expression.Constant(_comparer, typeof(StringComparer))
+                    Expression.Constant(_comparisonType, typeof(StringComparison))
                     ),
                 Expression.Block(
                     Expression.Assign(success, Expression.Constant(true, typeof(bool))),

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -1,10 +1,11 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class TextLiteral : Parser<string>, ICompilable
+    public sealed class TextLiteral : Parser<string>, ICompilable, ISeekable
     {
         private readonly StringComparer _comparer;
 
@@ -15,6 +16,12 @@ namespace Parlot.Fluent
         }
 
         public string Text { get; }
+
+        public bool CanSeek => Text.Length > 0;
+
+        public char ExpectedChar => Text[0];
+
+        public bool SkipWhitespace => false;
 
         public override bool Parse(ParseContext context, ref ParseResult<string> result)
         {

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -19,7 +19,7 @@ namespace Parlot.Fluent
 
         public bool CanSeek => Text.Length > 0;
 
-        public char ExpectedChar => Text[0];
+        public char[] ExpectedChars => new[] { Text[0] };
 
         public bool SkipWhitespace => false;
 

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -20,7 +20,7 @@ namespace Parlot.Fluent
         
         public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
 
-        public char ExpectedChar => _parser is ISeekable seekable ? seekable.ExpectedChar : default;
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
 
         public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -1,4 +1,5 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Linq;
 using System.Linq.Expressions;
@@ -11,27 +12,31 @@ namespace Parlot.Fluent
     /// </summary>
     /// <typeparam name="T">The input parser type.</typeparam>
     /// <typeparam name="U">The output parser type.</typeparam>
-    public sealed class Then<T, U> : Parser<U>, ICompilable
+    public sealed class Then<T, U> : Parser<U>, ICompilable, ISeekable
     {
         private readonly Func<T, U> _action1;
         private readonly Func<ParseContext, T, U> _action2;
         private readonly Parser<T> _parser;
+        
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char ExpectedChar => _parser is ISeekable seekable ? seekable.ExpectedChar : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public Then(Parser<T> parser)
         {
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
 
-        public Then(Parser<T> parser, Func<T, U> action)
+        public Then(Parser<T> parser, Func<T, U> action) : this(parser)
         {
             _action1 = action ?? throw new ArgumentNullException(nameof(action));
-            _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
 
-        public Then(Parser<T> parser, Func<ParseContext, T, U> action)
+        public Then(Parser<T> parser, Func<ParseContext, T, U> action) : this(parser)
         {
             _action2 = action ?? throw new ArgumentNullException(nameof(action));
-            _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
 
         public override bool Parse(ParseContext context, ref ParseResult<U> result)

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -1,11 +1,12 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class ZeroOrMany<T> : Parser<List<T>>, ICompilable
+    public sealed class ZeroOrMany<T> : Parser<List<T>>, ICompilable, ISeekable
     {
         private readonly Parser<T> _parser;
 
@@ -13,6 +14,12 @@ namespace Parlot.Fluent
         {
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<List<T>> result)
         {

--- a/src/Parlot/Fluent/ZeroOrOne.cs
+++ b/src/Parlot/Fluent/ZeroOrOne.cs
@@ -1,11 +1,11 @@
 ﻿using Parlot.Compilation;
+using Parlot.Rewriting;
 using System;
-using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
 {
-    public sealed class ZeroOrOne<T> : Parser<T>, ICompilable
+    public sealed class ZeroOrOne<T> : Parser<T>, ICompilable, ISeekable
     {
         private readonly Parser<T> _parser;
 
@@ -13,6 +13,12 @@ namespace Parlot.Fluent
         {
             _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         }
+
+        public bool CanSeek => _parser is ISeekable seekable && seekable.CanSeek;
+
+        public char[] ExpectedChars => _parser is ISeekable seekable ? seekable.ExpectedChars : default;
+
+        public bool SkipWhitespace => _parser is ISeekable seekable && seekable.SkipWhitespace;
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)
         {

--- a/src/Parlot/IsExternalInit.cs
+++ b/src/Parlot/IsExternalInit.cs
@@ -1,0 +1,4 @@
+﻿namespace System.Runtime.CompilerServices;
+
+// c.f. https://stackoverflow.com/questions/64749385/predefined-type-system-runtime-compilerservices-isexternalinit-is-not-defined
+internal static class IsExternalInit { }

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -14,7 +14,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
+    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -14,7 +14,12 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'"/>
   </ItemGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);SUPPORTS_READONLYSPAN</DefineConstants>
+  </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.1' ">
     <DefineConstants>$(DefineConstants);SUPPORTS_READONLYSPAN;SUPPORTS_CODENALYSIS</DefineConstants>

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -15,7 +15,6 @@
   <ItemGroup>
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
-    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0'" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">

--- a/src/Parlot/Rewriting/IRewritable.cs
+++ b/src/Parlot/Rewriting/IRewritable.cs
@@ -1,0 +1,16 @@
+﻿namespace Parlot.Rewriting
+{
+    using Parlot.Fluent;
+
+    /// <summary>
+    /// A Parser implementing this interface can be rewritten in a more optimized way.
+    /// The result will replace the instance.
+    /// </summary>
+    public interface IRewritable<T>
+    {
+        /// <summary>
+        /// Returns the parser to substitute.
+        /// </summary>
+        Parser<T> Rewrite();
+    }
+}

--- a/src/Parlot/Rewriting/ISeekable.cs
+++ b/src/Parlot/Rewriting/ISeekable.cs
@@ -13,9 +13,9 @@
         bool CanSeek { get; }
 
         /// <summary>
-        /// Gets the char that should be matched next to evaluate this Parser.
+        /// Gets the chars that can be matched next to evaluate this Parser.
         /// </summary>
-        char ExpectedChar { get; }
+        char[] ExpectedChars { get; }
 
         /// <summary>
         /// Gets whether the current parser needs to skip whitespaces before being invoked.

--- a/src/Parlot/Rewriting/ISeekable.cs
+++ b/src/Parlot/Rewriting/ISeekable.cs
@@ -1,0 +1,25 @@
+﻿namespace Parlot.Rewriting
+{
+    /// <summary>
+    /// A Parser implementing this interface can only be triggered if the next char matches the one provided.
+    /// It is used to create char lookups to optimize which Parsers need to be invoked next.
+    /// </summary>
+    public interface ISeekable
+    {
+        /// <summary>
+        /// Gets whether the current parser can be selected from a single char.
+        /// This could vary based on the subsequent parsers.
+        /// </summary>
+        bool CanSeek { get; }
+
+        /// <summary>
+        /// Gets the char that should be matched next to evaluate this Parser.
+        /// </summary>
+        char ExpectedChar { get; }
+
+        /// <summary>
+        /// Gets whether the current parser needs to skip whitespaces before being invoked.
+        /// </summary>
+        bool SkipWhitespace { get; }
+    }
+}

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -12,7 +12,7 @@ namespace Parlot
         public readonly string Buffer;
         public readonly Cursor Cursor;
 
-        private record struct WhiteSpaceMarker(int Offset, bool IsNotWhiteSpace, bool IsNotWhiteSpaceOrNewLine);
+        private readonly record struct WhiteSpaceMarker(int Offset, bool IsNotWhiteSpace, bool IsNotWhiteSpaceOrNewLine);
 
         // Caches the latest whitespace check. Remember that the current position is not a whitespace.
         private WhiteSpaceMarker _whiteSpaceMarker = new (-1, false, false);

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -12,6 +12,9 @@ namespace Parlot
         public readonly string Buffer;
         public readonly Cursor Cursor;
 
+        // Caches the latest whitespace check. Remember that the current position is not a whitespace.
+        private (int Offset, bool IsNotWhiteSpace, bool IsNotWhiteSpaceOrNewLine) _whiteSpaceMarker = (-1, false, false);
+
         /// <summary>
         /// Scans some text.
         /// </summary>
@@ -29,8 +32,17 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool SkipWhiteSpaceOrNewLine()
         {
+            // Don't read if we already know it's not a whitespace
+            if (Cursor.Position.Offset == _whiteSpaceMarker.Offset && _whiteSpaceMarker.IsNotWhiteSpaceOrNewLine)
+            {
+                return false;
+            }
+
             if (!Character.IsWhiteSpaceOrNewLine(Cursor.Current))
             {
+                // Memorize the fact that the current offset is not a whitespace
+                _whiteSpaceMarker = (Cursor.Position.Offset, true, true);
+
                 return false;
             }
 
@@ -47,18 +59,30 @@ namespace Parlot
                 Cursor.Advance();
             }
 
+            // Memorize the fact that the current offset is not a whitespace or new line
+            _whiteSpaceMarker = (Cursor.Position.Offset, true, true);
+
             return true;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool SkipWhiteSpace()
         {
+            // Don't read if we already know it's not a whitespace
+            if (Cursor.Position.Offset == _whiteSpaceMarker.Offset && _whiteSpaceMarker.IsNotWhiteSpace)
+            {
+                return false;
+            }
+
             bool found = false;
             while (Character.IsWhiteSpace(Cursor.Current))
             {
                 Cursor.AdvanceOnce();
                 found = true;
             }
+
+            // Memorize the fact that the current offset is not a whitespace
+            _whiteSpaceMarker = (Cursor.Position.Offset, true, false);
 
             return found;
         }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -12,8 +12,10 @@ namespace Parlot
         public readonly string Buffer;
         public readonly Cursor Cursor;
 
+        private record struct WhiteSpaceMarker(int Offset, bool IsNotWhiteSpace, bool IsNotWhiteSpaceOrNewLine);
+
         // Caches the latest whitespace check. Remember that the current position is not a whitespace.
-        private (int Offset, bool IsNotWhiteSpace, bool IsNotWhiteSpaceOrNewLine) _whiteSpaceMarker = (-1, false, false);
+        private WhiteSpaceMarker _whiteSpaceMarker = new (-1, false, false);
 
         /// <summary>
         /// Scans some text.
@@ -41,7 +43,7 @@ namespace Parlot
             if (!Character.IsWhiteSpaceOrNewLine(Cursor.Current))
             {
                 // Memorize the fact that the current offset is not a whitespace
-                _whiteSpaceMarker = (Cursor.Position.Offset, true, true);
+                _whiteSpaceMarker = new (Cursor.Position.Offset, true, true);
 
                 return false;
             }
@@ -60,7 +62,7 @@ namespace Parlot
             }
 
             // Memorize the fact that the current offset is not a whitespace or new line
-            _whiteSpaceMarker = (Cursor.Position.Offset, true, true);
+            _whiteSpaceMarker = new (Cursor.Position.Offset, true, true);
 
             return true;
         }
@@ -82,7 +84,7 @@ namespace Parlot
             }
 
             // Memorize the fact that the current offset is not a whitespace
-            _whiteSpaceMarker = (Cursor.Position.Offset, true, false);
+            _whiteSpaceMarker = new (Cursor.Position.Offset, true, false);
 
             return found;
         }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -79,7 +79,7 @@ namespace Parlot
             bool found = false;
             while (Character.IsWhiteSpace(Cursor.Current))
             {
-                Cursor.AdvanceOnce();
+                Cursor.Advance();
                 found = true;
             }
 

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -276,18 +276,14 @@ namespace Parlot
         /// Reads the specific expected text.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadText(string text, StringComparer comparer) => ReadText(text, comparer, out _); 
+        public bool ReadText(string text, StringComparison comparisonType) => ReadText(text, comparisonType, out _); 
         
         /// <summary>
         /// Reads the specific expected text.
         /// </summary>
-        public bool ReadText(string text, StringComparer comparer, out TokenResult result)
+        public bool ReadText(string text, StringComparison comparisonType, out TokenResult result)
         {
-            var match = comparer is null
-                ? Cursor.Match(text)
-                : Cursor.Match(text, comparer);
-
-            if (!match)
+            if (!Cursor.Match(text, comparisonType))
             {
                 result = TokenResult.Fail();
                 return false;
@@ -310,7 +306,7 @@ namespace Parlot
         /// Reads the specific expected text.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadText(string text, out TokenResult result) => ReadText(text, comparer: null, out result);
+        public bool ReadText(string text, out TokenResult result) => ReadText(text, comparisonType: StringComparison.Ordinal, out result);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ReadSingleQuotedString() => ReadSingleQuotedString(out _);

--- a/test/Parlot.Benchmarks/ExprBench.cs
+++ b/test/Parlot.Benchmarks/ExprBench.cs
@@ -16,21 +16,21 @@ namespace Parlot.Benchmarks
         private const string _expression1 = "3 - 1 / 2 + 1";
         private const string _expression2 = "1 - ( 3 + 2.5 ) * 4 - 1 / 2 + 1 - ( 3 + 2.5 ) * 4 - 1 / 2 + 1 - ( 3 + 2.5 ) * 4 - 1 / 2";
 
-        public ExprBench()
-        {
-            var expected1 = (decimal)3.5;
-            var expected2 = (decimal)-64.5;
+        //public ExprBench()
+        //{
+        //    var expected1 = (decimal)3.5;
+        //    var expected2 = (decimal)-64.5;
 
-            if (PidginSmall().Evaluate() != expected1) throw new Exception(nameof(PidginSmall));
-            if (ParlotRawSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotRawSmall));
-            if (ParlotFluentSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotFluentSmall));
-            if (ParlotCompiledSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotCompiledSmall));
+        //    if (PidginSmall().Evaluate() != expected1) throw new Exception(nameof(PidginSmall));
+        //    if (ParlotRawSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotRawSmall));
+        //    if (ParlotFluentSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotFluentSmall));
+        //    if (ParlotCompiledSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotCompiledSmall));
 
-            if (PidginBig().Evaluate() != expected2) throw new Exception(nameof(PidginBig));
-            if (ParlotRawBig().Evaluate() != expected2) throw new Exception(nameof(ParlotRawBig));
-            if (ParlotFluentBig().Evaluate() != expected2) throw new Exception(nameof(ParlotFluentBig));
-            if (ParlotCompiledBig().Evaluate() != expected2) throw new Exception(nameof(ParlotCompiledBig));
-        }
+        //    if (PidginBig().Evaluate() != expected2) throw new Exception(nameof(PidginBig));
+        //    if (ParlotRawBig().Evaluate() != expected2) throw new Exception(nameof(ParlotRawBig));
+        //    if (ParlotFluentBig().Evaluate() != expected2) throw new Exception(nameof(ParlotFluentBig));
+        //    if (ParlotCompiledBig().Evaluate() != expected2) throw new Exception(nameof(ParlotCompiledBig));
+        //}
 
         [Benchmark(Baseline = true), BenchmarkCategory("Expression1")]
         public Expression ParlotRawSmall()

--- a/test/Parlot.Benchmarks/ExprBench.cs
+++ b/test/Parlot.Benchmarks/ExprBench.cs
@@ -32,13 +32,13 @@ namespace Parlot.Benchmarks
             if (ParlotCompiledBig().Evaluate() != expected2) throw new Exception(nameof(ParlotCompiledBig));
         }
 
-        [Benchmark(Baseline = true), BenchmarkCategory("Expression1")]
+        [Benchmark, BenchmarkCategory("Expression1")]
         public Expression ParlotRawSmall()
         {
             return _parser.Parse(_expression1);
         }
 
-        [Benchmark, BenchmarkCategory("Expression1")]
+        [Benchmark(Baseline = true), BenchmarkCategory("Expression1")]
         public Expression ParlotCompiledSmall()
         {
             return _compiled.Parse(_expression1);
@@ -57,13 +57,13 @@ namespace Parlot.Benchmarks
             return ExprParser.ParseOrThrow(_expression1);
         }
 
-        [Benchmark(Baseline = true), BenchmarkCategory("Expression2")]
+        [Benchmark, BenchmarkCategory("Expression2")]
         public Expression ParlotRawBig()
         {
             return _parser.Parse(_expression2);
         }
 
-        [Benchmark, BenchmarkCategory("Expression2")]
+        [Benchmark(Baseline = true), BenchmarkCategory("Expression2")]
         public Expression ParlotCompiledBig()
         {
             return _compiled.Parse(_expression2);

--- a/test/Parlot.Benchmarks/ExprBench.cs
+++ b/test/Parlot.Benchmarks/ExprBench.cs
@@ -16,21 +16,21 @@ namespace Parlot.Benchmarks
         private const string _expression1 = "3 - 1 / 2 + 1";
         private const string _expression2 = "1 - ( 3 + 2.5 ) * 4 - 1 / 2 + 1 - ( 3 + 2.5 ) * 4 - 1 / 2 + 1 - ( 3 + 2.5 ) * 4 - 1 / 2";
 
-        //public ExprBench()
-        //{
-        //    var expected1 = (decimal)3.5;
-        //    var expected2 = (decimal)-64.5;
+        public ExprBench()
+        {
+            var expected1 = (decimal)3.5;
+            var expected2 = (decimal)-64.5;
 
-        //    if (PidginSmall().Evaluate() != expected1) throw new Exception(nameof(PidginSmall));
-        //    if (ParlotRawSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotRawSmall));
-        //    if (ParlotFluentSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotFluentSmall));
-        //    if (ParlotCompiledSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotCompiledSmall));
+            if (PidginSmall().Evaluate() != expected1) throw new Exception(nameof(PidginSmall));
+            if (ParlotRawSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotRawSmall));
+            if (ParlotFluentSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotFluentSmall));
+            if (ParlotCompiledSmall().Evaluate() != expected1) throw new Exception(nameof(ParlotCompiledSmall));
 
-        //    if (PidginBig().Evaluate() != expected2) throw new Exception(nameof(PidginBig));
-        //    if (ParlotRawBig().Evaluate() != expected2) throw new Exception(nameof(ParlotRawBig));
-        //    if (ParlotFluentBig().Evaluate() != expected2) throw new Exception(nameof(ParlotFluentBig));
-        //    if (ParlotCompiledBig().Evaluate() != expected2) throw new Exception(nameof(ParlotCompiledBig));
-        //}
+            if (PidginBig().Evaluate() != expected2) throw new Exception(nameof(PidginBig));
+            if (ParlotRawBig().Evaluate() != expected2) throw new Exception(nameof(ParlotRawBig));
+            if (ParlotFluentBig().Evaluate() != expected2) throw new Exception(nameof(ParlotFluentBig));
+            if (ParlotCompiledBig().Evaluate() != expected2) throw new Exception(nameof(ParlotCompiledBig));
+        }
 
         [Benchmark(Baseline = true), BenchmarkCategory("Expression1")]
         public Expression ParlotRawSmall()

--- a/test/Parlot.Benchmarks/JsonBench.cs
+++ b/test/Parlot.Benchmarks/JsonBench.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
@@ -9,6 +8,7 @@ using Parlot.Benchmarks.SpracheParsers;
 using Parlot.Benchmarks.SuperpowerParsers;
 using Parlot.Benchmarks.PidginParsers;
 using Parlot.Fluent;
+using Newtonsoft.Json.Linq;
 
 namespace Parlot.Benchmarks
 {
@@ -66,6 +66,12 @@ namespace Parlot.Benchmarks
             return SuperpowerJsonParser.Parse(_bigJson);
         }
 
+        [Benchmark, BenchmarkCategory("Big")]
+        public JObject BigJson_Newtonsoft()
+        {
+            return JObject.Parse(_bigJson);
+        }
+
         [Benchmark(Baseline = true), BenchmarkCategory("Long")]
         public IJson LongJson_Parlot()
         {
@@ -96,6 +102,12 @@ namespace Parlot.Benchmarks
             return SuperpowerJsonParser.Parse(_longJson);
         }
 
+        [Benchmark, BenchmarkCategory("Long")]
+        public JObject LongJson_Newtonsoft()
+        {
+            return JObject.Parse(_longJson);
+        }
+
         [Benchmark(Baseline = true), BenchmarkCategory("Deep")]
         public IJson DeepJson_Parlot()
         {
@@ -118,6 +130,12 @@ namespace Parlot.Benchmarks
         public IJson DeepJson_Sprache()
         {
             return SpracheJsonParser.Parse(_deepJson).Value;
+        }
+
+        [Benchmark, BenchmarkCategory("Deep")]
+        public JObject DeepJson_Newtonsoft()
+        {
+            return JObject.Parse(_deepJson);
         }
 
         //this one blows the stack
@@ -157,11 +175,17 @@ namespace Parlot.Benchmarks
             return SuperpowerJsonParser.Parse(_wideJson);
         }
 
+        [Benchmark, BenchmarkCategory("Wide")]
+        public JObject WideJson_Newtonsoft()
+        {
+            return JObject.Parse(_wideJson);
+        }
+
         private static IJson BuildJson(int length, int depth, int width)
             => new JsonArray(
                 Enumerable.Repeat(1, length)
                     .Select(_ => BuildObject(depth, width))
-                    .ToImmutableArray()
+                    .ToArray()
             );
 
         private static IJson BuildObject(int depth, int width)
@@ -171,9 +195,10 @@ namespace Parlot.Benchmarks
                 return new JsonString(RandomString(6));
             }
             return new JsonObject(
-                Enumerable.Repeat(1, width)
+                new Dictionary<string, IJson>(
+                    Enumerable.Repeat(1, width)
                     .Select(_ => new KeyValuePair<string, IJson>(RandomString(5), BuildObject(depth - 1, width)))
-                    .ToImmutableDictionary()
+                    )
             );
         }
 

--- a/test/Parlot.Benchmarks/JsonBench.cs
+++ b/test/Parlot.Benchmarks/JsonBench.cs
@@ -9,6 +9,7 @@ using Parlot.Benchmarks.SuperpowerParsers;
 using Parlot.Benchmarks.PidginParsers;
 using Parlot.Fluent;
 using Newtonsoft.Json.Linq;
+using Newtonsoft.Json;
 
 namespace Parlot.Benchmarks
 {
@@ -23,6 +24,7 @@ namespace Parlot.Benchmarks
         private Parser<IJson> _compiled;
 #nullable restore
 
+        private static JsonSerializerSettings _jsonSerializerSettings = new JsonSerializerSettings() { MaxDepth = 1024 };
         private static readonly Random _random = new();
 
         [GlobalSetup]
@@ -67,9 +69,9 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark, BenchmarkCategory("Big")]
-        public JObject BigJson_Newtonsoft()
+        public JToken BigJson_Newtonsoft()
         {
-            return JObject.Parse(_bigJson);
+            return JToken.Parse(_bigJson);
         }
 
         [Benchmark(Baseline = true), BenchmarkCategory("Long")]
@@ -103,9 +105,9 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark, BenchmarkCategory("Long")]
-        public JObject LongJson_Newtonsoft()
+        public JToken LongJson_Newtonsoft()
         {
-            return JObject.Parse(_longJson);
+            return JToken.Parse(_longJson);
         }
 
         [Benchmark(Baseline = true), BenchmarkCategory("Deep")]
@@ -133,9 +135,9 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark, BenchmarkCategory("Deep")]
-        public JObject DeepJson_Newtonsoft()
+        public JToken DeepJson_Newtonsoft()
         {
-            return JObject.Parse(_deepJson);
+            return JsonConvert.DeserializeObject<JToken>(_deepJson, _jsonSerializerSettings);
         }
 
         //this one blows the stack
@@ -176,9 +178,9 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark, BenchmarkCategory("Wide")]
-        public JObject WideJson_Newtonsoft()
+        public JToken WideJson_Newtonsoft()
         {
-            return JObject.Parse(_wideJson);
+            return JToken.Parse(_wideJson);
         }
 
         private static IJson BuildJson(int length, int depth, int width)

--- a/test/Parlot.Benchmarks/JsonBench.cs
+++ b/test/Parlot.Benchmarks/JsonBench.cs
@@ -39,21 +39,27 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark(Baseline = true), BenchmarkCategory("Big")]
-        public IJson BigJson_Parlot()
-        {
-            return JsonParser.Parse(_bigJson);
-        }
-
-        [Benchmark, BenchmarkCategory("Big")]
         public IJson BigJson_ParlotCompiled()
         {
             return _compiled.Parse(_bigJson);
         }
 
         [Benchmark, BenchmarkCategory("Big")]
+        public IJson BigJson_Parlot()
+        {
+            return JsonParser.Parse(_bigJson);
+        }
+
+        [Benchmark, BenchmarkCategory("Big")]
         public IJson BigJson_Pidgin()
         {
             return PidginJsonParser.Parse(_bigJson).Value;
+        }
+
+        [Benchmark, BenchmarkCategory("Big")]
+        public JToken BigJson_Newtonsoft()
+        {
+            return JToken.Parse(_bigJson);
         }
 
         [Benchmark, BenchmarkCategory("Big")]
@@ -68,28 +74,28 @@ namespace Parlot.Benchmarks
             return SuperpowerJsonParser.Parse(_bigJson);
         }
 
-        [Benchmark, BenchmarkCategory("Big")]
-        public JToken BigJson_Newtonsoft()
-        {
-            return JToken.Parse(_bigJson);
-        }
-
         [Benchmark(Baseline = true), BenchmarkCategory("Long")]
-        public IJson LongJson_Parlot()
-        {
-            return JsonParser.Parse(_longJson);
-        }
-
-        [Benchmark, BenchmarkCategory("Long")]
         public IJson LongJson_ParlotCompiled()
         {
             return _compiled.Parse(_longJson);
         }
 
         [Benchmark, BenchmarkCategory("Long")]
+        public IJson LongJson_Parlot()
+        {
+            return JsonParser.Parse(_longJson);
+        }
+
+        [Benchmark, BenchmarkCategory("Long")]
         public IJson LongJson_Pidgin()
         {
             return PidginJsonParser.Parse(_longJson).Value;
+        }
+
+        [Benchmark, BenchmarkCategory("Long")]
+        public JToken LongJson_Newtonsoft()
+        {
+            return JToken.Parse(_longJson);
         }
 
         [Benchmark, BenchmarkCategory("Long")]
@@ -104,22 +110,16 @@ namespace Parlot.Benchmarks
             return SuperpowerJsonParser.Parse(_longJson);
         }
 
-        [Benchmark, BenchmarkCategory("Long")]
-        public JToken LongJson_Newtonsoft()
-        {
-            return JToken.Parse(_longJson);
-        }
-
         [Benchmark(Baseline = true), BenchmarkCategory("Deep")]
-        public IJson DeepJson_Parlot()
-        {
-            return JsonParser.Parse(_deepJson);
-        }
-
-        [Benchmark, BenchmarkCategory("Deep")]
         public IJson DeepJson_ParlotCompiled()
         {
             return _compiled.Parse(_deepJson);
+        }
+
+        [Benchmark, BenchmarkCategory("Deep")]
+        public IJson DeepJson_Parlot()
+        {
+            return JsonParser.Parse(_deepJson);
         }
 
         [Benchmark, BenchmarkCategory("Deep")]
@@ -129,15 +129,15 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark, BenchmarkCategory("Deep")]
-        public IJson DeepJson_Sprache()
-        {
-            return SpracheJsonParser.Parse(_deepJson).Value;
-        }
-
-        [Benchmark, BenchmarkCategory("Deep")]
         public JToken DeepJson_Newtonsoft()
         {
             return JsonConvert.DeserializeObject<JToken>(_deepJson, _jsonSerializerSettings);
+        }
+
+        [Benchmark, BenchmarkCategory("Deep")]
+        public IJson DeepJson_Sprache()
+        {
+            return SpracheJsonParser.Parse(_deepJson).Value;
         }
 
         //this one blows the stack
@@ -148,21 +148,27 @@ namespace Parlot.Benchmarks
         //}
 
         [Benchmark(Baseline = true), BenchmarkCategory("Wide")]
-        public IJson WideJson_Parlot()
-        {
-            return JsonParser.Parse(_wideJson);
-        }
-
-        [Benchmark, BenchmarkCategory("Wide")]
         public IJson WideJson_ParlotCompiled()
         {
             return _compiled.Parse(_wideJson);
         }
 
         [Benchmark, BenchmarkCategory("Wide")]
+        public IJson WideJson_Parlot()
+        {
+            return JsonParser.Parse(_wideJson);
+        }
+
+        [Benchmark, BenchmarkCategory("Wide")]
         public IJson WideJson_Pidgin()
         {
             return PidginJsonParser.Parse(_wideJson).Value;
+        }
+
+        [Benchmark, BenchmarkCategory("Wide")]
+        public JToken WideJson_Newtonsoft()
+        {
+            return JToken.Parse(_wideJson);
         }
 
         [Benchmark, BenchmarkCategory("Wide")]
@@ -175,12 +181,6 @@ namespace Parlot.Benchmarks
         public IJson WideJson_Superpower()
         {
             return SuperpowerJsonParser.Parse(_wideJson);
-        }
-
-        [Benchmark, BenchmarkCategory("Wide")]
-        public JToken WideJson_Newtonsoft()
-        {
-            return JToken.Parse(_wideJson);
         }
 
         private static IJson BuildJson(int length, int depth, int width)

--- a/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
+++ b/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
+++ b/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="Pidgin" Version="2.5.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="Pidgin" Version="3.0.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
-    <PackageReference Include="Superpower" Version="2.3.0" />
+    <PackageReference Include="Superpower" Version="3.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
+++ b/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Pidgin" Version="2.5.0" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="Superpower" Version="2.3.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Parlot.Benchmarks/ParlotBenchmarks.cs
+++ b/test/Parlot.Benchmarks/ParlotBenchmarks.cs
@@ -14,6 +14,9 @@ namespace Parlot.Benchmarks
         private const string _stringWithoutEscapes = "This is a new line \n \t and a tab and some \xa0";
         private readonly Parser<char> _whiteSpaceExpression = Parsers.OneOf(Parsers.Terms.Char('a'), Parsers.Terms.Char('b'), Parsers.Terms.Char('v'), Parsers.Terms.Char('d'));
 
+        // Exercises Cursor.Match(string)
+        private readonly Parser<string> _matchStringExpression = Parsers.OneOf(Parsers.Literals.Text("hello"), Parsers.Literals.Text("goodbye"));
+
         private readonly JsonBench _jsonBench = new();
         private readonly ExprBench _exprBench = new();
 
@@ -21,6 +24,24 @@ namespace Parlot.Benchmarks
         public void Setup()
         {
             _jsonBench.Setup();
+        }
+
+        [Benchmark, BenchmarkCategory("Cursor.Match(string)")]
+        public string CursorMatchHello()
+        {
+            return _matchStringExpression.Parse("hello");
+        }
+
+        [Benchmark, BenchmarkCategory("Cursor.Match(string)")]
+        public string CursorMatchGoodbye()
+        {
+            return _matchStringExpression.Parse("goodbye");
+        }
+
+        [Benchmark, BenchmarkCategory("Cursor.Match(string)")]
+        public string CursorMatchNone()
+        {
+            return _matchStringExpression.Parse("hellllo");
         }
 
         [Benchmark, BenchmarkCategory("WhiteSpace")]

--- a/test/Parlot.Benchmarks/ParlotBenchmarks.cs
+++ b/test/Parlot.Benchmarks/ParlotBenchmarks.cs
@@ -1,7 +1,9 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
+using Parlot.Fluent;
 using Parlot.Tests.Calc;
 using Parlot.Tests.Json;
+using System.Collections.Generic;
 
 namespace Parlot.Benchmarks
 {
@@ -10,6 +12,7 @@ namespace Parlot.Benchmarks
     {
         private const string _stringWithEscapes = "This is a new line \\n \\t and a tab and some \\xa0";
         private const string _stringWithoutEscapes = "This is a new line \n \t and a tab and some \xa0";
+        private readonly Parser<char> _whiteSpaceExpression = Parsers.OneOf(Parsers.Terms.Char('a'), Parsers.Terms.Char('b'), Parsers.Terms.Char('v'), Parsers.Terms.Char('d'));
 
         private readonly JsonBench _jsonBench = new();
         private readonly ExprBench _exprBench = new();
@@ -18,6 +21,12 @@ namespace Parlot.Benchmarks
         public void Setup()
         {
             _jsonBench.Setup();
+        }
+
+        [Benchmark, BenchmarkCategory("WhiteSpace")]
+        public char SkipWhiteSpace()
+        {
+            return _whiteSpaceExpression.Parse("d");
         }
 
         [Benchmark, BenchmarkCategory("DecodeString")]

--- a/test/Parlot.Benchmarks/PidginParsers/PidginJsonParser.cs
+++ b/test/Parlot.Benchmarks/PidginParsers/PidginJsonParser.cs
@@ -1,7 +1,7 @@
 ﻿using Parlot.Tests.Json;
 using Pidgin;
 using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using static Pidgin.Parser;
 using static Pidgin.Parser<char>;
 
@@ -33,7 +33,7 @@ namespace Parlot.Benchmarks.PidginParsers
             Json.Between(SkipWhitespaces)
                 .Separated(Comma)
                 .Between(LBracket, RBracket)
-                .Select<IJson>(els => new JsonArray(els.ToImmutableArray()));
+                .Select<IJson>(els => new JsonArray(els.ToArray()));
 
         private static readonly Parser<char, KeyValuePair<string, IJson>> JsonMember =
             String
@@ -44,7 +44,7 @@ namespace Parlot.Benchmarks.PidginParsers
             JsonMember.Between(SkipWhitespaces)
                 .Separated(Comma)
                 .Between(LBrace, RBrace)
-                .Select<IJson>(kvps => new JsonObject(kvps.ToImmutableDictionary()));
+                .Select<IJson>(kvps => new JsonObject(new Dictionary<string, IJson>(kvps)));
 
         public static Result<char, IJson> Parse(string input) => Json.Parse(input);
     }

--- a/test/Parlot.Benchmarks/Program.cs
+++ b/test/Parlot.Benchmarks/Program.cs
@@ -7,7 +7,6 @@ namespace Parlot.Benchmarks
     {
         static void Main(string[] args)
         {
-
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
 
             //var benchmarks = new ParlotBenchmarks();

--- a/test/Parlot.Benchmarks/Program.cs
+++ b/test/Parlot.Benchmarks/Program.cs
@@ -1,5 +1,4 @@
 ﻿using BenchmarkDotNet.Running;
-using System.Threading;
 
 namespace Parlot.Benchmarks
 {
@@ -8,22 +7,6 @@ namespace Parlot.Benchmarks
         static void Main(string[] args)
         {
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
-
-            //var benchmarks = new ParlotBenchmarks();
-            //benchmarks.Setup();
-
-            //for (int i = 0; i < 1000; i++)
-            //{
-            //    benchmarks.DeepJson();
-            //}
-
-            //Thread.Sleep(3000);
-
-            //for (int i = 0; i < 1000; i++)
-            //{
-            //    benchmarks.DeepJson();
-            //}
-
         }
     }
 }

--- a/test/Parlot.Benchmarks/Program.cs
+++ b/test/Parlot.Benchmarks/Program.cs
@@ -1,4 +1,5 @@
 ﻿using BenchmarkDotNet.Running;
+using System.Threading;
 
 namespace Parlot.Benchmarks
 {
@@ -6,7 +7,24 @@ namespace Parlot.Benchmarks
     {
         static void Main(string[] args)
         {
+
             BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+            //var benchmarks = new ParlotBenchmarks();
+            //benchmarks.Setup();
+
+            //for (int i = 0; i < 1000; i++)
+            //{
+            //    benchmarks.DeepJson();
+            //}
+
+            //Thread.Sleep(3000);
+
+            //for (int i = 0; i < 1000; i++)
+            //{
+            //    benchmarks.DeepJson();
+            //}
+
         }
     }
 }

--- a/test/Parlot.Benchmarks/RegexBenchmarks.cs
+++ b/test/Parlot.Benchmarks/RegexBenchmarks.cs
@@ -36,6 +36,12 @@ namespace Parlot.Benchmarks
             if (!ParlotEmailCompiled()) throw new Exception(nameof(ParlotEmailCompiled));
         }
 
+        [Benchmark(Baseline = true)]
+        public bool RegexEmailCompiled()
+        {
+            return EmailRegexCompiled.Match(_email).Success;
+        }
+
         [Benchmark]
         public bool RegexEmail()
         {
@@ -43,21 +49,14 @@ namespace Parlot.Benchmarks
         }
 
         [Benchmark]
-        public bool RegexEmailCompiled()
+        public bool ParlotEmailCompiled()
         {
-            return EmailRegexCompiled.Match(_email).Success;
+            return EmailCompiled.Parse(_email).Length > 0;
         }
-
         [Benchmark]
         public bool ParlotEmail()
         {
             return Email.TryParse(_email, out _);
-        }
-
-        [Benchmark]
-        public bool ParlotEmailCompiled()
-        {
-            return EmailCompiled.Parse(_email).Length > 0;
         }
     }
 }

--- a/test/Parlot.Benchmarks/SpracheParsers/SpracheJsonParser.cs
+++ b/test/Parlot.Benchmarks/SpracheParsers/SpracheJsonParser.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using Parlot.Tests.Json;
 using Sprache;
 using static Sprache.Parse;
@@ -33,7 +33,7 @@ namespace Parlot.Benchmarks.SpracheParsers
             Json.Contained(WhiteSpace.Many(), WhiteSpace.Many())
                 .DelimitedBy(Comma)
                 .Contained(LBracket, RBracket)
-                .Select(els => new JsonArray(els.ToImmutableArray()));
+                .Select(els => new JsonArray(els.ToArray()));
 
         private static readonly Sprache.Parser<KeyValuePair<string, IJson>> JsonMember =
             from name in String.SelectMany(_ => ColonWhitespace, (name, ws) => name)  // avoid allocating a transparent identifier for a result we don't care about
@@ -44,7 +44,7 @@ namespace Parlot.Benchmarks.SpracheParsers
             JsonMember.Contained(WhiteSpace.Many(), WhiteSpace.Many())
                 .DelimitedBy(Comma)
                 .Contained(LBrace, RBrace)
-                .Select(kvps => new JsonObject(kvps.ToImmutableDictionary()));
+                .Select(kvps => new JsonObject(new Dictionary<string, IJson>(kvps)));
 
         public static IResult<IJson> Parse(string input) => Json(new Input(input));
     }

--- a/test/Parlot.Benchmarks/SuperpowerParsers/SuperpowerJsonParser.cs
+++ b/test/Parlot.Benchmarks/SuperpowerParsers/SuperpowerJsonParser.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using System.Collections.Immutable;
+using System.Linq;
 using Parlot.Tests.Json;
 using Superpower;
 
@@ -35,7 +35,7 @@ namespace Parlot.Benchmarks.SuperpowerParsers
             Json.Between(Superpower.Parsers.Character.WhiteSpace.Many(), Superpower.Parsers.Character.WhiteSpace.Many())
                 .ManyDelimitedBy(Comma)
                 .Between(LBracket, RBracket)
-                .Select(els => (IJson)new JsonArray(els.ToImmutableArray()));
+                .Select(els => (IJson)new JsonArray(els.ToArray()));
 
         private static readonly TextParser<KeyValuePair<string, IJson>> JsonMember =
             from name in String.SelectMany(_ => ColonWhitespace, (name, ws) => name)  // avoid allocating a transparent identifier for a result we don't care about
@@ -46,7 +46,7 @@ namespace Parlot.Benchmarks.SuperpowerParsers
             JsonMember.Between(Superpower.Parsers.Character.WhiteSpace.Many(), Superpower.Parsers.Character.WhiteSpace.Many())
                 .ManyDelimitedBy(Comma)
                 .Between(LBrace, RBrace)
-                .Select(kvps => (IJson)new JsonObject(kvps.ToImmutableDictionary()));
+                .Select(kvps => (IJson)new JsonObject(new Dictionary<string, IJson>(kvps)));
 
         public static IJson Parse(string input) => Json.Parse(input);
     }

--- a/test/Parlot.Tests/CompileTests.cs
+++ b/test/Parlot.Tests/CompileTests.cs
@@ -537,7 +537,7 @@ namespace Parlot.Tests
         [Fact]
         public void TextWithWhiteSpaceCompiledShouldResetPosition()
         {
-            var code = OneOf(Terms.Text("a"), Literals.Text(" b"));
+            var code = OneOf(Terms.Text("a"), Literals.Text(" b")).Compile();
 
             Assert.True(code.TryParse(" b", out _));
         }

--- a/test/Parlot.Tests/CursorTests.cs
+++ b/test/Parlot.Tests/CursorTests.cs
@@ -148,6 +148,24 @@ namespace Parlot.Tests
         }
 
         [Fact]
+        public void AdvanceShouldStopAtEof()
+        {
+            var c = new Cursor("1234");
+
+            Assert.Equal('1', c.Current);
+            Assert.Equal(0, c.Position.Offset);
+            Assert.Equal(1, c.Position.Column);
+            Assert.Equal(1, c.Position.Line);
+
+            c.Advance(4);
+
+            Assert.Equal(Cursor.NullChar, c.Current);
+            Assert.Equal(4, c.Position.Offset);
+            Assert.Equal(5, c.Position.Column);
+            Assert.Equal(1, c.Position.Line);
+        }
+
+        [Fact]
         public void ResetPositionShouldMoveToEof()
         {
             var c = new Cursor("123");

--- a/test/Parlot.Tests/Json/JsonModel.cs
+++ b/test/Parlot.Tests/Json/JsonModel.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace Parlot.Tests.Json
@@ -9,8 +9,8 @@ namespace Parlot.Tests.Json
 
     public class JsonArray : IJson
     {
-        public ImmutableArray<IJson> Elements { get; }
-        public JsonArray(ImmutableArray<IJson> elements)
+        public IJson[] Elements { get; }
+        public JsonArray(IJson[] elements)
         {
             Elements = elements;
         }
@@ -20,8 +20,8 @@ namespace Parlot.Tests.Json
 
     public class JsonObject : IJson
     {
-        public IImmutableDictionary<string, IJson> Members { get; }
-        public JsonObject(IImmutableDictionary<string, IJson> members)
+        public IDictionary<string, IJson> Members { get; }
+        public JsonObject(IDictionary<string, IJson> members)
         {
             Members = members;
         }

--- a/test/Parlot.Tests/Json/JsonParser.cs
+++ b/test/Parlot.Tests/Json/JsonParser.cs
@@ -1,6 +1,5 @@
 using Parlot.Fluent;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using static Parlot.Fluent.Parsers;
 
 namespace Parlot.Tests.Json
@@ -28,7 +27,7 @@ namespace Parlot.Tests.Json
 
             var jsonArray =
                 Between(LBracket, Separated(Comma, json), RBracket)
-                    .Then<IJson>(static els => new JsonArray(els.ToImmutableArray()));
+                    .Then<IJson>(static els => new JsonArray(els.ToArray()));
 
             var jsonMember =
                 String.And(Colon).And(json)
@@ -36,7 +35,7 @@ namespace Parlot.Tests.Json
 
             var jsonObject =
                 Between(LBrace, Separated(Comma, jsonMember), RBrace)
-                    .Then<IJson>(static kvps => new JsonObject(kvps.ToImmutableDictionary()));
+                    .Then<IJson>(static kvps => new JsonObject(new Dictionary<string, IJson>(kvps)));
 
             Json = json.Parser = jsonString.Or(jsonArray).Or(jsonObject);
         }

--- a/test/Parlot.Tests/Models/FakeSeekable.cs
+++ b/test/Parlot.Tests/Models/FakeSeekable.cs
@@ -1,0 +1,35 @@
+﻿using Parlot.Fluent;
+using Parlot.Rewriting;
+
+namespace Parlot.Tests.Models
+{
+    public partial class RewriteTests
+    {
+        public sealed class FakeSeekable : Parser<string>, ISeekable
+        {
+            public FakeSeekable()
+            {
+            }
+
+            public string Text { get; set; }
+            public bool CanSeek { get; set; }
+            public char[] ExpectedChars { get; set; }
+            public bool SkipWhiteSpace { get; }
+            public bool SkipWhitespace { get; set; }
+            public bool Success { get; set; }
+
+            public override bool Parse(ParseContext context, ref ParseResult<string> result)
+            {
+                context.EnterParser(this);
+
+                if (Success)
+                {
+                    result.Set(0, 0, Text);
+                    return true;
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/test/Parlot.Tests/RewriteTests.cs
+++ b/test/Parlot.Tests/RewriteTests.cs
@@ -1,0 +1,93 @@
+using Parlot.Fluent;
+using Parlot.Rewriting;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+using static Parlot.Tests.Models.RewriteTests;
+
+namespace Parlot.Tests
+{
+    public partial class RewriteTests
+    {
+        [Fact]
+        public void TextLiteralShouldBeSeekable()
+        {
+            var text = Literals.Text("hello");
+            var seekable = text as ISeekable;
+
+            Assert.NotNull(seekable);
+            Assert.True(seekable.CanSeek);
+            Assert.Equal(new[] { 'h' }, seekable.ExpectedChars);
+            Assert.False(seekable.SkipWhitespace);
+        }
+
+        [Fact]
+        public void SkipWhiteSpaceShouldBeSeekable()
+        {
+            var text = Terms.Text("hello");
+            var seekable = text as ISeekable;
+
+            Assert.NotNull(seekable);
+            Assert.True(seekable.CanSeek);
+            Assert.Equal(new[] { 'h' }, seekable.ExpectedChars);
+            Assert.True(seekable.SkipWhitespace);
+        }
+
+        [Fact]
+        public void CharLiteralShouldBeSeekable()
+        {
+            var text = Literals.Char('a');
+            var seekable = text as ISeekable;
+
+            Assert.NotNull(seekable);
+            Assert.True(seekable.CanSeek);
+            Assert.Equal(new[] { 'a' }, seekable.ExpectedChars);
+            Assert.False(seekable.SkipWhitespace);
+        }
+
+        [Fact]
+        public void OneOfShouldRewriteAllSeekable()
+        {
+            var hello = new FakeSeekable { CanSeek = true, ExpectedChars = new[] { 'a' }, SkipWhitespace = false, Success = true, Text = "hello" };
+            var goodbye = new FakeSeekable { CanSeek = true, ExpectedChars = new[] { 'b' }, SkipWhitespace = false, Success = true, Text = "goodbye" };
+            var oneof = Parsers.OneOf(hello, goodbye);
+
+            Assert.Equal("hello", oneof.Parse("a"));
+            Assert.Equal("goodbye", oneof.Parse("b"));
+            Assert.Null(oneof.Parse("hello"));
+        }
+
+        [Fact]
+        public void OneOfShouldRewriteAllSeekableCompiled()
+        {
+            var helloOrGoodbye = Parsers.OneOf(Terms.Text("hello"), Terms.Text("goodbye")).Compile();
+
+            Assert.Equal("hello", helloOrGoodbye.Parse(" hello"));
+            Assert.Equal("goodbye", helloOrGoodbye.Parse(" goodbye"));
+            Assert.Null(helloOrGoodbye.Parse("yo!"));
+        }
+
+        [Fact]
+        public void OneOfShouldRewriteAllSeekableSkipwhiteSpaceCompiled()
+        {
+            var hello = new FakeSeekable { CanSeek = true, ExpectedChars = new[] { 'a' }, SkipWhitespace = false, Success = true, Text = "hello" };
+            var goodbye = new FakeSeekable { CanSeek = true, ExpectedChars = new[] { 'b' }, SkipWhitespace = false, Success = true, Text = "goodbye" };
+            var oneof = Parsers.OneOf(hello, goodbye).Compile();
+
+            Assert.Equal("hello", oneof.Parse("a"));
+            Assert.Equal("goodbye", oneof.Parse("b"));
+            Assert.Null(oneof.Parse("hello"));
+        }
+
+        [Fact]
+        public void OneOfShouldNotRewriteIfOneIsNotSeekable()
+        {
+            var hello = new FakeSeekable { CanSeek = true, ExpectedChars = new[] { 'a' }, SkipWhitespace = false, Success = true, Text = "hello" };
+            var goodbye = OneOf(Parsers.Literals.Text("goodbye"));
+            var oneof = Parsers.OneOf(goodbye, hello);
+
+            Assert.Equal("hello", oneof.Parse("a"));
+            Assert.Equal("goodbye", oneof.Parse("goodbye"));
+            Assert.Equal("hello", oneof.Parse("b")); // b is not found in "goodbye" so the next parser is checked and always succeeds true
+        }
+    }
+}

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -126,7 +126,7 @@ namespace Parlot.Tests
             Assert.False(s.ReadText("aBcd"));
             Assert.False(s.ReadText("abCd"));
             Assert.False(s.ReadText("abcD"));
-            Assert.True(s.ReadText("ABCD", comparer: StringComparer.OrdinalIgnoreCase, out var result));
+            Assert.True(s.ReadText("ABCD", StringComparison.OrdinalIgnoreCase, out var result));
             Assert.Equal("abcd", result.GetText());
         }
 


### PR DESCRIPTION
Before

```

|                     Method |          Mean |         Error |     StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------------------- |--------------:|--------------:|-----------:|--------:|-------:|----------:|
|           CursorMatchHello |      45.83 ns |      9.488 ns |   0.520 ns |  0.0204 |      - |     128 B |
|         CursorMatchGoodbye |      59.47 ns |      2.266 ns |   0.124 ns |  0.0204 |      - |     128 B |
|            CursorMatchNone |      38.25 ns |     12.920 ns |   0.708 ns |  0.0204 |      - |     128 B |
|                            |               |               |            |         |        |           |
|             SkipWhiteSpace |      61.13 ns |      4.925 ns |   0.270 ns |  0.0204 |      - |     128 B |
|                            |               |               |            |         |        |           |
| DecodeStringWithoutEscapes |      11.93 ns |      2.786 ns |   0.153 ns |       - |      - |         - |
|    DecodeStringWithEscapes |     122.02 ns |     20.751 ns |   1.137 ns |  0.0191 |      - |     120 B |
|                            |               |               |            |         |        |           |
|         ExpressionRawSmall |     375.84 ns |      9.490 ns |   0.520 ns |  0.0482 |      - |     304 B |
|    ExpressionCompiledSmall |     619.13 ns |     15.042 ns |   0.824 ns |  0.1040 |      - |     656 B |
|      ExpressionFluentSmall |     930.06 ns |    152.683 ns |   8.369 ns |  0.1040 |      - |     656 B |
|                            |               |               |            |         |        |           |
|           ExpressionRawBig |   1,769.36 ns |     80.902 ns |   4.435 ns |  0.1907 |      - |   1,200 B |
|      ExpressionCompiledBig |   3,527.21 ns |    350.353 ns |  19.204 ns |  0.4578 | 0.0038 |   2,888 B |
|        ExpressionFluentBig |   4,936.93 ns |    396.767 ns |  21.748 ns |  0.4578 |      - |   2,888 B |
|                            |               |               |            |         |        |           |
|                    BigJson | 155,278.92 ns |  7,270.598 ns | 398.526 ns | 16.1133 | 4.3945 | 101,672 B |
|            BigJsonCompiled | 129,750.94 ns | 12,826.122 ns | 703.043 ns | 16.1133 | 4.6387 | 101,675 B |
|                            |               |               |            |         |        |           |
|                   DeepJson | 101,506.69 ns | 15,960.851 ns | 874.868 ns | 17.9443 | 4.3945 | 112,976 B |
|           DeepJsonCompiled |  73,291.34 ns | 11,373.355 ns | 623.412 ns | 17.9443 | 4.7607 | 112,976 B |
|                            |               |               |            |         |        |           |
|                   LongJson | 126,858.36 ns |  7,748.298 ns | 424.710 ns | 21.4844 | 7.0801 | 135,512 B |
|           LongJsonCompiled | 105,367.39 ns |  5,815.415 ns | 318.763 ns | 21.4844 | 7.0801 | 135,512 B |
|                            |               |               |            |         |        |           |
|                   WideJson |  71,432.41 ns |  5,591.488 ns | 306.488 ns |  6.5918 | 1.0986 |  41,584 B |
|           WideJsonCompiled |  61,578.80 ns |  4,373.520 ns | 239.727 ns |  6.5918 | 1.0986 |  41,584 B |
```

After

```

|                     Method |          Mean |         Error |     StdDev |   Gen 0 |  Gen 1 | Allocated |
|--------------------------- |--------------:|--------------:|-----------:|--------:|-------:|----------:|
|           CursorMatchHello |      43.62 ns |      2.116 ns |   0.116 ns |  0.0216 |      - |     136 B |
|         CursorMatchGoodbye |      44.72 ns |      2.184 ns |   0.120 ns |  0.0216 |      - |     136 B |
|            CursorMatchNone |      35.52 ns |      2.205 ns |   0.121 ns |  0.0216 |      - |     136 B |
|                            |               |               |            |         |        |           |
|             SkipWhiteSpace |      43.44 ns |      1.466 ns |   0.080 ns |  0.0216 |      - |     136 B |
|                            |               |               |            |         |        |           |
| DecodeStringWithoutEscapes |      10.29 ns |      1.322 ns |   0.072 ns |       - |      - |         - |
|    DecodeStringWithEscapes |     122.33 ns |     15.457 ns |   0.847 ns |  0.0191 |      - |     120 B |
|                            |               |               |            |         |        |           |
|         ExpressionRawSmall |     336.99 ns |     14.758 ns |   0.809 ns |  0.0496 |      - |     312 B |
|    ExpressionCompiledSmall |     579.00 ns |     38.098 ns |   2.088 ns |  0.1049 |      - |     664 B |
|      ExpressionFluentSmall |     858.92 ns |    144.214 ns |   7.905 ns |  0.1049 |      - |     664 B |
|                            |               |               |            |         |        |           |
|           ExpressionRawBig |   1,607.09 ns |     76.577 ns |   4.197 ns |  0.1907 |      - |   1,208 B |
|      ExpressionCompiledBig |   3,149.37 ns |    208.323 ns |  11.419 ns |  0.4616 | 0.0038 |   2,896 B |
|        ExpressionFluentBig |   4,536.28 ns |    306.708 ns |  16.812 ns |  0.4578 |      - |   2,896 B |
|                            |               |               |            |         |        |           |
|                    BigJson | 143,809.98 ns |  7,429.023 ns | 407.210 ns | 16.1133 | 4.1504 | 101,680 B |
|            BigJsonCompiled | 118,860.58 ns |  6,199.133 ns | 339.795 ns | 16.1133 | 4.8828 | 101,680 B |
|                            |               |               |            |         |        |           |
|                   DeepJson |  90,613.77 ns |  7,011.874 ns | 384.344 ns | 17.9443 | 4.2725 | 112,984 B |
|           DeepJsonCompiled |  65,661.43 ns |  5,726.605 ns | 313.895 ns | 17.9443 | 4.6387 | 112,984 B |
|                            |               |               |            |         |        |           |
|                   LongJson | 115,968.64 ns | 10,665.565 ns | 584.616 ns | 21.4844 | 7.0801 | 135,520 B |
|           LongJsonCompiled |  94,632.68 ns | 11,143.391 ns | 610.807 ns | 21.4844 | 7.0801 | 135,520 B |
|                            |               |               |            |         |        |           |
|                   WideJson |  66,854.04 ns |  3,849.785 ns | 211.020 ns |  6.5918 | 1.0986 |  41,592 B |
|           WideJsonCompiled |  54,751.33 ns |  2,700.468 ns | 148.022 ns |  6.5918 | 1.0986 |  41,592 B |
```
And benchmarks comparing JSON parsing, including Newtonsoft

```
|                  Method |        Mean |      Error |    StdDev | Ratio | RatioSD |    Gen 0 |    Gen 1 | Allocated |
|------------------------ |------------:|-----------:|----------:|------:|--------:|---------:|---------:|----------:|
|          BigJson_Parlot |   141.28 us |  27.220 us |  1.492 us |  1.00 |    0.00 |  16.1133 |   4.1504 |     99 KB |
|  BigJson_ParlotCompiled |   116.68 us |   5.311 us |  0.291 us |  0.83 |    0.01 |  16.1133 |   4.8828 |     99 KB |
|          BigJson_Pidgin |   268.07 us |  25.410 us |  1.393 us |  1.90 |    0.03 |  16.1133 |   3.9063 |     99 KB |
|         BigJson_Sprache | 2,072.73 us |  68.511 us |  3.755 us | 14.67 |    0.16 | 859.3750 | 214.8438 |  5,272 KB |
|      BigJson_Superpower | 1,445.79 us |  11.676 us |  0.640 us | 10.23 |    0.11 | 148.4375 |  39.0625 |    911 KB |
|      BigJson_Newtonsoft |   188.77 us |  31.459 us |  1.724 us |  1.34 |    0.02 |  32.9590 |  12.9395 |    203 KB |
|                         |             |            |           |       |         |          |          |           |
|         LongJson_Parlot |   115.18 us |  17.040 us |  0.934 us |  1.00 |    0.00 |  21.4844 |   7.0801 |    132 KB |
| LongJson_ParlotCompiled |    94.83 us |   7.648 us |  0.419 us |  0.82 |    0.01 |  21.4844 |   7.0801 |    132 KB |
|         LongJson_Pidgin |   248.97 us |   7.483 us |  0.410 us |  2.16 |    0.02 |  21.4844 |   6.8359 |    132 KB |
|        LongJson_Sprache | 1,818.10 us | 167.172 us |  9.163 us | 15.79 |    0.14 | 697.2656 | 197.2656 |  4,273 KB |
|     LongJson_Superpower | 1,213.95 us |  28.241 us |  1.548 us | 10.54 |    0.10 | 119.1406 |  39.0625 |    735 KB |
|     LongJson_Newtonsoft |   137.40 us |   5.082 us |  0.279 us |  1.19 |    0.01 |  32.9590 |  14.6484 |    203 KB |
|                         |             |            |           |       |         |          |          |           |
|         DeepJson_Parlot |    88.67 us |   2.616 us |  0.143 us |  1.00 |    0.00 |  17.9443 |   4.2725 |    110 KB |
| DeepJson_ParlotCompiled |    65.79 us |   2.291 us |  0.126 us |  0.74 |    0.00 |  17.9443 |   4.6387 |    110 KB |
|         DeepJson_Pidgin |   370.77 us |  18.345 us |  1.006 us |  4.18 |    0.01 |  36.6211 |  12.2070 |    225 KB |
|        DeepJson_Sprache | 1,563.18 us | 462.780 us | 25.367 us | 17.63 |    0.31 | 476.5625 | 193.3594 |  2,926 KB |
|     DeepJson_Newtonsoft |   112.45 us |   8.912 us |  0.488 us |  1.27 |    0.00 |  29.1748 |  11.5967 |    179 KB |
|                         |             |            |           |       |         |          |          |           |
|         WideJson_Parlot |    67.51 us |   4.374 us |  0.240 us |  1.00 |    0.00 |   6.5918 |   1.0986 |     41 KB |
| WideJson_ParlotCompiled |    54.39 us |   1.875 us |  0.103 us |  0.81 |    0.00 |   6.5918 |   1.0986 |     41 KB |
|         WideJson_Pidgin |   120.91 us |   8.235 us |  0.451 us |  1.79 |    0.01 |   6.5918 |   1.0986 |     41 KB |
|        WideJson_Sprache |   899.91 us |  46.837 us |  2.567 us | 13.33 |    0.05 | 451.1719 |  89.8438 |  2,767 KB |
|     WideJson_Superpower |   700.68 us |  29.067 us |  1.593 us | 10.38 |    0.03 |  73.2422 |  11.7188 |    452 KB |
|     WideJson_Newtonsoft |    93.49 us |   1.166 us |  0.064 us |  1.38 |    0.00 |  17.3340 |   5.7373 |    107 KB |
```