### PR TITLE
Tiered compilation and whitespace performance

### DIFF
--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -4,6 +4,45 @@ namespace Parlot
 {
     public static class Character
     {
+        private static ReadOnlySpan<byte> WhiteSpaces => new byte[]
+        {
+            // \t (0x09 == 9)
+            // SPACE (0x20 == 32)
+            // NON-BREAKING SPACE (0xA0 == 160)
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
+        };
+
+        private static readonly byte[] WhiteSpaceOrNewLines = new byte[]
+        {
+            // \t (0x09 == 9)
+            // \n (0x0A == 10)
+            // \v (0x0B == 11)
+            // \r (0x0C == 13)
+            // SPACE (0x20 == 32)
+            // NON-BREAKING SPACE (0xA0 == 160)
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
+        };
+
         public static bool IsDecimalDigit(char ch)
             => ch >= '0' && ch <= '9';
 
@@ -25,10 +64,10 @@ namespace Parlot
 
         public static bool IsWhiteSpace(char ch)
         {
-            return (ch == 32) || // space
-                   (ch == 9) || // horizontal tab
-                   (ch == 0xA0) || // non-breaking space
-                   IsWhiteSpaceNonAscii(ch);
+            return ch < WhiteSpaces.Length 
+                ? WhiteSpaces[ch] == 0
+                : ch >= 0x1680 && IsWhiteSpaceNonAscii(ch)
+                ;
         }
 
         public static bool IsWhiteSpaceNonAscii(char ch)
@@ -43,9 +82,13 @@ namespace Parlot
                         ch == 0xFEFF));
         }
 
-
         public static bool IsWhiteSpaceOrNewLine(char ch)
-            => IsNewLine(ch) || IsWhiteSpace(ch);
+        {
+            return ch < WhiteSpaceOrNewLines.Length
+                ? WhiteSpaceOrNewLines[ch] == 0
+                : ch >= 0x1680 && IsWhiteSpaceNonAscii(ch)
+                ;
+        }
 
         public static bool IsNewLine(char ch)
             => (ch == '\n') || (ch == '\r') || (ch == '\v');

--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -4,45 +4,6 @@ namespace Parlot
 {
     public static class Character
     {
-        private static ReadOnlySpan<byte> WhiteSpaces => new byte[]
-        {
-            // \t (0x09 == 9)
-            // SPACE (0x20 == 32)
-            // NON-BREAKING SPACE (0xA0 == 160)
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
-        };
-
-        private static readonly byte[] WhiteSpaceOrNewLines = new byte[]
-        {
-            // \t (0x09 == 9)
-            // \n (0x0A == 10)
-            // \v (0x0B == 11)
-            // \r (0x0C == 13)
-            // SPACE (0x20 == 32)
-            // NON-BREAKING SPACE (0xA0 == 160)
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
-        };
-
         public static bool IsDecimalDigit(char ch)
             => ch >= '0' && ch <= '9';
 
@@ -64,9 +25,11 @@ namespace Parlot
 
         public static bool IsWhiteSpace(char ch)
         {
-            return ch < WhiteSpaces.Length 
-                ? WhiteSpaces[ch] == 0
-                : ch >= 0x1680 && IsWhiteSpaceNonAscii(ch)
+            return (ch <= 32 &&
+                       ((ch == 32) || // space
+                       (ch == '\t')))  // horizontal tab
+                || (ch == 0xA0) // non-breaking space
+                || (ch >= 0x1680 && IsWhiteSpaceNonAscii(ch))
                 ;
         }
 
@@ -84,9 +47,14 @@ namespace Parlot
 
         public static bool IsWhiteSpaceOrNewLine(char ch)
         {
-            return ch < WhiteSpaceOrNewLines.Length
-                ? WhiteSpaceOrNewLines[ch] == 0
-                : ch >= 0x1680 && IsWhiteSpaceNonAscii(ch)
+            return (ch <= 32 &&
+                       ((ch == 32) || // space
+                       (ch == '\n') ||
+                       (ch == '\r') ||
+                       (ch == '\t') || // horizontal tab
+                       (ch == '\v'))) 
+                || (ch == 0xA0) // non-breaking space
+                || (ch >= 0x1680 && IsWhiteSpaceNonAscii(ch))
                 ;
         }
 

--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -26,18 +26,23 @@ namespace Parlot
         public static bool IsWhiteSpace(char ch)
         {
             return (ch == 32) || // space
-                   (ch == '\t') || // horizontal tab
-                   (ch == 0xC) || // form feed - new page
+                   (ch == 9) || // horizontal tab
                    (ch == 0xA0) || // non-breaking space
-                   (ch >= 0x1680 && (
-                                        ch == 0x1680 ||
-                                        ch == 0x180E ||
-                                        (ch >= 0x2000 && ch <= 0x200A) ||
-                                        ch == 0x202F ||
-                                        ch == 0x205F ||
-                                        ch == 0x3000 ||
-                                        ch == 0xFEFF));
+                   IsWhiteSpaceNonAscii(ch);
         }
+
+        public static bool IsWhiteSpaceNonAscii(char ch)
+        {
+            return (ch >= 0x1680 && (
+                        ch == 0x1680 ||
+                        ch == 0x180E ||
+                        (ch >= 0x2000 && ch <= 0x200A) ||
+                        ch == 0x202F ||
+                        ch == 0x205F ||
+                        ch == 0x3000 ||
+                        ch == 0xFEFF));
+        }
+
 
         public static bool IsWhiteSpaceOrNewLine(char ch)
             => IsNewLine(ch) || IsWhiteSpace(ch);

--- a/src/Parlot/Compilation/CompiledParser.cs
+++ b/src/Parlot/Compilation/CompiledParser.cs
@@ -29,12 +29,13 @@ namespace Parlot.Compilation
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)
         {
-            var start = context.Scanner.Cursor.Offset;
+            var cursor = context.Scanner.Cursor;
+            var start = cursor.Offset;
             var parsed = _parse(context);
 
             if (parsed.Item1)
             {
-                result.Set(start, context.Scanner.Cursor.Offset, parsed.Item2);
+                result.Set(start, cursor.Offset, parsed.Item2);
                 return true;
             }
 

--- a/src/Parlot/Compilation/CompiledParser.cs
+++ b/src/Parlot/Compilation/CompiledParser.cs
@@ -22,9 +22,12 @@ namespace Parlot.Compilation
     {
         private readonly Func<ParseContext, ValueTuple<bool, T>> _parse;
 
-        public CompiledParser(Func<ParseContext, ValueTuple<bool, T>> parse)
+        public Parser<T> Source { get; }
+
+        public CompiledParser(Func<ParseContext, ValueTuple<bool, T>> parse, Parser<T> source)
         {
             _parse = parse ?? throw new ArgumentNullException(nameof(parse));
+            Source = source;
         }
 
         public override bool Parse(ParseContext context, ref ParseResult<T> result)

--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -23,6 +23,9 @@ namespace Parlot.Compilation
         internal static MethodInfo Scanner_ReadDoubleQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDoubleQuotedString), new Type[0] { });
         internal static MethodInfo Scanner_ReadQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadQuotedString), new Type[0] { });
 
+        internal static MethodInfo Cursor_Advance = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.Advance), Array.Empty<Type>());
+        internal static MethodInfo Cursor_AdvanceNoNewLines = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.AdvanceNoNewLines), new Type[] { typeof(int) });
+
         internal static ConstructorInfo TextSpan_Constructor = typeof(TextSpan).GetConstructor(new[] { typeof(string), typeof(int), typeof(int) });
 
         public static Expression NewTextSpan(this CompilationContext _, Expression buffer, Expression offset, Expression count) => Expression.New(TextSpan_Constructor, new[] { buffer, offset, count });
@@ -48,7 +51,8 @@ namespace Parlot.Compilation
         public static MethodCallExpression ReadNonWhiteSpaceOrNewLine(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadNonWhiteSpaceOrNewLine);
         public static MethodCallExpression SkipWhiteSpace(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_SkipWhiteSpace);
         public static MethodCallExpression SkipWhiteSpaceOrNewLine(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_SkipWhiteSpaceOrNewLine);
-        public static MethodCallExpression Advance(this CompilationContext context) => Expression.Call(context.Cursor(), typeof(Cursor).GetMethod(nameof(Parlot.Cursor.Advance), new Type[0] { }));
+        public static MethodCallExpression Advance(this CompilationContext context) => Expression.Call(context.Cursor(), Cursor_Advance);
+        public static MethodCallExpression AdvanceNoNewLine(this CompilationContext context, Expression count) => Expression.Call(context.Cursor(), Cursor_AdvanceNoNewLines, new[] { count });
 
         public static ParameterExpression DeclareSuccessVariable(this CompilationContext context, CompilationResult result, bool defaultValue)
         {

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -113,6 +113,28 @@ namespace Parlot
         }
 
         /// <summary>
+        /// Advances the cursor with the knowledge there are no new lines.
+        /// </summary>
+        public void AdvanceNoNewLines(int offset, int line, int column)
+        {
+            var newOffset = _offset + offset;
+
+            // Detect if the cursor will be over Eof
+            if (newOffset > _textLength - 1)
+            {
+                Eof = true;
+                _offset = _textLength;
+                _current = NullChar;
+                return;
+            }
+
+            _current = _buffer[newOffset];
+            _offset = newOffset;
+            _line += line;
+            _column += column;
+        }
+
+        /// <summary>
         /// Moves the cursor to the specific position
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -115,7 +115,7 @@ namespace Parlot
         /// <summary>
         /// Advances the cursor with the knowledge there are no new lines.
         /// </summary>
-        public void AdvanceNoNewLines(int offset, int line, int column)
+        public void AdvanceNoNewLines(int offset)
         {
             var newOffset = _offset + offset;
 
@@ -130,8 +130,6 @@ namespace Parlot
 
             _current = _buffer[newOffset];
             _offset = newOffset;
-            _line += line;
-            _column += column;
         }
 
         /// <summary>
@@ -292,10 +290,25 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s, StringComparison comparisonType)
         {
-            // StringComparison.Orinal is an optimized code path in Span.StartsWith
+            if (_textLength < _offset + s.Length)
+            {
+                return false;
+            }
 
             var sSpan = s.AsSpan();
             var bufferSpan = _buffer.AsSpan(_offset);
+
+            if (comparisonType == StringComparison.Ordinal && bufferSpan.Length > 0)
+            {
+                var length = sSpan.Length - 1;
+
+                if (bufferSpan[0] != sSpan[0] || bufferSpan[length] != sSpan[length])
+                {
+                    return false;
+                }
+            }
+
+            // StringComparison.Orinal is an optimized code path in Span.StartsWith
 
             return bufferSpan.StartsWith(sSpan, comparisonType);
         }

--- a/src/Parlot/Fluent/Capture.cs
+++ b/src/Parlot/Fluent/Capture.cs
@@ -44,11 +44,7 @@ namespace Parlot.Fluent
             var value = context.DeclareValueVariable(result, Expression.Default(typeof(TextSpan)));
 
             // var start = context.Scanner.Cursor.Position;
-
-            var start = Expression.Variable(typeof(TextPosition), $"start{context.NextNumber}");
-            result.Variables.Add(start);
-
-            result.Body.Add(Expression.Assign(start, context.Position()));
+            var start = context.DeclarePositionVariable(result);
 
             var ignoreResults = context.DiscardResult;
             context.DiscardResult = true;
@@ -82,7 +78,9 @@ namespace Parlot.Fluent
                     Expression.IfThenElse(
                         parserCompileResult.Success,
                         Expression.Block(
-                            Expression.Assign(value,
+                            context.DiscardResult
+                            ? Expression.Empty()
+                            : Expression.Assign(value,
                                 context.NewTextSpan(
                                     context.Buffer(),
                                     startOffset,

--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -104,7 +104,11 @@ namespace Parlot.Fluent
             // value = def.Item2;
 
             result.Body.Add(Expression.Assign(success, Expression.Field(deferred, "Item1")));
-            result.Body.Add(Expression.Assign(value, Expression.Field(deferred, "Item2")));
+            result.Body.Add(
+                context.DiscardResult
+                            ? Expression.Empty()
+                            : Expression.Assign(value, Expression.Field(deferred, "Item2"))
+            );
 
             return result;
         }

--- a/src/Parlot/Fluent/Error.cs
+++ b/src/Parlot/Fluent/Error.cs
@@ -54,7 +54,10 @@ namespace Parlot.Fluent
             var block = Expression.Block(
                 parserCompileResult.Variables,
                 parserCompileResult.Body
-                .Append(Expression.Assign(value, parserCompileResult.Value))
+                .Append(
+                    context.DiscardResult
+                            ? Expression.Empty()
+                            : Expression.Assign(value, parserCompileResult.Value))
                     .Append(
                         Expression.IfThenElse(
                             parserCompileResult.Success,

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -1,6 +1,5 @@
 ﻿using Parlot.Compilation;
 using System;
-using System.Linq;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
@@ -113,7 +112,7 @@ namespace Parlot.Fluent
                             : Expression.Assign(value, context.NewTextSpan(context.Buffer(), start, Expression.Subtract(context.Offset(), start))),
                         Expression.Assign(success, Expression.Constant(true, typeof(bool)))
                     )
-                )                
+                )
             );
 
             result.Body.Add(block);

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -90,7 +90,7 @@ namespace Parlot.Fluent
                     Expression.Block(
                         new[] { start },
                         Expression.Assign(start, context.Offset()),
-                        context.Advance(),
+                        context.AdvanceNoNewLine(Expression.Constant(1)),
                         Expression.Loop(
                             Expression.IfThenElse(
                                 /* if */ Expression.AndAlso(
@@ -102,7 +102,7 @@ namespace Parlot.Fluent
                                                 : Expression.Constant(false, typeof(bool))
                                             )
                                     ),
-                                /* then */ context.Advance(),
+                                /* then */ context.AdvanceNoNewLine(Expression.Constant(1)),
                                 /* else */ Expression.Break(breakLabel)
                                 ),
                             breakLabel

--- a/src/Parlot/Fluent/Identifier.cs
+++ b/src/Parlot/Fluent/Identifier.cs
@@ -27,11 +27,11 @@ namespace Parlot.Fluent
 
                 // At this point we have an identifier, read while it's an identifier part.
 
-                context.Scanner.Cursor.Advance();
+                context.Scanner.Cursor.AdvanceNoNewLines(1);
 
                 while (!context.Scanner.Cursor.Eof && (Character.IsIdentifierPart(context.Scanner.Cursor.Current) || (_extraPart != null && _extraPart(context.Scanner.Cursor.Current))))
                 {
-                    context.Scanner.Cursor.Advance();
+                    context.Scanner.Cursor.AdvanceNoNewLines(1);
                 }
 
                 var end = context.Scanner.Cursor.Offset;

--- a/src/Parlot/Fluent/NonWhiteSpaceLiteral.cs
+++ b/src/Parlot/Fluent/NonWhiteSpaceLiteral.cs
@@ -83,7 +83,9 @@ namespace Parlot.Fluent
                             Expression.NotEqual(start, end),
                             Expression.Block(
                                 Expression.Assign(success, Expression.Constant(true, typeof(bool))),
-                                Expression.Assign(value, context.NewTextSpan(context.Buffer(), start, Expression.Subtract(end, start))
+                                context.DiscardResult
+                                    ? Expression.Empty()
+                                    : Expression.Assign(value, context.NewTextSpan(context.Buffer(), start, Expression.Subtract(end, start))
                                 )
                             )
                     )))

--- a/src/Parlot/Fluent/Not.cs
+++ b/src/Parlot/Fluent/Not.cs
@@ -37,7 +37,7 @@ namespace Parlot.Fluent
 
             // var start = context.Scanner.Cursor.Position;
 
-            var start = context.Position();
+            var start = context.DeclarePositionVariable(result);
 
             var parserCompileResult = _parser.Build(context);
 

--- a/src/Parlot/Fluent/OneOf.cs
+++ b/src/Parlot/Fluent/OneOf.cs
@@ -160,7 +160,7 @@ namespace Parlot.Fluent
                 var cases = _lookupTable.Select(kvp =>
                 {
                     Expression group = Expression.Empty();
-                    var parsers = kvp.Value;
+                    var parsers = kvp.Value.ToArray();
                     parsers.Reverse();
 
                     foreach (var parser in parsers)

--- a/src/Parlot/Fluent/OneOf.cs
+++ b/src/Parlot/Fluent/OneOf.cs
@@ -160,6 +160,8 @@ namespace Parlot.Fluent
                 var cases = _lookupTable.Select(kvp =>
                 {
                     Expression group = Expression.Empty();
+
+                    // The list is reversed since the parsers are unwrapped
                     var parsers = kvp.Value.ToArray();
                     parsers.Reverse();
 

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -9,7 +9,7 @@ namespace Parlot.Fluent
         /// <summary>
         /// The number of usages of the parser before it is compiled automatically. <c>0</c> to disable automatic compilation. Default is 0.
         /// </summary>
-        public int CompilationThreshold { get; set; } = 0;
+        public int CompilationThreshold { get; set; } = DefaultCompilationThreshold;
 
         /// <summary>
         /// Whether new lines are treated as normal chars or white spaces. Default is <c>false</c>.

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -4,6 +4,13 @@ namespace Parlot.Fluent
 {
     public class ParseContext
     {
+        public static int DefaultCompilationThreshold = 0;
+
+        /// <summary>
+        /// The number of usages of the parser before it is compiled automatically. <c>0</c> to disable automatic compilation. Default is 0.
+        /// </summary>
+        public int CompilationThreshold { get; set; } = 0;
+
         /// <summary>
         /// Whether new lines are treated as normal chars or white spaces. Default is <c>false</c>.
         /// </summary>

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -5,11 +5,11 @@ namespace Parlot.Fluent
     public class ParseContext
     {
         /// <summary>
-        /// Whether new lines are treated as normal chars or white spaces.
+        /// Whether new lines are treated as normal chars or white spaces. Default is <c>false</c>.
         /// </summary>
         /// <remarks>
         /// When <c>false</c>, new lines will be skipped like any other white space.
-        /// Otherwise white spaces need to be read explicitely by a rule.
+        /// Otherwise new lines need to be read explicitely by a rule.
         /// </remarks>
         public bool UseNewLines { get; private set; }
 

--- a/src/Parlot/Fluent/Parser.Compile.cs
+++ b/src/Parlot/Fluent/Parser.Compile.cs
@@ -54,7 +54,7 @@ namespace Parlot.Fluent
 
             var result = Expression.Lambda<Func<ParseContext, ValueTuple<bool, T>>>(body, compilationContext.ParseContext);
 
-            var parser = result.Compile();
+            var parser = result.CompileFast();
 
             // parser is a Func, so we use CompiledParser to encapsulate it in a Parser<T>
             return new CompiledParser<T>(parser, this);

--- a/src/Parlot/Fluent/Parser.TryParse.cs
+++ b/src/Parlot/Fluent/Parser.TryParse.cs
@@ -2,10 +2,15 @@
 {
     public abstract partial class Parser<T>
     {
-        public T Parse(string text, ParseContext context = null)
+        public T Parse(string text)
         {
-            context ??= new ParseContext(new Scanner(text));
+            var context = new ParseContext(new Scanner(text));
 
+            return Parse(context);
+        }
+
+        public T Parse(ParseContext context)
+        {
             var localResult = new ParseResult<T>();
 
             var success = Parse(context, ref localResult);

--- a/src/Parlot/Fluent/TextBefore.cs
+++ b/src/Parlot/Fluent/TextBefore.cs
@@ -160,7 +160,7 @@
                                 ? Expression.Empty()
                                 : Expression.IfThen(Expression.Equal(length, Expression.Constant(0)), Expression.Break(breakLabel)),
                                 Expression.Assign(success, Expression.Constant(true)),
-                                Expression.Assign(value, context.NewTextSpan(context.Buffer(), context.Offset(start), length)),
+                                context.DiscardResult ? Expression.Empty() : Expression.Assign(value, context.NewTextSpan(context.Buffer(), context.Offset(start), length)),
                                 Expression.Break(breakLabel)
                                 )
                             ),
@@ -178,7 +178,7 @@
                                 ? Expression.Empty()
                                 : Expression.IfThen(Expression.Equal(length, Expression.Constant(0)), Expression.Break(breakLabel)),
                                 Expression.Assign(success, Expression.Constant(true)),
-                                Expression.Assign(value, context.NewTextSpan(context.Buffer(), context.Offset(start), length)),
+                                context.DiscardResult ? Expression.Empty() : Expression.Assign(value, context.NewTextSpan(context.Buffer(), context.Offset(start), length)),
                                 Expression.Break(breakLabel)
                                 )
                             ),

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -1,6 +1,7 @@
 ﻿using Parlot.Compilation;
 using Parlot.Rewriting;
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent
@@ -8,11 +9,13 @@ namespace Parlot.Fluent
     public sealed class TextLiteral : Parser<string>, ICompilable, ISeekable
     {
         private readonly StringComparison _comparisonType;
+        private readonly bool _hasNewLines;
 
         public TextLiteral(string text, StringComparison comparisonType)
         {
             Text = text ?? throw new ArgumentNullException(nameof(text));
             _comparisonType = comparisonType;
+            _hasNewLines = text.Any(x => Character.IsNewLine(x));
         }
 
         public string Text { get; }
@@ -32,7 +35,16 @@ namespace Parlot.Fluent
             if (cursor.Match(Text, _comparisonType))
             {
                 var start = cursor.Offset;
-                cursor.Advance(Text.Length);
+                
+                if (_hasNewLines)
+                {
+                    cursor.Advance(Text.Length);
+                }
+                else
+                {
+                    cursor.AdvanceNoNewLines(Text.Length);
+                }
+
                 result.Set(start, cursor.Offset, Text);
                 return true;
             }

--- a/src/Parlot/Fluent/WhiteSpaceLiteral.cs
+++ b/src/Parlot/Fluent/WhiteSpaceLiteral.cs
@@ -62,7 +62,7 @@ namespace Parlot.Fluent
                         Expression.NotEqual(start, end),
                         Expression.Assign(success, Expression.Constant(true, typeof(bool)))
                         ),
-                    Expression.Assign(value, context.NewTextSpan(context.Buffer(), start, Expression.Subtract(end, start)))
+                    context.DiscardResult ? Expression.Empty() : Expression.Assign(value, context.NewTextSpan(context.Buffer(), start, Expression.Subtract(end, start)))
                     )
                 );
 

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -13,6 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FastExpressionCompiler" Version="3.2.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FastExpressionCompiler" Version="3.2.1" />
+    <PackageReference Include="FastExpressionCompiler.src" Version="3.2.1" />
     <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
   </ItemGroup>

--- a/src/Parlot/ParseException.cs
+++ b/src/Parlot/ParseException.cs
@@ -4,7 +4,7 @@ namespace Parlot
 {
     public class ParseException : Exception
     {
-        public ParseException(string message, in TextPosition position) : base(message)
+        public ParseException(string message, TextPosition position) : base(message)
         {
             Position = position;
         }

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -92,7 +92,7 @@ namespace Parlot
             // We can move the cursor without tracking new lines since we know these are only spaces
             if (offset > 0)
             {
-                Cursor.AdvanceNoNewLines(offset, 0, 0);
+                Cursor.Advance(offset);
                 return true;
             }
 
@@ -133,7 +133,7 @@ namespace Parlot
             // We can move the cursor without tracking new lines since we know these are only spaces
             if (offset > 0)
             {
-                Cursor.AdvanceNoNewLines(offset, 0, 0);
+                Cursor.AdvanceNoNewLines(offset);
                 return true;
             }
 
@@ -192,7 +192,7 @@ namespace Parlot
 
             do
             {
-                Cursor.Advance();
+                Cursor.AdvanceNoNewLines(1);
 
             } while (!Cursor.Eof && Character.IsDecimalDigit(Cursor.Current));
 
@@ -209,7 +209,7 @@ namespace Parlot
 
                 do
                 {
-                    Cursor.Advance();
+                    Cursor.AdvanceNoNewLines(1);
 
                 } while (!Cursor.Eof && Character.IsDecimalDigit(Cursor.Current));
             }
@@ -235,7 +235,7 @@ namespace Parlot
 
             do
             {
-                Cursor.Advance();
+                Cursor.AdvanceNoNewLines(1);
 
             } while (!Cursor.Eof && Character.IsDecimalDigit(Cursor.Current));
 

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -9,38 +9,6 @@ namespace Parlot
     /// </summary>
     public class Scanner
     {
-        private static readonly byte MaxWhiteSpacesValue = 162;
-
-        private static readonly byte[] WhiteSpaces = new byte[161] 
-        {
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
-        };
-
-        private static readonly byte MaxWhiteSpaceOrNewLinesValue = 162;
-
-        private static readonly byte[] WhiteSpaceOrNewLines = new byte[161]
-        {
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-            1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0
-        };
-
         public readonly string Buffer;
         public readonly Cursor Cursor;
 
@@ -64,29 +32,9 @@ namespace Parlot
             var offset = 0;
             var maxOffset = Cursor.Buffer.Length - Cursor.Offset;
 
-            while (offset < maxOffset)
+            while (offset < maxOffset && Character.IsWhiteSpaceOrNewLine(Cursor.PeekNext(offset)))
             {
-                var current = Cursor.PeekNext(offset);
-
-                // Fast path using the lookup table for common chars
-                if (current < MaxWhiteSpaceOrNewLinesValue)
-                {
-                    var b = (byte)current;
-
-                    if (WhiteSpaceOrNewLines[b] != 0)
-                    {
-                        break;
-                    }
-
-                    offset++;
-                }
-                else
-                {
-                    if (Character.IsWhiteSpaceOrNewLine(current))
-                    {
-                        offset++;
-                    }
-                }
+                offset++;
             }
 
             // We can move the cursor without tracking new lines since we know these are only spaces
@@ -105,29 +53,9 @@ namespace Parlot
             var offset = 0;
             var maxOffset = Cursor.Buffer.Length - Cursor.Offset;
 
-            while (offset < maxOffset)
+            while (offset < maxOffset && Character.IsWhiteSpace(Cursor.PeekNext(offset)))
             {
-                var current = Cursor.PeekNext(offset);
-
-                // Fast path using the lookup table for common chars
-                if (current < MaxWhiteSpacesValue)
-                {
-                    var b = (byte) current;
-
-                    if (WhiteSpaces[b] != 0)
-                    {
-                        break;
-                    }
-
-                    offset++;
-                }
-                else
-                {
-                    if (Character.IsWhiteSpace(current))
-                    {
-                        offset++;
-                    }
-                }
+                offset++;
             }
 
             // We can move the cursor without tracking new lines since we know these are only spaces
@@ -142,7 +70,7 @@ namespace Parlot
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other)
-            => ReadFirstThenOthers(first, other, out _); 
+            => ReadFirstThenOthers(first, other, out _);
 
         public bool ReadFirstThenOthers(Func<char, bool> first, Func<char, bool> other, out TokenResult result)
         {
@@ -220,7 +148,7 @@ namespace Parlot
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool ReadInteger() => ReadInteger(out _);
-        
+
         public bool ReadInteger(out TokenResult result)
         {
             // perf: fast path to prevent a copy of the position
@@ -275,7 +203,7 @@ namespace Parlot
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadNonWhiteSpace() => ReadNonWhiteSpace(out _); 
+        public bool ReadNonWhiteSpace() => ReadNonWhiteSpace(out _);
 
         public bool ReadNonWhiteSpace(out TokenResult result)
         {
@@ -283,7 +211,7 @@ namespace Parlot
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadNonWhiteSpaceOrNewLine() => ReadNonWhiteSpaceOrNewLine(out _); 
+        public bool ReadNonWhiteSpaceOrNewLine() => ReadNonWhiteSpaceOrNewLine(out _);
 
         public bool ReadNonWhiteSpaceOrNewLine(out TokenResult result)
         {
@@ -327,8 +255,8 @@ namespace Parlot
         /// Reads the specific expected text.
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool ReadText(string text, StringComparison comparisonType) => ReadText(text, comparisonType, out _); 
-        
+        public bool ReadText(string text, StringComparison comparisonType) => ReadText(text, comparisonType, out _);
+
         /// <summary>
         /// Reads the specific expected text.
         /// </summary>
@@ -343,7 +271,7 @@ namespace Parlot
             int start = Cursor.Offset;
             Cursor.Advance(text.Length);
             result = TokenResult.Succeed(Buffer, start, Cursor.Offset);
-            
+
             return true;
         }
 
@@ -562,7 +490,7 @@ namespace Parlot
                     result = TokenResult.Fail();
                     return false;
                 }
-            }            
+            }
 
             result = TokenResult.Succeed(Buffer, start.Offset, Cursor.Offset);
 

--- a/test/Parlot.Benchmarks/ParlotBenchmarks.cs
+++ b/test/Parlot.Benchmarks/ParlotBenchmarks.cs
@@ -12,7 +12,8 @@ namespace Parlot.Benchmarks
     {
         private const string _stringWithEscapes = "This is a new line \\n \\t and a tab and some \\xa0";
         private const string _stringWithoutEscapes = "This is a new line \n \t and a tab and some \xa0";
-        private readonly Parser<char> _whiteSpaceExpression = Parsers.OneOf(Parsers.Terms.Char('a'), Parsers.Terms.Char('b'), Parsers.Terms.Char('v'), Parsers.Terms.Char('d'));
+        private readonly Parser<char> _lookupExpression = Parsers.OneOf(Parsers.Terms.Char('a'), Parsers.Terms.Char('b'), Parsers.Terms.Char('v'), Parsers.Terms.Char('d'));
+        private readonly Parser<char> _whitespaceExpression = Parsers.Terms.Char('a');
 
         // Exercises Cursor.Match(string)
         private readonly Parser<string> _matchStringExpression = Parsers.OneOf(Parsers.Literals.Text("hello"), Parsers.Literals.Text("goodbye"));
@@ -44,10 +45,22 @@ namespace Parlot.Benchmarks
             return _matchStringExpression.Parse("hellllo");
         }
 
-        [Benchmark, BenchmarkCategory("WhiteSpace")]
-        public char SkipWhiteSpace()
+        [Benchmark, BenchmarkCategory("Lookup")]
+        public char Lookup()
         {
-            return _whiteSpaceExpression.Parse("d");
+            return _lookupExpression.Parse("d");
+        }
+
+        [Benchmark, BenchmarkCategory("WhiteSpace")]
+        public char SkipWhiteSpace_1()
+        {
+            return _whitespaceExpression.Parse(" a");
+        }
+
+        [Benchmark, BenchmarkCategory("WhiteSpace")]
+        public char SkipWhiteSpace_10()
+        {
+            return _whitespaceExpression.Parse("          a");
         }
 
         [Benchmark, BenchmarkCategory("DecodeString")]

--- a/test/Parlot.Benchmarks/ParlotBenchmarks.cs
+++ b/test/Parlot.Benchmarks/ParlotBenchmarks.cs
@@ -3,7 +3,6 @@ using BenchmarkDotNet.Configs;
 using Parlot.Fluent;
 using Parlot.Tests.Calc;
 using Parlot.Tests.Json;
-using System.Collections.Generic;
 
 namespace Parlot.Benchmarks
 {
@@ -54,13 +53,13 @@ namespace Parlot.Benchmarks
         [Benchmark, BenchmarkCategory("WhiteSpace")]
         public char SkipWhiteSpace_1()
         {
-            return _whitespaceExpression.Parse(" a");
+            return _whitespaceExpression.Parse(new ParseContext(new Scanner(" a"), useNewLines: true));
         }
 
         [Benchmark, BenchmarkCategory("WhiteSpace")]
         public char SkipWhiteSpace_10()
         {
-            return _whitespaceExpression.Parse("          a");
+            return _whitespaceExpression.Parse(new ParseContext(new Scanner("          a"), useNewLines: true));
         }
 
         [Benchmark, BenchmarkCategory("DecodeString")]

--- a/test/Parlot.Benchmarks/ParlotBenchmarks.cs
+++ b/test/Parlot.Benchmarks/ParlotBenchmarks.cs
@@ -26,6 +26,18 @@ namespace Parlot.Benchmarks
             _jsonBench.Setup();
         }
 
+        [Benchmark, BenchmarkCategory("Compilation")]
+        public Parser<char> CreateCompiledSmallParser()
+        {
+            return Parsers.OneOf(Parsers.Terms.Char('a'), Parsers.Terms.Char('b'), Parsers.Terms.Char('v'), Parsers.Terms.Char('d')).Compile();
+        }
+
+        [Benchmark, BenchmarkCategory("Compilation")]
+        public Parser<Expression> CreateCompiledExpressionParser()
+        {
+            return FluentParser.Expression.Compile();
+        }
+
         [Benchmark, BenchmarkCategory("Cursor.Match(string)")]
         public string CursorMatchHello()
         {

--- a/test/Parlot.Tests/CharacterTests.cs
+++ b/test/Parlot.Tests/CharacterTests.cs
@@ -50,7 +50,7 @@ namespace Parlot.Tests
         [InlineData('a', false)]
         public void ShouldDetectWhiteSpaceOrNewLines(char c, bool isWhiteSpace)
         {
-            Assert.Equal(isWhiteSpace, Character.IsWhiteSpace(c));
+            Assert.Equal(isWhiteSpace, Character.IsWhiteSpaceOrNewLine(c));
         }
     }
 }

--- a/test/Parlot.Tests/CharacterTests.cs
+++ b/test/Parlot.Tests/CharacterTests.cs
@@ -26,5 +26,31 @@ namespace Parlot.Tests
             var span = new TextSpan("   a\\nbc   ", 3, 5);
             Assert.Equal("a\nbc", Character.DecodeString(span).ToString());
         }
+
+        [Theory]
+        [InlineData('\x09', true)]
+        [InlineData('\x20', true)]
+        [InlineData('\xa0', true)]
+        [InlineData('\v', false)]
+        [InlineData('\n', false)]
+        [InlineData('\r', false)]
+        [InlineData('a', false)]
+        public void ShouldDetectWhiteSpace(char c, bool isWhiteSpace)
+        {
+            Assert.Equal(isWhiteSpace, Character.IsWhiteSpace(c));
+        }
+
+        [Theory]
+        [InlineData('\x09', true)]
+        [InlineData('\x20', true)]
+        [InlineData('\xa0', true)]
+        [InlineData('\v', true)]
+        [InlineData('\n', true)]
+        [InlineData('\r', true)]
+        [InlineData('a', false)]
+        public void ShouldDetectWhiteSpaceOrNewLines(char c, bool isWhiteSpace)
+        {
+            Assert.Equal(isWhiteSpace, Character.IsWhiteSpace(c));
+        }
     }
 }

--- a/test/Parlot.Tests/CompileTests.cs
+++ b/test/Parlot.Tests/CompileTests.cs
@@ -611,5 +611,26 @@ namespace Parlot.Tests
             Assert.True(parser.TryParse("ab", out _));
             Assert.True(parser.TryParse("abc", out _));
         }
+
+        [Fact]
+        public void CanCompileSubTree()
+        {
+            Parser<char> Dot = Literals.Char('.');
+            Parser<char> Plus = Literals.Char('+');
+            Parser<char> Minus = Literals.Char('-');
+            Parser<char> At = Literals.Char('@');
+            Parser<TextSpan> WordChar = Literals.Pattern(char.IsLetterOrDigit).Compile();
+            Parser<List<char>> WordDotPlusMinus = OneOrMany(OneOf(WordChar.Then(x => 'w'), Dot, Plus, Minus));
+            Parser<List<char>> WordDotMinus = OneOrMany(OneOf(WordChar.Then(x => 'w'), Dot, Minus));
+            Parser<List<char>> WordMinus = OneOrMany(OneOf(WordChar.Then(x => 'w'), Minus));
+            Parser<TextSpan> Email = Capture(WordDotPlusMinus.And(At).And(WordMinus).And(Dot).And(WordDotMinus));
+
+            string _email = "sebastien.ros@gmail.com";
+
+            var parser = Email.Compile();
+            var result = parser.Parse(_email);
+
+            Assert.Equal(_email, result.ToString());
+        }
     }
 }


### PR DESCRIPTION
- [x] Update compiled versions to use `AdvanceNoNewLines` where it was introduced
- [x] Reset compilation thresholds to `0` in benchmarks
