### PR TITLE
Additional support for string literals

### DIFF
--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -32,6 +32,7 @@ public static class ExpressionHelper
     internal static readonly MethodInfo Scanner_ReadDoubleQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDoubleQuotedString), [])!;
     internal static readonly MethodInfo Scanner_ReadQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadQuotedString), [])!;
     internal static readonly MethodInfo Scanner_ReadBacktickString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadBacktickString), [])!;
+    internal static readonly MethodInfo Scanner_ReadCustomString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadQuotedString), [typeof(char[])])!;
 
     internal static readonly MethodInfo Cursor_Advance = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.Advance), [])!;
     internal static readonly MethodInfo Cursor_AdvanceNoNewLines = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.AdvanceNoNewLines), [typeof(int)])!;
@@ -66,6 +67,7 @@ public static class ExpressionHelper
     public static MethodCallExpression ReadSingleQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadSingleQuotedString);
     public static MethodCallExpression ReadDoubleQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadDoubleQuotedString);
     public static MethodCallExpression ReadBacktickString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadBacktickString);
+    public static MethodCallExpression ReadCustomString(this CompilationContext context, Expression expectedChars) => Expression.Call(context.Scanner(), Scanner_ReadCustomString, expectedChars);
     public static MethodCallExpression ReadQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadQuotedString);
     public static MethodCallExpression ReadChar(this CompilationContext context, char c) => Expression.Call(context.Scanner(), Scanner_ReadChar, Expression.Constant(c));
 

--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -31,6 +31,7 @@ public static class ExpressionHelper
     internal static readonly MethodInfo Scanner_ReadSingleQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadSingleQuotedString), [])!;
     internal static readonly MethodInfo Scanner_ReadDoubleQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDoubleQuotedString), [])!;
     internal static readonly MethodInfo Scanner_ReadQuotedString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadQuotedString), [])!;
+    internal static readonly MethodInfo Scanner_ReadBacktickString = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadBacktickString), [])!;
 
     internal static readonly MethodInfo Cursor_Advance = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.Advance), [])!;
     internal static readonly MethodInfo Cursor_AdvanceNoNewLines = typeof(Cursor).GetMethod(nameof(Parlot.Cursor.AdvanceNoNewLines), [typeof(int)])!;
@@ -64,6 +65,7 @@ public static class ExpressionHelper
 
     public static MethodCallExpression ReadSingleQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadSingleQuotedString);
     public static MethodCallExpression ReadDoubleQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadDoubleQuotedString);
+    public static MethodCallExpression ReadBacktickString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadBacktickString);
     public static MethodCallExpression ReadQuotedString(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadQuotedString);
     public static MethodCallExpression ReadChar(this CompilationContext context, char c) => Expression.Call(context.Scanner(), Scanner_ReadChar, Expression.Constant(c));
 

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -115,6 +115,7 @@ public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
             StringLiteralQuotes.Double => context.ReadDoubleQuotedString(),
             StringLiteralQuotes.SingleOrDouble => context.ReadQuotedString(),
             StringLiteralQuotes.Backtick => context.ReadBacktickString(),
+            StringLiteralQuotes.Custom => context.ReadCustomString(Expression.Constant(ExpectedChars)),
             _ => throw new InvalidOperationException()
         };
 

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -10,7 +10,9 @@ public enum StringLiteralQuotes
 {
     Single,
     Double,
-    SingleOrDouble
+    Backtick,
+    SingleOrDouble,
+    Custom
 }
 
 public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
@@ -19,6 +21,7 @@ public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
 
     static readonly char[] SingleQuotes = ['\''];
     static readonly char[] DoubleQuotes = ['\"'];
+    static readonly char[] Backtick = ['`'];
     static readonly char[] SingleOrDoubleQuotes = ['\'', '\"'];
 
     private readonly StringLiteralQuotes _quotes;
@@ -31,9 +34,25 @@ public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
         {
             StringLiteralQuotes.Single => SingleQuotes,
             StringLiteralQuotes.Double => DoubleQuotes,
+            StringLiteralQuotes.Backtick => Backtick,
             StringLiteralQuotes.SingleOrDouble => SingleOrDoubleQuotes,
-            _ => []
+            _ => throw new InvalidOperationException()
         };
+
+        Name = "StringLiteral";
+    }
+
+    public StringLiteral(char quote)
+    {
+        _quotes = quote switch
+        {
+            '\'' => StringLiteralQuotes.Single,
+            '\"' => StringLiteralQuotes.Double,
+            '`' => StringLiteralQuotes.Backtick,
+            _ => StringLiteralQuotes.Custom,
+        };
+
+        ExpectedChars = [quote];
 
         Name = "StringLiteral";
     }
@@ -55,6 +74,8 @@ public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
             StringLiteralQuotes.Single => context.Scanner.ReadSingleQuotedString(),
             StringLiteralQuotes.Double => context.Scanner.ReadDoubleQuotedString(),
             StringLiteralQuotes.SingleOrDouble => context.Scanner.ReadQuotedString(),
+            StringLiteralQuotes.Backtick => context.Scanner.ReadBacktickString(),
+            StringLiteralQuotes.Custom => context.Scanner.ReadQuotedString(ExpectedChars),
             _ => false
         };
 
@@ -93,6 +114,7 @@ public sealed class StringLiteral : Parser<TextSpan>, ICompilable, ISeekable
             StringLiteralQuotes.Single => context.ReadSingleQuotedString(),
             StringLiteralQuotes.Double => context.ReadDoubleQuotedString(),
             StringLiteralQuotes.SingleOrDouble => context.ReadQuotedString(),
+            StringLiteralQuotes.Backtick => context.ReadBacktickString(),
             _ => throw new InvalidOperationException()
         };
 

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -507,6 +507,7 @@ public class Scanner
     {
         return ReadQuotedString('`', out result);
     }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool ReadQuotedString() => ReadQuotedString(out _);
 

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -1,8 +1,6 @@
 using System;
 using Parlot.Fluent;
-using static FastExpressionCompiler.ExpressionCompiler;
 using System.Linq;
-
 
 #if NET8_0_OR_GREATER
 using System.Buffers;
@@ -531,7 +529,7 @@ public class Scanner
     public bool ReadQuotedString(out ReadOnlySpan<char> result) => ReadQuotedString(['\'', '\"'],out result);
 
     /// <summary>
-    /// Reads a string token enclosed in single or double quotes.
+    /// Reads a string token enclosed in quotes or custom characters.
     /// </summary>
     /// <remarks>
     /// This method doesn't escape the string, but only validates its content is syntactically correct.

--- a/test/Parlot.Tests/CompileTests.cs
+++ b/test/Parlot.Tests/CompileTests.cs
@@ -71,6 +71,26 @@ public class CompileTests
     }
 
     [Fact]
+    public void ShouldCompileCustomStringLiterals()
+    {
+        var parser = new StringLiteral('|').Compile();
+
+        var result = parser.Parse("|hello world|");
+
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
+    public void ShouldCompileCustomBacktickStringLiterals()
+    {
+        var parser = new StringLiteral(StringLiteralQuotes.Backtick).Compile();
+
+        var result = parser.Parse("`hello world`");
+
+        Assert.Equal("hello world", result);
+    }
+
+    [Fact]
     public void ShouldCompileOrs()
     {
         var parser = Terms.Text("hello").Or(Terms.Text("world")).Compile();

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -32,6 +32,19 @@ public class ScannerTests
     }
 
     [Theory]
+    [InlineData('`', "`Lorem ipsum`", "`Lorem ipsum`")]
+    [InlineData('|', "|Lorem ipsum|", "|Lorem ipsum|")]
+    [InlineData('\'', "'Lorem ipsum'", "'Lorem ipsum'")]
+    [InlineData('"', "\"Lorem ipsum\"", "\"Lorem ipsum\"")]
+    public void ShouldReadEscapedStringWithCustomMatchingQuotes(char quote, string text, string expected)
+    {
+        Scanner s = new(text);
+        var success = s.ReadQuotedString([quote], out var result);
+        Assert.True(success);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
     [InlineData("'Lorem \\n ipsum'", "'Lorem \\n ipsum'")]
     [InlineData("\"Lorem \\n ipsum\"", "\"Lorem \\n ipsum\"")]
     [InlineData("\"Lo\\trem \\n ipsum\"", "\"Lo\\trem \\n ipsum\"")]
@@ -43,6 +56,21 @@ public class ScannerTests
     {
         Scanner s = new(text);
         var success = s.ReadQuotedString(out var result);
+        Assert.True(success);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData('`', "`Lorem \\n ipsum`", "`Lorem \\n ipsum`")]
+    [InlineData('`', "`Lo\\trem \\n ipsum`", "`Lo\\trem \\n ipsum`")]
+    [InlineData('`', "`Lorem \\u1234 ipsum`", "`Lorem \\u1234 ipsum`")]
+    [InlineData('`', "`Lorem \\xabcd ipsum`", "`Lorem \\xabcd ipsum`")]
+    [InlineData('`', "`\\a ding`", "`\\a ding`")]
+    [InlineData('`', "`Lorem ipsum` \\xabcd", "`Lorem ipsum`")]
+    public void ShouldReadCustomStringWithEscapes(char quote, string text, string expected)
+    {
+        Scanner s = new(text);
+        var success = s.ReadQuotedString([quote], out var result);
         Assert.True(success);
         Assert.Equal(expected, result);
     }
@@ -216,6 +244,20 @@ public class ScannerTests
         Assert.False(new Scanner("\"abcd").ReadDoubleQuotedString());
         Assert.False(new Scanner("abcd\"").ReadDoubleQuotedString());
         Assert.False(new Scanner("\"ab\\\"cd").ReadDoubleQuotedString());
+    }
+
+    [Fact]
+    public void ReadBacktickStringShouldBacktickQuotedStrings()
+    {
+        new Scanner("`abcd`").ReadBacktickString(out var result);
+        Assert.Equal("`abcd`", result);
+
+        new Scanner("`a\\nb`").ReadBacktickString(out result);
+        Assert.Equal("`a\\nb`", result);
+
+        Assert.False(new Scanner("`abcd").ReadBacktickString());
+        Assert.False(new Scanner("abcd`").ReadBacktickString());
+        Assert.False(new Scanner("`ab\\`cd").ReadBacktickString());
     }
 
     [Theory]


### PR DESCRIPTION
This does a combination of options from #194 

- Allows backticks as a quote type
- Allows custom quote types (might not be worth it, I can delete those parts)
- Makes `ReadQuotedString` public so developers can inherit and create custom string literals