### PR TITLE
Support underscores in decimal numbers

### DIFF
--- a/src/Parlot/Character.Mask.cs
+++ b/src/Parlot/Character.Mask.cs
@@ -21,6 +21,8 @@ public static partial class Character
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsDecimalDigit(char ch) => IsInRange(ch, '0', '9');
 
+    public static bool IsDecimalDigitOrUnderscore(char ch) => IsInRange(ch, '0', '9') || ch == '_';
+
     public static bool IsIdentifierStart(char ch)
     {
         return (_characterData[ch] & (byte)CharacterMask.IdentifierStart) != 0;

--- a/src/Parlot/Character.SearchValues.cs
+++ b/src/Parlot/Character.SearchValues.cs
@@ -7,6 +7,7 @@ namespace Parlot;
 public static partial class Character
 {
     internal static readonly SearchValues<char> _decimalDigits = SearchValues.Create(DecimalDigits);
+    internal static readonly SearchValues<char> _decimalDigitsAndUnderscore = SearchValues.Create(DecimalDigits + "_");
     internal static readonly SearchValues<char> _hexDigits = SearchValues.Create(HexDigits);
     internal static readonly SearchValues<char> _identifierStart = SearchValues.Create(DefaultIdentifierStart);
     internal static readonly SearchValues<char> _identifierPart = SearchValues.Create(DefaultIdentifierPart);

--- a/src/Parlot/Compilation/ExpressionHelper.cs
+++ b/src/Parlot/Compilation/ExpressionHelper.cs
@@ -1,9 +1,11 @@
-using Parlot.Fluent;
 using System;
+using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using System.Linq;
+
 using FastExpressionCompiler;
+
+using Parlot.Fluent;
 
 namespace Parlot.Compilation;
 
@@ -22,7 +24,7 @@ public static class ExpressionHelper
     internal static readonly MethodInfo Scanner_ReadText_NoResult = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadText), [typeof(ReadOnlySpan<char>), typeof(StringComparison)])!;
     internal static readonly MethodInfo Scanner_ReadChar = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadChar), [typeof(char)])!;
     internal static readonly MethodInfo Scanner_ReadDecimal = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDecimal), [])!;
-    internal static readonly MethodInfo Scanner_ReadDecimalAllArguments = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDecimal), [typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(ReadOnlySpan<char>).MakeByRefType(), typeof(char), typeof(char)])!;
+    internal static readonly MethodInfo Scanner_ReadDecimalAllArguments = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadDecimal), [typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(bool), typeof(ReadOnlySpan<char>).MakeByRefType(), typeof(char), typeof(char)])!;
     internal static readonly MethodInfo Scanner_ReadInteger = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadInteger), [])!;
     internal static readonly MethodInfo Scanner_ReadNonWhiteSpace = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadNonWhiteSpace), [])!;
     internal static readonly MethodInfo Scanner_ReadNonWhiteSpaceOrNewLine = typeof(Scanner).GetMethod(nameof(Parlot.Scanner.ReadNonWhiteSpaceOrNewLine), [])!;
@@ -87,7 +89,7 @@ public static class ExpressionHelper
             );
     }
     public static MethodCallExpression ReadDecimal(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadDecimal);
-    public static MethodCallExpression ReadDecimal(this CompilationContext context, Expression allowLeadingSign, Expression allowDecimalSeparator, Expression allowGroupSeparator, Expression allowExponent, Expression number, Expression decimalSeparator, Expression groupSeparator) => Expression.Call(context.Scanner(), Scanner_ReadDecimalAllArguments, allowLeadingSign, allowDecimalSeparator, allowGroupSeparator, allowExponent, number, decimalSeparator, groupSeparator);
+    public static MethodCallExpression ReadDecimal(this CompilationContext context, Expression allowLeadingSign, Expression allowDecimalSeparator, Expression allowGroupSeparator, Expression allowExponent, Expression allowUnderscore, Expression number, Expression decimalSeparator, Expression groupSeparator) => Expression.Call(context.Scanner(), Scanner_ReadDecimalAllArguments, allowLeadingSign, allowDecimalSeparator, allowGroupSeparator, allowExponent, allowUnderscore, number, decimalSeparator, groupSeparator);
     public static MethodCallExpression ReadInteger(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadInteger);
     public static MethodCallExpression ReadNonWhiteSpace(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadNonWhiteSpace);
     public static MethodCallExpression ReadNonWhiteSpaceOrNewLine(this CompilationContext context) => Expression.Call(context.Scanner(), Scanner_ReadNonWhiteSpaceOrNewLine);

--- a/src/Parlot/Fluent/NumberLiteral.cs
+++ b/src/Parlot/Fluent/NumberLiteral.cs
@@ -25,6 +25,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
     private readonly bool _allowExponent;
+    private readonly bool _allowUnderscore;
 
     public bool CanSeek { get; } = true;
 
@@ -50,6 +51,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
         _allowDecimalSeparator = (numberOptions & NumberOptions.AllowDecimalSeparator) != 0;
         _allowGroupSeparator = (numberOptions & NumberOptions.AllowGroupSeparators) != 0;
         _allowExponent = (numberOptions & NumberOptions.AllowExponent) != 0;
+        _allowUnderscore = (numberOptions & NumberOptions.AllowUnderscore) != 0;
 
         ExpectedChars = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 
@@ -68,6 +70,11 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
             ExpectedChars = [.. ExpectedChars, groupSeparator];
         }
 
+        if (_allowUnderscore)
+        {
+            ExpectedChars = [.. ExpectedChars, '_'];
+        }
+
         // Exponent can't be a starting char
 
         Name = "NumberLiteral";
@@ -80,7 +87,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
         var reset = context.Scanner.Cursor.Position;
         var start = reset.Offset;
 
-        if (context.Scanner.ReadDecimal(_allowLeadingSign, _allowDecimalSeparator, _allowGroupSeparator, _allowExponent, out var number, _decimalSeparator, _groupSeparator))
+        if (context.Scanner.ReadDecimal(_allowLeadingSign, _allowDecimalSeparator, _allowGroupSeparator, _allowExponent, _allowUnderscore, out var number, _decimalSeparator, _groupSeparator))
         {
             var end = context.Scanner.Cursor.Offset;
 

--- a/src/Parlot/Fluent/NumberLiteral.cs
+++ b/src/Parlot/Fluent/NumberLiteral.cs
@@ -1,11 +1,12 @@
 #if NET8_0_OR_GREATER
-using Parlot.Compilation;
-using Parlot.Rewriting;
 using System;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+
+using Parlot.Compilation;
+using Parlot.Rewriting;
 
 namespace Parlot.Fluent;
 
@@ -141,6 +142,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
                     Expression.Constant(_allowDecimalSeparator),
                     Expression.Constant(_allowGroupSeparator),
                     Expression.Constant(_allowExponent),
+                    Expression.Constant(_allowUnderscore),
                     numberSpan, Expression.Constant(_decimalSeparator), Expression.Constant(_groupSeparator)),
                 Expression.Block(
                     Expression.Assign(end, context.Offset()),

--- a/src/Parlot/Fluent/NumberLiteralBase.cs
+++ b/src/Parlot/Fluent/NumberLiteralBase.cs
@@ -1,10 +1,11 @@
-using Parlot.Compilation;
-using Parlot.Rewriting;
 using System;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Numerics;
 using System.Reflection;
+
+using Parlot.Compilation;
+using Parlot.Rewriting;
 
 namespace Parlot.Fluent;
 
@@ -140,6 +141,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
                     Expression.Constant(_allowDecimalSeparator),
                     Expression.Constant(_allowGroupSeparator),
                     Expression.Constant(_allowExponent),
+                    Expression.Constant(_allowUnderscore),
                     numberSpan, Expression.Constant(_decimalSeparator), Expression.Constant(_groupSeparator)),
                 Expression.Block(
                     Expression.Assign(end, context.Offset()),

--- a/src/Parlot/Fluent/NumberLiteralBase.cs
+++ b/src/Parlot/Fluent/NumberLiteralBase.cs
@@ -25,7 +25,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
     private readonly bool _allowExponent;
-
+    private readonly bool _allowUnderscore;
     public bool CanSeek => true;
 
     public char[] ExpectedChars { get; set; } = [];
@@ -53,6 +53,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         _allowDecimalSeparator = (numberOptions & NumberOptions.AllowDecimalSeparator) != 0;
         _allowGroupSeparator = (numberOptions & NumberOptions.AllowGroupSeparators) != 0;
         _allowExponent = (numberOptions & NumberOptions.AllowExponent) != 0;
+        _allowUnderscore = (numberOptions & NumberOptions.AllowUnderscore) != 0;
 
         var expectedChars = "0123456789";
 
@@ -71,6 +72,11 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
             expectedChars += "eE";
         }
 
+        if (_allowUnderscore)
+        {
+            expectedChars += "_";
+        }
+
         ExpectedChars = expectedChars.ToCharArray();
 
         Name = "NumberLiteral";
@@ -83,7 +89,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         var reset = context.Scanner.Cursor.Position;
         var start = reset.Offset;
 
-        if (context.Scanner.ReadDecimal(_allowLeadingSign, _allowDecimalSeparator, _allowGroupSeparator, _allowExponent, out var number, _decimalSeparator, _groupSeparator))
+        if (context.Scanner.ReadDecimal(_allowLeadingSign, _allowDecimalSeparator, _allowGroupSeparator, _allowExponent, _allowUnderscore, out var number, _decimalSeparator, _groupSeparator))
         {
             var end = context.Scanner.Cursor.Offset;
 

--- a/src/Parlot/Fluent/NumberOptions.cs
+++ b/src/Parlot/Fluent/NumberOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace Parlot.Fluent;
 
@@ -8,7 +8,7 @@ public enum NumberOptions
     /// <summary>
     /// Indicates that no style elements, such as leading sign, thousands
     /// separators, decimal separator or exponent, can be present in the parsed string.
-    /// The string to be parsed must consist of integral decimal digits only.        
+    /// The string to be parsed must consist of integral decimal digits only.
     /// </summary>
     None = 0,
 
@@ -36,6 +36,11 @@ public enum NumberOptions
     /// and an integer.
     /// </summary>
     AllowExponent = 8,
+
+    /// <summary>
+    /// Indicates that the numeric string can include a "whitespace" in the form of an underscore ("_") character.
+    /// </summary>
+    AllowUnderscore = 16,
 
     /// <summary>
     /// Indicates that the <see cref="AllowLeadingSign"/>

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -1,7 +1,8 @@
 using System;
-using Parlot.Fluent;
-using System.Linq;
 
+using Parlot.Fluent;
+
+using System.Linq;
 #if NET8_0_OR_GREATER
 using System.Buffers;
 #endif
@@ -130,7 +131,7 @@ public class Scanner
     public bool ReadDecimal(out ReadOnlySpan<char> number) => ReadDecimal(true, true, false, true, false, out number);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    public bool ReadDecimal(NumberOptions numberOptions, out ReadOnlySpan<char> number, bool allowUnderscore = false, char decimalSeparator = '.', char groupSeparator = ',')
+    public bool ReadDecimal(NumberOptions numberOptions, out ReadOnlySpan<char> number, char decimalSeparator = '.', char groupSeparator = ',')
     {
         return ReadDecimal(
             (numberOptions & NumberOptions.AllowLeadingSign) != 0,

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Buffers;
+
 using Xunit;
 
 namespace Parlot.Tests;
@@ -277,6 +278,16 @@ public class ScannerTests
     public void ShouldReadValidDecimal(string text, string expected)
     {
         Assert.True(new Scanner(text).ReadDecimal(out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("12_3.01", "123.01")]
+    [InlineData("12_3.0_1", "123.01")]
+    [InlineData("12_3", "123")]
+    public void ShouldReadValidDecimalWithUnderscores(string text, string expected)
+    {
+        Assert.True(new Scanner(text).ReadDecimal(Fluent.NumberOptions.AllowUnderscore | Fluent.NumberOptions.Number , out var result));
         Assert.Equal(expected, result);
     }
 


### PR DESCRIPTION
Modern programming languages support underscores in numbers for better readability. The suggested change enables the parser to handle them. This is done by first accepting them as valid “digits” and then cutting them out as the number is returned. Unfortunately, this requires an extra copying step, but it is taken only when the underscores are present. 

A small remark: NumberLiteral.cs and NumberLiteralBase.cs contain changes, but not as many as GitHub shows. 