### PR TITLE
ZeroOrOne should not be ISeekable, Discard should be

### DIFF
--- a/src/Parlot/Fluent/Discard.cs
+++ b/src/Parlot/Fluent/Discard.cs
@@ -1,4 +1,5 @@
 using Parlot.Compilation;
+using Parlot.Rewriting;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent;
@@ -6,7 +7,7 @@ namespace Parlot.Fluent;
 /// <summary>
 /// Doesn't parse anything and return the default value.
 /// </summary>
-public sealed class Discard<T, U> : Parser<U>, ICompilable
+public sealed class Discard<T, U> : Parser<U>, ICompilable, ISeekable
 {
     private readonly Parser<T> _parser;
     private readonly U _value;
@@ -15,7 +16,20 @@ public sealed class Discard<T, U> : Parser<U>, ICompilable
     {
         _parser = parser;
         _value = value;
+
+        if (parser is ISeekable seekable)
+        {
+            CanSeek = seekable.CanSeek;
+            ExpectedChars = seekable.ExpectedChars;
+            SkipWhitespace = seekable.SkipWhitespace;
+        }
     }
+
+    public bool CanSeek { get; }
+
+    public char[] ExpectedChars { get; } = [];
+
+    public bool SkipWhitespace { get; }
 
     public override bool Parse(ParseContext context, ref ParseResult<U> result)
     {

--- a/src/Parlot/Fluent/ZeroOrOne.cs
+++ b/src/Parlot/Fluent/ZeroOrOne.cs
@@ -1,11 +1,10 @@
 using Parlot.Compilation;
-using Parlot.Rewriting;
 using System;
 using System.Linq.Expressions;
 
 namespace Parlot.Fluent;
 
-public sealed class ZeroOrOne<T> : Parser<T>, ICompilable, ISeekable
+public sealed class ZeroOrOne<T> : Parser<T>, ICompilable
 {
     private readonly Parser<T> _parser;
     private readonly T _defaultValue;
@@ -14,19 +13,7 @@ public sealed class ZeroOrOne<T> : Parser<T>, ICompilable, ISeekable
     {
         _parser = parser ?? throw new ArgumentNullException(nameof(parser));
         _defaultValue = defaultValue;
-        if (_parser is ISeekable seekable)
-        {
-            CanSeek = seekable.CanSeek;
-            ExpectedChars = seekable.ExpectedChars;
-            SkipWhitespace = seekable.SkipWhitespace;
-        }
     }
-
-    public bool CanSeek { get; }
-
-    public char[] ExpectedChars { get; } = [];
-
-    public bool SkipWhitespace { get; }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
     {


### PR DESCRIPTION
The below test fails if you use the `.Then` line but passes if you use `.Discard` instead.

Checking the code, the first bug appears to be that `ZeroOrOne` implements `ISeekable` by copying the child parsers values.
This seems wrong because `ZeroOrOne` succeeds whether the child parser succeeds or not.
I think instead `ZeroOrOne` should not implement `ISeekable`.
(For performance an `And` started from a `ZeroOrOne` could be `ISeekable` if the `ZeroOrOne` child is `ISeekable` and the parser it is being `And`ed to is `ISeekable`, I haven't implemented this)

This bug doesn't show up when you use `.Discard` because `Discard` does not implement `ISeekable`, I think it should implement it by copying the child parsers values (matching the behaviour of `Then`).

```
[Fact]
public void ATest()
{
    var a = Literals.Char('a');
    var b = Literals.Char('b');

    var maybeAAndB = ZeroOrOne(a).And(b);

    var oneOf = OneOf(
        //maybeAAndB.Discard('z'),
        maybeAAndB.Then(_ => 'z'),
        Literals.Char('c')
        );

    Assert.True(maybeAAndB.TryParse("ab", out _));
    Assert.True(oneOf.TryParse("ab", out _));

    Assert.True(maybeAAndB.TryParse("b", out _));
    Assert.True(oneOf.TryParse("b", out _));
}
```

I haven't included the test in the PR, I'm not quite sure where to put it and what form it should take, let me know and I can do it.