### PR TITLE
Fix grammar in Optional() copilot-instructions section

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -131,7 +131,7 @@ It is not necessary to wrap `Terms` parsers with `SkipWhitespace()` as they alre
 
 ### `Optional()` usage
 
-Use the `Optional()` combinator to make a parser optional. Returns an instance of `Option<T>` regardless of whether the parser matches or not. Use `HasValue` to check if the parser was successful. Or use `OrSome()` to provide a default value when the parser does not match.
+Use the `Optional()` combinator to make a parser optional. It will always return an instance of `Option<T>` regardless of whether the parser matches or not. Use `HasValue` to check if the parser was successful. Or use `OrSome()` to provide a default value when the parser does not match.
 
 ```c#
 // Parse an integer or return -1 if not present


### PR DESCRIPTION
I noticed this started "If will ..." when catching up on changes