### PR TITLE
Fix `ElseError` example in documentation

### DIFF
--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -660,15 +660,15 @@ Usage:
 var parser = 
     Terms.Char('a')
     .Or(Terms.Char('b')
-    .Or(Terms.Char('c').Error("Unexpected char c")
+    .Or(Terms.Char('c').Error("Unexpected char c")));
 
-parser.Parse("1,");
+parser.Parse("c");
 ```
 
 Result:
 
 ```
-failure: "Expected an integer at (1:3)
+failure: "Unexpected char c"
 ```
 ### When
 


### PR DESCRIPTION
This PR fixes the `ElseError` example in the documentation, which was syntactically incorrect and also did not demonstrate the expected result/output.
