### PR TITLE
Remove unnecessary `ref` modifier on `ParseResult<>`

### DIFF
--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace Parlot
 {
-    public ref struct ParseResult<T>
+    public struct ParseResult<T>
     {
         public ParseResult(int start, int end, T value)
         {


### PR DESCRIPTION
This PR removes the `ref` modifier on `ParseResult<>` that seems to be unused and unnecessarily could post restrictions on usage. Its removal does not seem to have any bearing on the compiled code:

```diff
--- .\before.il
+++ .\after.il
@@ -1678,17 +1678,6 @@
 .class public sequential ansi sealed beforefieldinit Parlot.ParseResult`1<T>
 	extends [netstandard]System.ValueType
 {
-	.custom instance void [netstandard]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
-		01 00 00 00
-	)
-	.custom instance void [netstandard]System.ObsoleteAttribute::.ctor(string, bool) = (
-		01 00 52 54 79 70 65 73 20 77 69 74 68 20 65 6d
-		62 65 64 64 65 64 20 72 65 66 65 72 65 6e 63 65
-		73 20 61 72 65 20 6e 6f 74 20 73 75 70 70 6f 72
-		74 65 64 20 69 6e 20 74 68 69 73 20 76 65 72 73
-		69 6f 6e 20 6f 66 20 79 6f 75 72 20 63 6f 6d 70
-		69 6c 65 72 2e 01 00 00
-	)
 	// Fields
 	.field public int32 Start
 	.field public int32 End
@@ -58420,8 +58409,8 @@
 
 
 	// Fields
-	.field assembly static initonly valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=256' '21244F82B210125632917591768F6BF22EB6861F80C6C25A25BD26DFB580EA7B' at I_00035F48
-	.data cil I_00035F48 = bytearray (
+	.field assembly static initonly valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=256' '21244F82B210125632917591768F6BF22EB6861F80C6C25A25BD26DFB580EA7B' at I_00035E98
+	.data cil I_00035E98 = bytearray (
 		ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 		ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 		ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
@@ -58439,8 +58428,8 @@
 		ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 		ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff
 	)
-	.field assembly static initonly valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=65535' '6413BECF20AD55EDE9309EA4BBE5B6097EE9EF531DF5A5096BD52D6DA032745C' at I_00036048
-	.data cil I_00036048 = bytearray (
+	.field assembly static initonly valuetype '<PrivateImplementationDetails>'/'__StaticArrayInitTypeSize=65535' '6413BECF20AD55EDE9309EA4BBE5B6097EE9EF531DF5A5096BD52D6DA032745C' at I_00035F98
+	.data cil I_00035F98 = bytearray (
 		00 00 00 00 00 00 00 00 00 0c 08 08 00 08 00 00
 		00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
 		0c 00 00 00 03 00 00 00 00 00 00 00 00 00 00 00
```

The above delta was produced as follows (commit f1586c898402f7056152a8012803db470ceee849 below was the head of `main` at time of opening this PR):

    dotnet new tool-manifest
    dotnet tool install ilspycmd --version 8.2.0.7535
    git checkout f1586c898402f7056152a8012803db470ceee849
    dotnet build -c Release src/Parlot
    dotnet ilspycmd -il src/Parlot/bin/Release/netstandard2.1\Parlot.dll > before.il
    git checkout ParseResult-x-ref
    dotnet build -c Release src/Parlot
    dotnet ilspycmd -il src/Parlot/bin/Release/netstandard2.1\Parlot.dll > after.il
    diff -u before.il after.il
