### PR TITLE
Fix high memory consumption

### DIFF
--- a/src/Parlot/Fluent/Between.cs
+++ b/src/Parlot/Fluent/Between.cs
@@ -23,8 +23,6 @@ public sealed class Between<A, T, B> : Parser<T>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"Between({before.Name},{parser.Name},{after.Name})";
     }
 
     public bool CanSeek { get; }
@@ -144,4 +142,7 @@ public sealed class Between<A, T, B> : Parser<T>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => Name ?? $"Between({_before},{_parser},{_after})";
+
 }

--- a/src/Parlot/Fluent/Capture.cs
+++ b/src/Parlot/Fluent/Capture.cs
@@ -10,7 +10,6 @@ public sealed class Capture<T> : Parser<TextSpan>, ICompilable
     public Capture(Parser<T> parser)
     {
         _parser = parser;
-        Name = $"{parser.Name} (Capture)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
@@ -87,4 +86,6 @@ public sealed class Capture<T> : Parser<TextSpan>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Capture)";
 }

--- a/src/Parlot/Fluent/CharLiteral.cs
+++ b/src/Parlot/Fluent/CharLiteral.cs
@@ -9,8 +9,7 @@ public sealed class CharLiteral : Parser<char>, ICompilable, ISeekable
     public CharLiteral(char c)
     {
         Char = c;
-        ExpectedChars = [c];
-        Name = $"Char('{c}')";
+        ExpectedChars = new[] { c };
     }
 
     public char Char { get; }
@@ -45,12 +44,6 @@ public sealed class CharLiteral : Parser<char>, ICompilable, ISeekable
     {
         var result = context.CreateCompilationResult<char>();
 
-        // if (context.Scanner.ReadChar(Char))
-        // {
-        //     success = true;
-        //     value = Char;
-        // }
-
         result.Body.Add(
             Expression.IfThen(
                 context.ReadChar(Char),
@@ -65,4 +58,6 @@ public sealed class CharLiteral : Parser<char>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"Char('{Char}')";
 }

--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -2,6 +2,7 @@ using FastExpressionCompiler;
 using Parlot.Compilation;
 using Parlot.Rewriting;
 using System;
+
 #if NET
 using System.Linq;
 #endif
@@ -19,7 +20,6 @@ public sealed class Deferred<T> : Parser<T>, ICompilable, ISeekable
         set
         {
             _parser = value ?? throw new ArgumentNullException(nameof(value));
-            Name = $"{_parser.Name} (Deferred)";
         }
     }
 
@@ -31,7 +31,6 @@ public sealed class Deferred<T> : Parser<T>, ICompilable, ISeekable
 
     public Deferred()
     {
-        Name = "Deferred";
     }
 
     public Deferred(Func<Deferred<T>, Parser<T>> parser) : this()
@@ -148,5 +147,29 @@ public sealed class Deferred<T> : Parser<T>, ICompilable, ISeekable
         );
 
         return result;
+    }
+
+    private bool _toString;
+
+    public override string ToString()
+    {
+        // Handle recursion
+
+        lock (this)
+        {
+            if (!_toString)
+            {
+                _toString = true;
+                var result = Name == null
+                    ? $"{Parser} (Deferred)"
+                    : $"{Name} (Deferred)";
+                _toString = false;
+                return result;
+            }
+            else
+            {
+                return "(Deferred)";
+            }
+        }
     }
 }

--- a/src/Parlot/Fluent/Discard.cs
+++ b/src/Parlot/Fluent/Discard.cs
@@ -15,8 +15,6 @@ public sealed class Discard<T, U> : Parser<U>, ICompilable
     {
         _parser = parser;
         _value = value;
-
-        Name = $"{parser.Name} (Discard)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<U> result)
@@ -60,4 +58,6 @@ public sealed class Discard<T, U> : Parser<U>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Discard)";
 }

--- a/src/Parlot/Fluent/Else.cs
+++ b/src/Parlot/Fluent/Else.cs
@@ -29,8 +29,6 @@ public sealed class Else<T> : Parser<T>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"{parser.Name} (Else)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -81,4 +79,6 @@ public sealed class Else<T> : Parser<T>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Else)";
 }

--- a/src/Parlot/Fluent/Eof.cs
+++ b/src/Parlot/Fluent/Eof.cs
@@ -13,7 +13,6 @@ public sealed class Eof<T> : Parser<T>, ICompilable
     public Eof(Parser<T> parser)
     {
         _parser = parser;
-        Name = $"{parser.Name} (Eof)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -62,4 +61,6 @@ public sealed class Eof<T> : Parser<T>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Eof)";
 }

--- a/src/Parlot/Fluent/Error.cs
+++ b/src/Parlot/Fluent/Error.cs
@@ -30,8 +30,6 @@ public sealed class ElseError<T> : Parser<T>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"{parser.Name} (ElseError)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -90,6 +88,8 @@ public sealed class ElseError<T> : Parser<T>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (ElseError)";
 }
 
 public sealed class Error<T> : Parser<T>, ICompilable
@@ -101,8 +101,6 @@ public sealed class Error<T> : Parser<T>, ICompilable
     {
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         _message = message;
-
-        Name = $"{parser.Name} (Error)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -149,6 +147,8 @@ public sealed class Error<T> : Parser<T>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Error)";
 }
 
 public sealed class Error<T, U> : Parser<U>, ICompilable, ISeekable
@@ -173,8 +173,6 @@ public sealed class Error<T, U> : Parser<U>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"{parser.Name} (Error)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<U> result)
@@ -222,4 +220,6 @@ public sealed class Error<T, U> : Parser<U>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (Error)";
 }

--- a/src/Parlot/Fluent/If.cs
+++ b/src/Parlot/Fluent/If.cs
@@ -24,8 +24,6 @@ public sealed class If<C, S, T> : Parser<T>, ICompilable where C : ParseContext
         _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
         _state = state;
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
-
-        Name = $"{parser.Name} (If)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -107,4 +105,6 @@ public sealed class If<C, S, T> : Parser<T>, ICompilable where C : ParseContext
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (If)";
 }

--- a/src/Parlot/Fluent/ListOfCharsLiteral.cs
+++ b/src/Parlot/Fluent/ListOfCharsLiteral.cs
@@ -32,8 +32,6 @@ internal sealed class ListOfChars : Parser<TextSpan>, ISeekable
         ExpectedChars = values.ToCharArray();
         _minSize = minSize;
         _maxSize = maxSize;
-
-        Name = $"AnyOf({values})";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
@@ -77,5 +75,7 @@ internal sealed class ListOfChars : Parser<TextSpan>, ISeekable
         context.ExitParser(this);
         return true;
     }
+
+    public override string ToString() => $"AnyOf([{string.Join(", ", ExpectedChars)}])";
 }
 #endif

--- a/src/Parlot/Fluent/Not.cs
+++ b/src/Parlot/Fluent/Not.cs
@@ -11,8 +11,6 @@ public sealed class Not<T> : Parser<T>, ICompilable
     public Not(Parser<T> parser)
     {
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
-
-        Name = $"Not ({parser.Name}";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -71,4 +69,6 @@ public sealed class Not<T> : Parser<T>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"Not ({_parser})";
 }

--- a/src/Parlot/Fluent/OneOf.ABT.cs
+++ b/src/Parlot/Fluent/OneOf.ABT.cs
@@ -15,8 +15,6 @@ public sealed class OneOf<A, B, T> : Parser<T>, ICompilable
     {
         _parserA = parserA ?? throw new ArgumentNullException(nameof(parserA));
         _parserB = parserB ?? throw new ArgumentNullException(nameof(parserB));
-
-        Name = $"OneOf ({parserA.Name}, {parserB.Name})";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -105,4 +103,6 @@ public sealed class OneOf<A, B, T> : Parser<T>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parserA} | {_parserB}";
 }

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -22,8 +22,6 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeeka
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"OneOrMany({parser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -127,4 +125,6 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeeka
 
         return result;
     }
+
+    public override string ToString() => $"{_parser}+";
 }

--- a/src/Parlot/Fluent/Parser.TryParse.cs
+++ b/src/Parlot/Fluent/Parser.TryParse.cs
@@ -7,6 +7,9 @@ public abstract partial class Parser<T>
     private int _invocations;
     private volatile Parser<T>? _compiledParser;
 
+    /// <summary>
+    /// Gets or sets the text which is to render the textual representation of the parser.
+    /// </summary>
     public string? Name { get; set; }
 
     public T? Parse(string text)

--- a/src/Parlot/Fluent/Parser.cs
+++ b/src/Parlot/Fluent/Parser.cs
@@ -58,7 +58,7 @@ public abstract partial class Parser<T>
     /// </summary>
     public Parser<T> Named(string name)
     {
-        this.Name = name;
+        Name = name;
         return this;
     }
 

--- a/src/Parlot/Fluent/SearchValuesCharLiteral.cs
+++ b/src/Parlot/Fluent/SearchValuesCharLiteral.cs
@@ -22,7 +22,6 @@ internal sealed class SearchValuesCharLiteral : Parser<TextSpan>, ISeekable
         _searchValues = searchValues ?? throw new ArgumentNullException(nameof(searchValues));
         _minSize = minSize;
         _maxSize = maxSize;
-        Name = $"AnyOf({searchValues})";
     }
 
     public SearchValuesCharLiteral(ReadOnlySpan<char> searchValues, int minSize = 1, int maxSize = 0)
@@ -33,7 +32,6 @@ internal sealed class SearchValuesCharLiteral : Parser<TextSpan>, ISeekable
 
         CanSeek = true;
         ExpectedChars = searchValues.ToArray();
-        Name = $"AnyOf('{searchValues}')";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
@@ -82,5 +80,7 @@ internal sealed class SearchValuesCharLiteral : Parser<TextSpan>, ISeekable
         context.ExitParser(this);
         return true;
     }
+
+    public override string ToString() => $"AnyOf({_searchValues})";
 }
 #endif

--- a/src/Parlot/Fluent/Seekable.cs
+++ b/src/Parlot/Fluent/Seekable.cs
@@ -25,8 +25,6 @@ internal sealed class Seekable<T> : Parser<T>, ISeekable
         ExpectedChars = expectedChars.ToArray().Distinct().ToArray();
         SkipWhitespace = skipWhiteSpace;
         CanSeek = true;
-
-        Name = $"{parser.Name} (Seekable)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -54,5 +52,7 @@ internal sealed class Seekable<T> : Parser<T>, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{Parser} (Seekable)";
 }
 

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -25,7 +25,6 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ICompilable, ISe
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-        Name = $"Separated({separator.Name}, {parser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -188,4 +187,6 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ICompilable, ISe
 
         return result;
     }
+
+    public override string ToString() => $"Separated({_separator}, {_parser})";
 }

--- a/src/Parlot/Fluent/Sequence.cs
+++ b/src/Parlot/Fluent/Sequence.cs
@@ -20,8 +20,6 @@ public sealed class Sequence<T1, T2> : Parser<ValueTuple<T1, T2>>, ICompilable, 
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser1.Name}, {parser2.Name})";
     }
 
     public bool CanSeek { get; }
@@ -70,6 +68,8 @@ public sealed class Sequence<T1, T2> : Parser<ValueTuple<T1, T2>>, ICompilable, 
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser1} & {_parser2}";
 }
 
 public sealed class Sequence<T1, T2, T3> : Parser<ValueTuple<T1, T2, T3>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -91,8 +91,6 @@ public sealed class Sequence<T1, T2, T3> : Parser<ValueTuple<T1, T2, T3>>, IComp
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -134,6 +132,8 @@ public sealed class Sequence<T1, T2, T3> : Parser<ValueTuple<T1, T2, T3>>, IComp
         return false;
     }
 
+    public override string ToString() => $"{_parser} & {_lastParser} ";
+
     public SkippableCompilationResult[] BuildSkippableParsers(CompilationContext context)
     {
         if (_parser is not ISkippableSequenceParser sequenceParser)
@@ -166,8 +166,6 @@ public sealed class Sequence<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T3, T4>
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -224,6 +222,8 @@ public sealed class Sequence<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T3, T4>
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} ";
 }
 
 public sealed class Sequence<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3, T4, T5>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -242,8 +242,6 @@ public sealed class Sequence<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3,
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -301,6 +299,8 @@ public sealed class Sequence<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3,
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} ";
 }
 
 public sealed class Sequence<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -319,8 +319,6 @@ public sealed class Sequence<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2,
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -380,6 +378,8 @@ public sealed class Sequence<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2,
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} ";
 }
 
 public sealed class Sequence<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -398,8 +398,6 @@ public sealed class Sequence<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1,
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"And({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -460,4 +458,6 @@ public sealed class Sequence<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1,
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} ";
 }

--- a/src/Parlot/Fluent/SequenceAndSkip.cs
+++ b/src/Parlot/Fluent/SequenceAndSkip.cs
@@ -22,8 +22,6 @@ public sealed class SequenceAndSkip<T1, T2> : Parser<T1>, ICompilable, ISkippabl
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser1.Name}, {parser2.Name})";
     }
 
     public bool CanSeek { get; }
@@ -129,6 +127,8 @@ public sealed class SequenceAndSkip<T1, T2> : Parser<T1>, ICompilable, ISkippabl
 
         return result;
     }
+
+    public override string ToString() => $"{_parser1} & (skip) {_parser2}";
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3> : Parser<ValueTuple<T1, T2>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -150,8 +150,6 @@ public sealed class SequenceAndSkip<T1, T2, T3> : Parser<ValueTuple<T1, T2>>, IC
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -206,6 +204,9 @@ public sealed class SequenceAndSkip<T1, T2, T3> : Parser<ValueTuple<T1, T2>>, IC
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
+
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T3>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -224,8 +225,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, 
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -281,6 +280,8 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, 
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3, T4>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -299,8 +300,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, 
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -357,6 +356,9 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, 
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
+
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2, T3, T4, T5>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -375,8 +377,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -436,6 +436,8 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -454,8 +456,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTu
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -463,7 +463,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTu
     public char[] ExpectedChars { get; } = [];
 
     public bool SkipWhitespace { get; }
-
 
     public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4, T5, T6>> result)
     {
@@ -516,6 +515,9 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTu
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
+
 }
 
 public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6, T7>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -534,8 +536,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<Val
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"AndSkip({parser.Name}, {lastParser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -543,7 +543,6 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<Val
     public char[] ExpectedChars { get; } = [];
 
     public bool SkipWhitespace { get; }
-
 
     public override bool Parse(ParseContext context, ref ParseResult<ValueTuple<T1, T2, T3, T4, T5, T6, T7>> result)
     {
@@ -597,4 +596,7 @@ public sealed class SequenceAndSkip<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<Val
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & (skip) {_lastParser}";
+
 }

--- a/src/Parlot/Fluent/SequenceSkipAnd.cs
+++ b/src/Parlot/Fluent/SequenceSkipAnd.cs
@@ -127,6 +127,8 @@ public sealed class SequenceSkipAnd<T1, T2> : Parser<T2>, ICompilable, ISkippabl
 
         return result;
     }
+
+    public override string ToString() => $"{_parser1} & {_parser2} (skip)";
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3> : Parser<ValueTuple<T1, T3>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -205,6 +207,8 @@ public sealed class SequenceSkipAnd<T1, T2, T3> : Parser<ValueTuple<T1, T3>>, IC
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, T4>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -281,6 +285,9 @@ public sealed class SequenceSkipAnd<T1, T2, T3, T4> : Parser<ValueTuple<T1, T2, 
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
+
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, T2, T3, T5>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -358,6 +365,9 @@ public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5> : Parser<ValueTuple<T1, 
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
+
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<T1, T2, T3, T4, T6>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -437,6 +447,9 @@ public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6> : Parser<ValueTuple<
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
+
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTuple<T1, T2, T3, T4, T5, T7>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -517,6 +530,9 @@ public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6, T7> : Parser<ValueTu
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
+
 }
 
 public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<ValueTuple<T1, T2, T3, T4, T5, T6, T8>>, ICompilable, ISkippableSequenceParser, ISeekable
@@ -598,4 +614,7 @@ public sealed class SequenceSkipAnd<T1, T2, T3, T4, T5, T6, T7, T8> : Parser<Val
     {
         return SequenceCompileHelper.CreateSequenceCompileResult(BuildSkippableParsers(context), context);
     }
+
+    public override string ToString() => $"{_parser} & {_lastParser} (skip)";
+
 }

--- a/src/Parlot/Fluent/SkipWhiteSpace.cs
+++ b/src/Parlot/Fluent/SkipWhiteSpace.cs
@@ -13,8 +13,6 @@ public sealed class SkipWhiteSpace<T> : Parser<T>, ICompilable, ISeekable
     {
         Parser = parser ?? throw new ArgumentNullException(nameof(parser));
 
-        Name = $"{Name} (SkipWhiteSpace)";
-
         if (parser is ISeekable seekable)
         {
             CanSeek = seekable.CanSeek;
@@ -88,4 +86,6 @@ public sealed class SkipWhiteSpace<T> : Parser<T>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{Parser} (Skip WS)";
 }

--- a/src/Parlot/Fluent/Switch.cs
+++ b/src/Parlot/Fluent/Switch.cs
@@ -20,8 +20,6 @@ public sealed class Switch<T, U> : Parser<U>, ICompilable
     {
         _previousParser = previousParser ?? throw new ArgumentNullException(nameof(previousParser));
         _action = action ?? throw new ArgumentNullException(nameof(action));
-
-        Name = $"{previousParser.Name} (Switch)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<U> result)
@@ -116,4 +114,6 @@ public sealed class Switch<T, U> : Parser<U>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_previousParser} (Switch)";
 }

--- a/src/Parlot/Fluent/TextBefore.cs
+++ b/src/Parlot/Fluent/TextBefore.cs
@@ -43,8 +43,6 @@ public sealed class TextBefore<T> : Parser<TextSpan>, ICompilable
 #endif
             _canJumpToNextExpectedChar = true;
         }
-
-        Name = $"TextBefore({delimiter.Name})";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<TextSpan> result)
@@ -272,4 +270,6 @@ public sealed class TextBefore<T> : Parser<TextSpan>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"TextBefore({_delimiter})";
 }

--- a/src/Parlot/Fluent/TextLiteral.cs
+++ b/src/Parlot/Fluent/TextLiteral.cs
@@ -14,8 +14,6 @@ public sealed class TextLiteral : Parser<string>, ICompilable, ISeekable
 
     public TextLiteral(string text, StringComparison comparisonType)
     {
-        Name = $"TextLiteral(\"{text}\")";
-
         Text = text ?? throw new ArgumentNullException(nameof(text));
         _comparisonType = comparisonType;
         _hasNewLines = text.Any(Character.IsNewLine);
@@ -114,4 +112,6 @@ public sealed class TextLiteral : Parser<string>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"Text(\"{Text}\")";
 }

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -29,8 +29,6 @@ public sealed class Then<T, U> : Parser<U>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"{parser.Name} (Then)";
     }
 
     public Then(Parser<T> parser, Func<T, U> action) : this(parser)
@@ -137,4 +135,6 @@ public sealed class Then<T, U> : Parser<U>, ICompilable, ISeekable
 
         return result;
     }
+
+    override public string ToString() => $"{_parser} (Then)";
 }

--- a/src/Parlot/Fluent/When.cs
+++ b/src/Parlot/Fluent/When.cs
@@ -21,16 +21,12 @@ public sealed class When<T> : Parser<T>, ICompilable
     {
         _action = action != null ? (c, t) => action(t) : throw new ArgumentNullException(nameof(action));
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
-
-        Name = $"{parser.Name} (When)";
     }
 
     public When(Parser<T> parser, Func<ParseContext, T, bool> action)
     {
         _action = action ?? throw new ArgumentNullException(nameof(action));
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
-
-        Name = $"{parser.Name} (When)";
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
@@ -99,4 +95,6 @@ public sealed class When<T> : Parser<T>, ICompilable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser} (When)";
 }

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -23,8 +23,6 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeek
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"ZeroOrMany({parser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -143,4 +141,6 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeek
 
         return result;
     }
+
+    public override string ToString() => $"{_parser}*";
 }

--- a/src/Parlot/Fluent/ZeroOrOne.cs
+++ b/src/Parlot/Fluent/ZeroOrOne.cs
@@ -20,8 +20,6 @@ public sealed class ZeroOrOne<T> : Parser<T>, ICompilable, ISeekable
             ExpectedChars = seekable.ExpectedChars;
             SkipWhitespace = seekable.SkipWhitespace;
         }
-
-        Name = $"ZeroOrOne({parser.Name})";
     }
 
     public bool CanSeek { get; }
@@ -76,4 +74,6 @@ public sealed class ZeroOrOne<T> : Parser<T>, ICompilable, ISeekable
 
         return result;
     }
+
+    public override string ToString() => $"{_parser}?";
 }


### PR DESCRIPTION
String representations of the parser were constructed automatically which would generate too many allocations based on the grammar size.