### PR TITLE
Optimize TextBefore

### DIFF
--- a/src/Parlot/Fluent/OneOf.cs
+++ b/src/Parlot/Fluent/OneOf.cs
@@ -1,4 +1,4 @@
-﻿using Parlot.Compilation;
+using Parlot.Compilation;
 using Parlot.Rewriting;
 using System;
 using System.Collections.Generic;
@@ -52,14 +52,18 @@ public sealed class OneOf<T> : Parser<T>, ICompilable, ISeekable
             {
                 // If all parsers have the same first char, no need to use a lookup table
 
+                ExpectedChars = lookupTable!.Keys.ToArray();
+                CanSeek = true;
                 lookupTable = null;
             }
-            else if (_parsers.All(x => x is ISeekable seekable && seekable.SkipWhitespace))
+
+            if (_parsers.All(x => x is ISeekable seekable && seekable.SkipWhitespace))
             {
                 // All parsers can start with white spaces
                 SkipWhitespace = true;
             }
-            else if (_parsers.Any(x => x is ISeekable seekable && seekable.SkipWhitespace))
+
+            if (_parsers.Any(x => x is ISeekable seekable && seekable.SkipWhitespace))
             {
                 // If not all parsers accept a white space, we can't use a lookup table since the order matters
 

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Parlot.Fluent;
 
@@ -43,8 +43,19 @@ public class ParseContext
     /// </summary>
     public Parser<TextSpan>? WhiteSpaceParser { get; set; }
 
+    private int _cacheOffset = -1;
+    private TextPosition _cachePosition;
+
     public void SkipWhiteSpace()
     {
+        var offset = Scanner.Cursor.Position.Offset;
+
+        if (offset == _cacheOffset)
+        {
+            Scanner.Cursor.ResetPosition(_cachePosition);
+            return;
+        }
+
         if (WhiteSpaceParser is null)
         {
             if (UseNewLines)
@@ -61,6 +72,9 @@ public class ParseContext
             ParseResult<TextSpan> _ = default;
             WhiteSpaceParser.Parse(this, ref _);
         }
+
+        _cacheOffset = offset;
+        _cachePosition = Scanner.Cursor.Position;
     }
 
     /// <summary>

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -46,13 +46,8 @@ public class Scanner
 
             if (!Character.IsWhiteSpaceOrNewLine(c))
             {
-                if (i > 0)
-                {
-                    Cursor.Advance(i);
-                    return true;
-                }
-
-                return false;
+                Cursor.Advance(i);
+                return true;
             }
         }
 

--- a/test/Parlot.Benchmarks/SkipWhiteSpaceBenchmarks.cs
+++ b/test/Parlot.Benchmarks/SkipWhiteSpaceBenchmarks.cs
@@ -84,18 +84,18 @@ public class SkipWhiteSpaceBenchmarks
         var index = span.IndexOfAnyExcept(SearchValuesHelper._whiteSpaces);
 
         // Only spaces ?
-        if (index == -1)
+        // Not tracking new lines since we know these are only spaces
+        switch (index)
         {
-            // Not tracking new lines since we know these are only spaces
-            cursor.AdvanceNoNewLines(span.Length);
+            case 0:
+                return false;
+            case -1:
+                cursor.AdvanceNoNewLines(span.Length);
+                return true;
+            default:
+                cursor.AdvanceNoNewLines(index);
+                return true;
         }
-        else
-        {
-            // Not tracking new lines since we know these are only spaces
-            cursor.AdvanceNoNewLines(index);
-        }
-
-        return true;
     }
 
     [Benchmark, BenchmarkCategory("Vectorized")]
@@ -114,16 +114,17 @@ public class SkipWhiteSpaceBenchmarks
         var index = span.IndexOfAnyExcept(SearchValuesHelper._whiteSpaceOrNewLines);
 
         // Only spaces ?
-        if (index == -1)
+        switch (index)
         {
-            cursor.Advance(span.Length);
+            case 0:
+                return false;
+            case -1:
+                cursor.Advance(span.Length);
+                return true;
+            default:
+                cursor.Advance(index);
+                return true;
         }
-        else
-        {
-            cursor.Advance(index);
-        }
-
-        return true;
     }
 
     [Benchmark, BenchmarkCategory("PeekSearchValue")]

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -122,6 +122,7 @@ public class ScannerTests
         Assert.True(s.Cursor.Eof);
 
         Assert.False(new Scanner("a").SkipWhiteSpaceOrNewLine());
+        Assert.False(new Scanner("a").SkipWhiteSpace());
     }
 
     [Fact]


### PR DESCRIPTION
Benchmarked with Fluid where it showed to be the issue while looking into SkipWhiteSpace. TextBefore would run the parser then advance 1 character, run it again, until the parser matched. Now if the parser implements `ISeekable` it will jump directly to the first char that could succeed.

This was important in Fluid since it seeks `{%` or `{{` for a tag start, and would then just run the parse for every single character before that. This results in at least 30% improvement in parsing in Liquid.
