### PR TITLE
Improve MatchAnyOf

### DIFF
--- a/src/Parlot/Cursor.cs
+++ b/src/Parlot/Cursor.cs
@@ -205,9 +205,6 @@ namespace Parlot
             return _current == c;
         }
 
-        /// <summary>
-        /// Whether any char of the string is at the current position.
-        /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool MatchAnyOf(string s)
         {
@@ -228,49 +225,7 @@ namespace Parlot
                 return true;
             }
 
-            for (var i = 0; i < length; i++)
-            {
-                if (s[i] == _current)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Whether any char of an array is at the current position.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public bool MatchAny(params char[] chars)
-        {
-            if (chars == null)
-            {
-                ThrowHelper.ThrowArgumentNullException(nameof(chars));
-            }
-
-            if (Eof)
-            {
-                return false;
-            }
-
-            var length = chars.Length;
-
-            if (length == 0)
-            {
-                return true;
-            }
-
-            for (var i = 0; i < length; i++)
-            {
-                if (chars[i] == _current)
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return s.IndexOf(_current) != -1;
         }
 
         /// <summary>
@@ -279,7 +234,7 @@ namespace Parlot
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool Match(string s)
         {
-            // Equivalent to StringComparison.Orinal copmarison
+            // Equivalent to StringComparison.Ordinal comparison
 
             var sSpan = s.AsSpan();
             var bufferSpan = _buffer.AsSpan(_offset);
@@ -311,7 +266,7 @@ namespace Parlot
                 }
             }
 
-            // StringComparison.Orinal is an optimized code path in Span.StartsWith
+            // StringComparison.Ordinal is an optimized code path in Span.StartsWith
 
             return bufferSpan.StartsWith(sSpan, comparisonType);
         }

--- a/test/Parlot.Tests/CursorTests.cs
+++ b/test/Parlot.Tests/CursorTests.cs
@@ -269,28 +269,6 @@ namespace Parlot.Tests
         }
 
         [Fact]
-        public void MatchAnyShouldMatchAny()
-        {
-            var c = new Cursor("1234");
-
-            Assert.Throws<ArgumentNullException>(() => c.MatchAny(null));
-
-            Assert.True(c.MatchAny(Array.Empty<char>()));
-            Assert.True(c.MatchAny('1'));
-            Assert.True(c.MatchAny('a', 'b', 'c', '1'));
-            Assert.True(c.MatchAny('1', '2', '3'));
-            Assert.False(c.MatchAny('a', 'b', 'c'));
-
-            c.ResetPosition(new TextPosition(4, 0, 0));
-
-            Assert.False(c.MatchAny('\0'));
-            Assert.False(c.MatchAny('1'));
-            Assert.False(c.MatchAny('a', 'b', 'c', '1'));
-            Assert.False(c.MatchAny('1', '2', '3'));
-            Assert.False(c.MatchAny('a', 'b', 'c'));
-        }
-
-        [Fact]
         public void MatchShouldMatch()
         {
             var c = new Cursor("1234");

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -188,12 +188,32 @@ namespace Parlot.Tests
 
         [Theory]
         [InlineData(" 1")]
+        public void ShouldNotReadInvalidInteger(string text)
+        {
+            Assert.False(new Scanner(text).ReadInteger());
+        }
+
+        [Theory]
+        [InlineData("1", "1")]
+        [InlineData("123", "123")]
+        [InlineData("123a", "123")]
+        [InlineData("123.0", "123")]
+        [InlineData("123.0a", "123")]
+        [InlineData("123 ", "123")]
+        public void ShouldReadValidInteger(string text, string expected)
+        {
+            Assert.True(new Scanner(text).ReadInteger(out var result));
+            Assert.Equal(expected, result.GetText());
+        }
+
+        [Theory]
+        [InlineData(" 1")]
         [InlineData("123.")]
         public void ShouldNotReadInvalidDecimal(string text)
         {
             Assert.False(new Scanner(text).ReadDecimal());
         }
-
+        
         [Theory]
         [InlineData("'a\nb' ", "'a\nb'")]
         [InlineData("'a\r\nb' ", "'a\r\nb'")]


### PR DESCRIPTION
And remove `char[]` overload which is not used and slower.

```
| Method      | Mean     | Error     | StdDev    | Allocated |
|------------ |---------:|----------:|----------:|----------:|
| MatchAnyOf  | 2.219 ns | 0.2854 ns | 0.0156 ns |         - |
| MatchAnyOf2 | 1.436 ns | 0.2393 ns | 0.0131 ns |         - |
```