### PR TITLE
Add support bell char and decode null char

### DIFF
--- a/src/Parlot/Character.cs
+++ b/src/Parlot/Character.cs
@@ -116,6 +116,8 @@ namespace Parlot
                             case '\'': c = '\''; break;
                             case '"': c = '\"'; break;
                             case '\\': c = '\\'; break;
+                            case '0': c = '\0'; break;
+                            case 'a': c = '\a'; break;
                             case 'b': c = '\b'; break;
                             case 'f': c = '\f'; break;
                             case 'n': c = '\n'; break;

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -384,6 +384,7 @@ namespace Parlot
                     {
                         case '0':
                         case '\\':
+                        case 'a':
                         case 'b':
                         case 'f':
                         case 'n':

--- a/test/Parlot.Tests/CharacterTests.cs
+++ b/test/Parlot.Tests/CharacterTests.cs
@@ -14,6 +14,8 @@ namespace Parlot.Tests
         [InlineData(" \\xa0 ", " \xa0 ")]
         [InlineData(" \\xfh ", " \xfh ")]
         [InlineData(" \u03B2 ", " β ")]
+        [InlineData(" \\a ", " \a ")]
+        [InlineData(" \\0hello ", " \0hello ")]
 
         public void ShouldDescodeString(string text, string expected)
         {

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -36,6 +36,7 @@ namespace Parlot.Tests
         [InlineData("\"Lo\\trem \\n ipsum\"", "\"Lo\\trem \\n ipsum\"")]
         [InlineData("'Lorem \\u1234 ipsum'", "'Lorem \\u1234 ipsum'")]
         [InlineData("'Lorem \\xabcd ipsum'", "'Lorem \\xabcd ipsum'")]
+        [InlineData("'\\a ding'", "'\\a ding'")]
         public void ShouldReadStringWithEscapes(string text, string expected)
         {
             Scanner s = new(text);


### PR DESCRIPTION
Hi, to avoid breaking changes in moving one of my old antler parsers I need to support the bell char and have the null char decoded.

This PR add support for that. There are probably other chars that are valid that might be worth adding.

Or perhaps a way to add extra valid chars to a string.