### PR TITLE
Fix small bugs

### DIFF
--- a/src/Parlot/Fluent/SearchValuesCharLiteral.cs
+++ b/src/Parlot/Fluent/SearchValuesCharLiteral.cs
@@ -53,7 +53,7 @@ internal sealed class SearchValuesCharLiteral : Parser<TextSpan>, ISeekable
         if (index != -1)
         {
             // Too small?
-            if (index == 0 || index < _minSize)
+            if (index < _minSize)
             {
                 context.ExitParser(this);
                 return false;

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -53,7 +53,7 @@ public class Scanner
             }
         }
 
-        Cursor.AdvanceNoNewLines(span.Length);
+        Cursor.Advance(span.Length);
         return true;
     }
 

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -1105,9 +1105,12 @@ public class FluentTests
     {
         Assert.False(Literals.AnyOf(chars).TryParse(source, out var _));
     }
+
     [Fact]
     public void AnyOfShouldRespectSizeConstraints()
     {
+        Assert.True(Literals.AnyOf("a", minSize: 0).TryParse("aaa", out var r) && r.ToString() == "aaa");
+        Assert.True(Literals.AnyOf("a", minSize: 0).TryParse("bbb", out _));
         Assert.False(Literals.AnyOf("a", minSize: 4).TryParse("aaa", out _));
         Assert.False(Literals.AnyOf("a", minSize: 2).TryParse("ab", out _));
         Assert.False(Literals.AnyOf("a", minSize: 3).TryParse("ab", out _));

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -132,22 +132,29 @@ public class ScannerTests
         // New lines are not considered white spaces
         Scanner s = new("Lorem ipsum   \r\n   ");
 
+        Assert.Equal(1, s.Cursor.Position.Line);
+
         Assert.False(s.SkipWhiteSpace());
+        Assert.Equal(1, s.Cursor.Position.Line);
 
         s.ReadNonWhiteSpace();
 
         Assert.True(s.SkipWhiteSpace());
         Assert.Equal(6, s.Cursor.Position.Offset);
+        Assert.Equal(1, s.Cursor.Position.Line);
 
         s.ReadNonWhiteSpace();
 
         Assert.True(s.SkipWhiteSpace());
         Assert.Equal(14, s.Cursor.Position.Offset);
+        Assert.Equal(1, s.Cursor.Position.Line);
 
         Assert.True(s.SkipWhiteSpaceOrNewLine());
         Assert.Equal(19, s.Cursor.Position.Offset);
+        Assert.Equal(2, s.Cursor.Position.Line);
 
         Assert.True(s.Cursor.Eof);
+        Assert.Equal(2, s.Cursor.Position.Line);
 
         Assert.False(new Scanner("a").SkipWhiteSpaceOrNewLine());
         Assert.False(new Scanner("a").SkipWhiteSpace());


### PR DESCRIPTION
- `AnyOf` should succeed when `minSize` equals 0 even when there is no match.
- `SkipWhiteSpaceOrNewLine` didn't count new lines