### PR TITLE
Add net8.0 target for tests/benchmarks, remove obsolete, update packages

### DIFF
--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -14,9 +14,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Memory" Version="4.5.4" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
-    <PackageReference Include="FastExpressionCompiler.Internal.src" Version="3.2.1" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.5" Condition="'$(TargetFramework)' == 'netstandard2.0' " />
+    <PackageReference Include="FastExpressionCompiler.Internal.src" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">

--- a/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
+++ b/test/Parlot.Benchmarks/Parlot.Benchmarks.csproj
@@ -2,16 +2,16 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
-    <PackageReference Include="Pidgin" Version="3.0.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.10" />
+    <PackageReference Include="Pidgin" Version="3.2.2" />
     <PackageReference Include="Sprache" Version="2.3.1" />
     <PackageReference Include="Superpower" Version="3.0.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Parlot.Tests/Parlot.Tests.csproj
+++ b/test/Parlot.Tests/Parlot.Tests.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <LangVersion>latest</LangVersion>
-    <!-- Ignore: The target framework '...' is out of support and will not receive security updates in the future -->
-    <NoWarn>NETSDK1138</NoWarn> 
   </PropertyGroup>
 
   <ItemGroup>
@@ -13,13 +11,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
And results for earlier `net6.0` benchmarks setup against new `net8.0`.

```

BenchmarkDotNet v0.13.10, Windows 11 (10.0.23595.1001)
AMD Ryzen 9 5950X, 1 CPU, 32 logical and 16 physical cores
.NET SDK 8.0.100
  [Host]     : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
  Job-GSHXLU : .NET 6.0.25 (6.0.2523.51912), X64 RyuJIT AVX2
  Job-OINLIE : .NET 8.0.0 (8.0.23.53103), X64 RyuJIT AVX2


```
| Method                         | Runtime  | Mean           | Error       | StdDev      | Ratio | RatioSD | Gen0   | Gen1   | Gen2   | Allocated | Alloc Ratio |
|------------------------------- |--------- |---------------:|------------:|------------:|------:|--------:|-------:|-------:|-------:|----------:|------------:|
| CreateCompiledSmallParser      | .NET 6.0 |  66,064.471 ns | 613.3239 ns | 543.6956 ns |  1.00 |    0.00 | 1.8311 | 0.8545 |      - |   32128 B |        1.00 |
| CreateCompiledSmallParser      | .NET 8.0 |  46,698.962 ns | 218.9613 ns | 194.1035 ns |  0.71 |    0.01 | 1.9531 | 1.7090 |      - |   33289 B |        1.04 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| CreateCompiledExpressionParser | .NET 6.0 |  11,568.647 ns |  59.3786 ns |  52.6376 ns |  1.00 |    0.00 | 0.2747 | 0.1373 | 0.0153 |    4847 B |        1.00 |
| CreateCompiledExpressionParser | .NET 8.0 |   8,120.875 ns |  53.3972 ns |  47.3352 ns |  0.70 |    0.00 | 0.2747 | 0.2441 |      - |    5022 B |        1.04 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| CursorMatchHello               | .NET 6.0 |      36.447 ns |   0.2416 ns |   0.2018 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| CursorMatchHello               | .NET 8.0 |      28.387 ns |   0.3950 ns |   0.3695 ns |  0.78 |    0.01 | 0.0076 |      - |      - |     128 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| CursorMatchGoodbye             | .NET 6.0 |      38.540 ns |   0.8188 ns |   0.9101 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| CursorMatchGoodbye             | .NET 8.0 |      28.757 ns |   0.1282 ns |   0.1137 ns |  0.75 |    0.02 | 0.0076 |      - |      - |     128 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| CursorMatchNone                | .NET 6.0 |      30.644 ns |   0.1063 ns |   0.0888 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| CursorMatchNone                | .NET 8.0 |      23.386 ns |   0.2306 ns |   0.2157 ns |  0.76 |    0.01 | 0.0076 |      - |      - |     128 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| DecodeStringWithoutEscapes     | .NET 6.0 |       8.829 ns |   0.1254 ns |   0.1173 ns |  1.00 |    0.00 |      - |      - |      - |         - |          NA |
| DecodeStringWithoutEscapes     | .NET 8.0 |      13.713 ns |   0.0329 ns |   0.0307 ns |  1.55 |    0.02 |      - |      - |      - |         - |          NA |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| DecodeStringWithEscapes        | .NET 6.0 |      63.227 ns |   0.1997 ns |   0.1559 ns |  1.00 |    0.00 | 0.0072 |      - |      - |     120 B |        1.00 |
| DecodeStringWithEscapes        | .NET 8.0 |      54.421 ns |   0.9898 ns |   0.7728 ns |  0.86 |    0.01 | 0.0072 |      - |      - |     120 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionRawBig               | .NET 6.0 |   1,290.535 ns |  18.0353 ns |  16.8703 ns |  1.00 |    0.00 | 0.0706 |      - |      - |    1200 B |        1.00 |
| ExpressionRawBig               | .NET 8.0 |   1,176.778 ns |   3.0264 ns |   2.8309 ns |  0.91 |    0.01 | 0.0706 |      - |      - |    1200 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionCompiledBig          | .NET 6.0 |   2,676.705 ns |   4.9175 ns |   4.3592 ns |  1.00 |    0.00 | 0.1717 |      - |      - |    2888 B |        1.00 |
| ExpressionCompiledBig          | .NET 8.0 |   2,257.064 ns |  12.9159 ns |  11.4496 ns |  0.84 |    0.00 | 0.1717 |      - |      - |    2888 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionFluentBig            | .NET 6.0 |   3,572.775 ns |  25.1562 ns |  23.5311 ns |  1.00 |    0.00 | 0.1717 |      - |      - |    2888 B |        1.00 |
| ExpressionFluentBig            | .NET 8.0 |   2,885.471 ns |  13.6091 ns |  12.0641 ns |  0.81 |    0.01 | 0.1717 |      - |      - |    2888 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionRawSmall             | .NET 6.0 |     268.375 ns |   1.6459 ns |   1.5396 ns |  1.00 |    0.00 | 0.0181 |      - |      - |     304 B |        1.00 |
| ExpressionRawSmall             | .NET 8.0 |     244.334 ns |   1.5613 ns |   1.4604 ns |  0.91 |    0.01 | 0.0181 |      - |      - |     304 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionCompiledSmall        | .NET 6.0 |     465.102 ns |   2.5673 ns |   2.4014 ns |  1.00 |    0.00 | 0.0391 |      - |      - |     656 B |        1.00 |
| ExpressionCompiledSmall        | .NET 8.0 |     426.028 ns |   1.8747 ns |   1.6619 ns |  0.92 |    0.00 | 0.0391 |      - |      - |     656 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| ExpressionFluentSmall          | .NET 6.0 |     681.676 ns |   1.8384 ns |   1.7196 ns |  1.00 |    0.00 | 0.0391 |      - |      - |     656 B |        1.00 |
| ExpressionFluentSmall          | .NET 8.0 |     554.659 ns |   1.5836 ns |   1.4038 ns |  0.81 |    0.00 | 0.0391 |      - |      - |     656 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| BigJson                        | .NET 6.0 | 109,022.250 ns | 510.9494 ns | 398.9157 ns |  1.00 |    0.00 | 5.9814 | 0.9766 |      - |  101672 B |        1.00 |
| BigJson                        | .NET 8.0 |  77,735.426 ns | 588.3469 ns | 550.3401 ns |  0.71 |    0.01 | 5.6152 | 1.0986 |      - |   93992 B |        0.92 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| BigJsonCompiled                | .NET 6.0 |  91,802.176 ns | 571.1060 ns | 534.2129 ns |  1.00 |    0.00 | 5.9814 | 1.3428 |      - |  101672 B |        1.00 |
| BigJsonCompiled                | .NET 8.0 |  66,770.095 ns | 501.5959 ns | 444.6517 ns |  0.73 |    0.01 | 5.6152 | 1.2207 |      - |   93992 B |        0.92 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| DeepJson                       | .NET 6.0 |  77,054.780 ns | 341.6904 ns | 319.6174 ns |  1.00 |    0.00 | 6.7139 | 0.6104 |      - |  112976 B |        1.00 |
| DeepJson                       | .NET 8.0 |  51,874.220 ns | 469.9253 ns | 439.5685 ns |  0.67 |    0.01 | 5.9814 | 0.6714 |      - |  100688 B |        0.89 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| DeepJsonCompiled               | .NET 6.0 |  49,498.904 ns | 387.1771 ns | 343.2224 ns |  1.00 |    0.00 | 6.7139 | 1.4648 |      - |  112976 B |        1.00 |
| DeepJsonCompiled               | .NET 8.0 |  42,776.002 ns | 210.9673 ns | 197.3390 ns |  0.86 |    0.01 | 5.9814 | 1.4038 |      - |  100688 B |        0.89 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| LongJson                       | .NET 6.0 |  92,829.261 ns | 349.2154 ns | 309.5704 ns |  1.00 |    0.00 | 8.0566 | 1.7090 |      - |  135512 B |        1.00 |
| LongJson                       | .NET 8.0 |  65,201.939 ns | 276.9507 ns | 245.5096 ns |  0.70 |    0.00 | 7.3242 | 1.7090 |      - |  123224 B |        0.91 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| LongJsonCompiled               | .NET 6.0 |  78,474.431 ns | 536.9552 ns | 502.2683 ns |  1.00 |    0.00 | 8.0566 | 1.7090 |      - |  135512 B |        1.00 |
| LongJsonCompiled               | .NET 8.0 |  61,426.626 ns | 293.8466 ns | 260.4874 ns |  0.78 |    0.01 | 7.3242 | 1.7090 |      - |  123224 B |        0.91 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| WideJson                       | .NET 6.0 |  50,205.221 ns | 251.6121 ns | 235.3581 ns |  1.00 |    0.00 | 2.4414 | 0.1831 |      - |   41584 B |        1.00 |
| WideJson                       | .NET 8.0 |  34,258.952 ns | 126.9208 ns | 112.5119 ns |  0.68 |    0.00 | 2.4414 | 0.2441 |      - |   41536 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| WideJsonCompiled               | .NET 6.0 |  42,753.030 ns | 228.5757 ns | 213.8098 ns |  1.00 |    0.00 | 2.4414 | 0.2441 |      - |   41584 B |        1.00 |
| WideJsonCompiled               | .NET 8.0 |  31,410.832 ns | 148.0368 ns | 131.2307 ns |  0.73 |    0.00 | 2.4414 | 0.2441 |      - |   41536 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| Lookup                         | .NET 6.0 |      36.338 ns |   0.1361 ns |   0.1207 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| Lookup                         | .NET 8.0 |      29.935 ns |   0.2509 ns |   0.2224 ns |  0.82 |    0.01 | 0.0076 |      - |      - |     128 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| SkipWhiteSpace_1               | .NET 6.0 |      27.034 ns |   0.1110 ns |   0.1038 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| SkipWhiteSpace_1               | .NET 8.0 |      22.322 ns |   0.1929 ns |   0.1805 ns |  0.83 |    0.01 | 0.0076 |      - |      - |     128 B |        1.00 |
|                                |          |                |             |             |       |         |        |        |        |           |             |
| SkipWhiteSpace_10              | .NET 6.0 |      37.482 ns |   0.1700 ns |   0.1507 ns |  1.00 |    0.00 | 0.0076 |      - |      - |     128 B |        1.00 |
| SkipWhiteSpace_10              | .NET 8.0 |      30.714 ns |   0.1662 ns |   0.1474 ns |  0.82 |    0.01 | 0.0076 |      - |      - |     128 B |        1.00 |
