### PR TITLE
OneOf Compilation issues

### DIFF
--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -682,5 +682,14 @@ namespace Parlot.Tests
                 .TryParse(new ParseContext(new Scanner(" \nab"), useNewLines: true),
                 out var _, out var _));
         }
+
+        [Fact]
+        public void OneOfShouldHandleMultipleStrings()
+        {
+            var operators = OneOf(Literals.Text(">="), Literals.Text(">"), Literals.Text("<="));//.And(Literals.Text("@now")).Compile(); // throws compilation exception
+            var nowParser = Literals.Text("@now");
+            var parser = operators.And(nowParser).Compile(); // Complition bug, works fine without
+            Assert.True(parser.TryParse(">@now", out var _));
+        }
     }
 }

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -686,10 +686,21 @@ namespace Parlot.Tests
         [Fact]
         public void OneOfShouldHandleMultipleStrings()
         {
-            var operators = OneOf(Literals.Text(">="), Literals.Text(">"), Literals.Text("<="));//.And(Literals.Text("@now")).Compile(); // throws compilation exception
+            var operators = OneOf(Literals.Text(">="), Literals.Text(">"), Literals.Text("<="));
             var nowParser = Literals.Text("@now");
             var parser = operators.And(nowParser).Compile(); // Complition bug, works fine without
             Assert.True(parser.TryParse(">@now", out var _));
+        }
+
+        [Fact]
+        public void ShouldCompileOneOf()
+        {
+            // throws System.InvalidOperationException : The parser needs to implement ISkippableSequenceParser
+            var operators = OneOf(Literals.Text(">="), Literals.Text(">"), Literals.Text("<="))
+                .And(Literals.Text("@now"))
+                .Compile(); // throws compilation exception
+
+            Assert.True(operators.TryParse(">@now", out var _));
         }
     }
 }


### PR DESCRIPTION
Just compilation, works fine without.

btw, did you see the recent `.IndexOf("substring")` improvements?

Uses a mask against the first and last char, to see if the chars in between are worth matching against.
