### PR TITLE
Added `ExpressionHelper.TextSpan_ToString` to prevent multiple copies at `NumberLiteralBase<T>`

### DIFF
--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -31,8 +31,10 @@ public static class ExpressionHelper
 
     internal static readonly ConstructorInfo TextSpan_Constructor = typeof(TextSpan).GetConstructor([typeof(string), typeof(int), typeof(int)])!;
 
+    internal static readonly MethodInfo TextSpan_ToString = typeof(ReadOnlySpan<char>).GetMethod(nameof(ToString), [])!;
+    
     internal static readonly MethodInfo MemoryExtensions_AsSpan = typeof(MemoryExtensions).GetMethod(nameof(MemoryExtensions.AsSpan), [typeof(string)])!;
-
+    
     public static Expression ArrayEmpty<T>() => ((Expression<Func<object>>)(() => Array.Empty<T>())).Body;
     public static Expression New<T>() where T : new() => ((Expression<Func<T>>)(() => new T())).Body;
 

--- a/src/Parlot/Fluent/NumberLiteralBase.cs
+++ b/src/Parlot/Fluent/NumberLiteralBase.cs
@@ -14,7 +14,6 @@ namespace Parlot.Fluent;
 public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable
 {
     private static readonly MethodInfo _defaultTryParseMethodInfo = typeof(T).GetMethod("TryParse", [typeof(string), typeof(NumberStyles), typeof(IFormatProvider), typeof(T).MakeByRefType()])!;
-    private static readonly MethodInfo _rosToString = typeof(ReadOnlySpan<char>).GetMethod(nameof(ToString), [])!;
 
     private readonly char _decimalSeparator;
     private readonly char _groupSeparator;
@@ -25,8 +24,6 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
     private readonly bool _allowExponent;
-
-    private delegate (bool, T) TryParseDelegate();
 
     public abstract bool TryParseNumber(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out T value);
 
@@ -115,7 +112,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable
                     Expression.Assign(result.Success,
                         Expression.Call(
                             _tryParseMethodInfo,
-                            Expression.Call(numberSpan, _rosToString),
+                            Expression.Call(numberSpan, ExpressionHelper.TextSpan_ToString),
                             numberStyles,
                             culture,
                             result.Value)


### PR DESCRIPTION
https://www.jetbrains.com/help/rider/StaticMemberInGenericType.html