### PR TITLE
Improve performance

### DIFF
--- a/src/Parlot/Fluent/HybridList.cs
+++ b/src/Parlot/Fluent/HybridList.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Parlot.Fluent;
+
+/// <summary>
+/// An internal implementation of IReadOnlyList&lt;T&gt; that stores up to 4 items inline
+/// before switching to a List&lt;T&gt; for growth.
+/// This provides efficient memory usage for small result sets while maintaining
+/// flexibility for larger lists.
+/// </summary>
+#nullable enable
+internal sealed class HybridList<T> : IReadOnlyList<T>
+{
+    private T? _item1;
+    private T? _item2;
+    private T? _item3;
+    private T? _item4;
+    private List<T>? _list;
+    private int _count;
+
+    public int Count => _count;
+
+    public T this[int index]
+    {
+        get
+        {
+            if (index < 0 || index >= _count)
+            {
+                throw new ArgumentOutOfRangeException(nameof(index));
+            }
+
+            if (_list is not null)
+            {
+                return _list[index];
+            }
+
+            return index switch
+            {
+                0 => _item1!,
+                1 => _item2!,
+                2 => _item3!,
+                3 => _item4!,
+                _ => throw new ArgumentOutOfRangeException(nameof(index))
+            };
+        }
+    }
+
+    public void Add(T item)
+    {
+        if (_list is not null)
+        {
+            _list.Add(item);
+            _count++;
+        }
+        else
+        {
+            switch (_count)
+            {
+                case 0:
+                    _item1 = item;
+                    _count++;
+                    break;
+                case 1:
+                    _item2 = item;
+                    _count++;
+                    break;
+                case 2:
+                    _item3 = item;
+                    _count++;
+                    break;
+                case 3:
+                    _item4 = item;
+                    _count++;
+                    break;
+                case 4:
+                    // Transition to List<T>
+                    _list = new List<T>(8) { _item1!, _item2!, _item3!, _item4!, item };
+                    _item1 = default;
+                    _item2 = default;
+                    _item3 = default;
+                    _item4 = default;
+                    _count++;
+                    break;
+                default:
+                    throw new InvalidOperationException("Unexpected count value");
+            }
+        }
+    }
+
+    public IEnumerator<T> GetEnumerator()
+    {
+        if (_list is not null)
+        {
+            return _list.GetEnumerator();
+        }
+
+        return GetEnumeratorInternal();
+    }
+
+    private IEnumerator<T> GetEnumeratorInternal()
+    {
+        if (_count >= 1)
+            yield return _item1!;
+        if (_count >= 2)
+            yield return _item2!;
+        if (_count >= 3)
+            yield return _item3!;
+        if (_count >= 4)
+            yield return _item4!;
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+}

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -42,7 +42,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeeka
         }
 
         var start = parsed.Start;
-        var results = new List<T>();
+        var results = new HybridList<T>();
 
         int end;
 

--- a/src/Parlot/Fluent/ParserExtensions.WhiteSpace.cs
+++ b/src/Parlot/Fluent/ParserExtensions.WhiteSpace.cs
@@ -22,9 +22,20 @@ public static partial class ParserExtensions
     /// <param name="parser">The parser to execute with the custom whitespace parser.</param>
     /// <param name="commentsBuilder">The action to configure the comments builder.</param>
     /// <returns>A parser that uses white spaces, new lines and comments.</returns>
+    /// <remarks>
+    /// Here is an example of usage:
+    /// <code>
+    /// var parserWithComments = myParser.WithComments(comments =>
+    /// {
+    ///     comments.WithWhiteSpaceOrNewLine();
+    ///     comments.WithSingleLine("//");
+    ///     comments.WithMultiLine("/*", "*/");
+    /// });
+    /// </code>
+    /// </remarks>
     public static Parser<T> WithComments<T>(this Parser<T> parser, Action<CommentsBuilder> commentsBuilder)
     {
-        var builder = new CommentsBuilder(Literals.WhiteSpace(includeNewLines: true));
+        var builder = new CommentsBuilder();
         commentsBuilder(builder);
         return new WithWhiteSpaceParser<T>(parser, builder.Build());
     }
@@ -34,23 +45,48 @@ public class CommentsBuilder
 {
     private readonly List<Parser<TextSpan>> _parsers = [];
 
+    [Obsolete("Use CommentsBuilder().WithParser(parser) instead.")]
     public CommentsBuilder(Parser<TextSpan> whiteSpaceParser)
     {
         _parsers.Add(whiteSpaceParser);
     }
 
-    public Parser<TextSpan> WithSingleLine(string singleLineStart)
+    public CommentsBuilder()
+    {
+    }
+
+    public CommentsBuilder WithWhiteSpace()
+    {
+        var parser = Literals.WhiteSpace();
+        _parsers.Add(parser);
+        return this;
+    }
+
+    public CommentsBuilder WithWhiteSpaceOrNewLine()
+    {
+        var parser = Literals.WhiteSpace(includeNewLines: true);
+        _parsers.Add(parser);
+        return this;
+    }
+
+    public CommentsBuilder WithParser(Parser<TextSpan> parser)
+    {
+        _parsers.Add(parser);
+        return this;
+    }
+
+    public CommentsBuilder WithSingleLine(string singleLineStart)
     {
         var parser = Literals.Comments(singleLineStart);
         _parsers.Add(parser);
-        return parser;
+        return this;
     }
 
-    public Parser<TextSpan> WithMultiLine(string multiLineStart, string multiLineEnd)
+    public CommentsBuilder WithMultiLine(string multiLineStart, string multiLineEnd)
     {
         var parser = Literals.Comments(multiLineStart, multiLineEnd);
         _parsers.Add(parser);
-        return parser;
+        return this;
     }
 
     public Parser<TextSpan> Build() 

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -37,7 +37,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ICompilable, ISe
     {
         context.EnterParser(this);
 
-        List<T>? results = null;
+        HybridList<T>? results = null;
 
         var start = 0;
         var end = context.Scanner.Cursor.Position;
@@ -84,7 +84,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ICompilable, ISe
             results!.Add(parsed.Value);
         }
 
-        result.Set(start, end.Offset, results ?? []);
+        result.Set(start, end.Offset, results ?? (IReadOnlyList<T>)[]);
 
         context.ExitParser(this);
         return true;

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -21,7 +21,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable
     {
         context.EnterParser(this);
 
-        List<T>? results = null;
+        HybridList<T>? results = null;
 
         var start = 0;
         var end = 0;
@@ -36,14 +36,14 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable
         {
             if (first)
             {
+                results = [];
                 first = false;
                 start = parsed.Start;
             }
 
             end = parsed.End;
-
-            results ??= [];
-            results.Add(parsed.Value);
+            
+            results!.Add(parsed.Value);
         }
 
         result.Set(start, end, results ?? (IReadOnlyList<T>)[]);

--- a/src/Samples/Sql/SqlAst.cs
+++ b/src/Samples/Sql/SqlAst.cs
@@ -1,6 +1,8 @@
 #nullable enable
 
 using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel.Design;
 using System.Linq;
 
 namespace Parlot.Tests.Sql;
@@ -529,8 +531,12 @@ public class ParameterExpression : Expression
 }
 
 // Identifiers
-public class Identifier : ISqlNode
+public sealed class Identifier : ISqlNode
 {
+    public static readonly Identifier STAR = new (["*"]);
+
+    private string _cachedToString = null!;
+
     public IReadOnlyList<string> Parts { get; }
 
     public Identifier(IReadOnlyList<string> parts)
@@ -538,17 +544,8 @@ public class Identifier : ISqlNode
         Parts = parts;
     }
 
-    public Identifier(string name) : this(new[] { name })
-    {
-    }
-
-    public Identifier(params string[] parts)
-    {
-        Parts = parts.Where(p => !string.IsNullOrWhiteSpace(p)).ToArray();
-    }
-
     public override string ToString()
     {
-        return string.Join(".", Parts);
+        return _cachedToString ??= (Parts.Count == 1 ? Parts[0] : string.Join(".", Parts));
     }
 }

--- a/test/Parlot.Benchmarks/SqlParserBenchmarks.cs
+++ b/test/Parlot.Benchmarks/SqlParserBenchmarks.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Diagnostics.Tracing;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using Microsoft.Diagnostics.NETCore.Client;
+using Microsoft.Diagnostics.Tracing.Parsers;
+using Parlot.Tests.Sql;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, ShortRunJob]
+// [Config(typeof(CustomConfig))]
+public class SqlParserBenchmarks
+{
+    // private class CustomConfig : ManualConfig
+    // {
+    //     public CustomConfig()
+    //     {
+    //         AddJob(Job.ShortRun);
+
+    //         var providers = new[]
+    //         {
+    //             new EventPipeProvider(ClrTraceEventParser.ProviderName, EventLevel.Verbose,
+    //                 (long) (
+    //                 ClrTraceEventParser.Keywords.GCAllObjectAllocation
+    //                 ))
+    //         };
+
+    //         AddDiagnoser(new EventPipeProfiler(providers: providers));
+    //     }
+    // }
+
+    [Params(
+        "select a where a not like '%foo%'"
+        // "select a where b = (select Avg(c) from d)"
+    )]
+    public string Sql { get; set; } = string.Empty;
+
+    [Benchmark]
+    public bool ParseExpression()
+    {
+        var result = SqlParser.TryParse(Sql, out var statementList, out var error);
+
+        if (statementList is null || error is not null)
+        {
+            throw new InvalidOperationException($"Parsing failed: {error}");
+        }
+
+        return result;
+    }
+}

--- a/test/Parlot.Tests/CommentTests.cs
+++ b/test/Parlot.Tests/CommentTests.cs
@@ -101,6 +101,7 @@ public class CommentTests
         var comments = Terms.Text("hello").And(Terms.Text("world"))
             .WithComments(builder =>
             {
+                builder.WithWhiteSpaceOrNewLine();
                 builder.WithSingleLine("--");
                 builder.WithSingleLine("#");
                 builder.WithMultiLine("/*", "*/");

--- a/test/Parlot.Tests/HybridListTests.cs
+++ b/test/Parlot.Tests/HybridListTests.cs
@@ -1,0 +1,299 @@
+using Parlot.Fluent;
+using System.Collections.Generic;
+using Xunit;
+
+#nullable enable
+
+namespace Parlot.Tests;
+
+public class HybridListTests
+{
+    [Fact]
+    public void Empty_InitiallyEmpty()
+    {
+        var list = new HybridList<int>();
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public void Add_SingleItem()
+    {
+        var list = new HybridList<int>();
+        list.Add(1);
+        
+        Assert.Single(list);
+        Assert.Equal(1, list[0]);
+    }
+
+    [Fact]
+    public void Add_FourItems_InlineStorage()
+    {
+        var list = new HybridList<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        list.Add(4);
+
+        Assert.Equal(4, list.Count);
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+        Assert.Equal(4, list[3]);
+    }
+
+    [Fact]
+    public void Add_FiveItems_TransitionsToList()
+    {
+        var list = new HybridList<int>();
+        list.Add(1);
+        list.Add(2);
+        list.Add(3);
+        list.Add(4);
+        list.Add(5);
+
+        Assert.Equal(5, list.Count);
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+        Assert.Equal(4, list[3]);
+        Assert.Equal(5, list[4]);
+    }
+
+    [Fact]
+    public void Add_ManyItems_AfterTransition()
+    {
+        var list = new HybridList<int>();
+        for (int i = 1; i <= 10; i++)
+        {
+            list.Add(i);
+        }
+
+        Assert.Equal(10, list.Count);
+        for (int i = 0; i < 10; i++)
+        {
+            Assert.Equal(i + 1, list[i]);
+        }
+    }
+
+    [Fact]
+    public void Indexer_OutOfRange_ThrowsException()
+    {
+        var list = new HybridList<int>();
+        list.Add(1);
+
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => list[-1]);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => list[1]);
+    }
+
+    [Fact]
+    public void Indexer_OutOfRange_AfterTransition_ThrowsException()
+    {
+        var list = new HybridList<int>();
+        for (int i = 1; i <= 5; i++)
+        {
+            list.Add(i);
+        }
+
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => list[-1]);
+        Assert.Throws<System.ArgumentOutOfRangeException>(() => list[5]);
+    }
+
+    [Fact]
+    public void Enumerate_InlineStorage()
+    {
+        var list = new HybridList<int>();
+        list.Add(10);
+        list.Add(20);
+        list.Add(30);
+
+        var items = new List<int>();
+        foreach (var item in list)
+        {
+            items.Add(item);
+        }
+
+        Assert.Equal(3, items.Count);
+        Assert.Equal(10, items[0]);
+        Assert.Equal(20, items[1]);
+        Assert.Equal(30, items[2]);
+    }
+
+    [Fact]
+    public void Enumerate_AfterTransition()
+    {
+        var list = new HybridList<int>();
+        for (int i = 1; i <= 7; i++)
+        {
+            list.Add(i);
+        }
+
+        var items = new List<int>();
+        foreach (var item in list)
+        {
+            items.Add(item);
+        }
+
+        Assert.Equal(7, items.Count);
+        for (int i = 0; i < 7; i++)
+        {
+            Assert.Equal(i + 1, items[i]);
+        }
+    }
+
+    [Fact]
+    public void GetEnumerator_InlineStorage_Empty()
+    {
+        var list = new HybridList<int>();
+
+        var items = new List<int>();
+        foreach (var item in list)
+        {
+            items.Add(item);
+        }
+
+        Assert.Empty(items);
+    }
+
+    [Fact]
+    public void Add_WithStrings()
+    {
+        var list = new HybridList<string>();
+        list.Add("alpha");
+        list.Add("beta");
+        list.Add("gamma");
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal("alpha", list[0]);
+        Assert.Equal("beta", list[1]);
+        Assert.Equal("gamma", list[2]);
+    }
+
+    [Fact]
+    public void Add_WithNullValues()
+    {
+        var list = new HybridList<string?>();
+        list.Add(null);
+        list.Add("value");
+        list.Add(null);
+
+        Assert.Equal(3, list.Count);
+        Assert.Null(list[0]);
+        Assert.Equal("value", list[1]);
+        Assert.Null(list[2]);
+    }
+
+    [Fact]
+    public void Enumerate_WithNullValues()
+    {
+        var list = new HybridList<string?>();
+        list.Add(null);
+        list.Add("a");
+        list.Add(null);
+        list.Add("b");
+        list.Add(null);
+
+        var items = new List<string?>();
+        foreach (var item in list)
+        {
+            items.Add(item);
+        }
+
+        Assert.Equal(5, items.Count);
+        Assert.Null(items[0]);
+        Assert.Equal("a", items[1]);
+        Assert.Null(items[2]);
+        Assert.Equal("b", items[3]);
+        Assert.Null(items[4]);
+    }
+
+    [Fact]
+    public void Add_LargeCount()
+    {
+        var list = new HybridList<int>();
+        const int count = 1000;
+
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        Assert.Equal(count, list.Count);
+        for (int i = 0; i < count; i++)
+        {
+            Assert.Equal(i, list[i]);
+        }
+    }
+
+    [Fact]
+    public void Enumerate_LargeCount()
+    {
+        var list = new HybridList<int>();
+        const int count = 1000;
+
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        var index = 0;
+        foreach (var item in list)
+        {
+            Assert.Equal(index, item);
+            index++;
+        }
+
+        Assert.Equal(count, index);
+    }
+
+    [Fact]
+    public void IReadOnlyListInterface()
+    {
+        IReadOnlyList<int> list = new HybridList<int>();
+        ((HybridList<int>)(object)list).Add(1);
+        ((HybridList<int>)(object)list).Add(2);
+        ((HybridList<int>)(object)list).Add(3);
+
+        Assert.Equal(3, list.Count);
+        Assert.Equal(1, list[0]);
+        Assert.Equal(2, list[1]);
+        Assert.Equal(3, list[2]);
+
+        var items = new List<int>();
+        foreach (var item in list)
+        {
+            items.Add(item);
+        }
+        Assert.Equal(3, items.Count);
+    }
+
+    [Fact]
+    public void TransitionPoint_ExactlyAtFourItems()
+    {
+        var list = new HybridList<int>();
+        list.Add(100);
+        list.Add(200);
+        list.Add(300);
+        list.Add(400);
+        
+        // Should still use inline storage
+        Assert.Equal(4, list.Count);
+        Assert.Equal(100, list[0]);
+        Assert.Equal(400, list[3]);
+    }
+
+    [Fact]
+    public void TransitionPoint_JustAfterFourItems()
+    {
+        var list = new HybridList<int>();
+        list.Add(100);
+        list.Add(200);
+        list.Add(300);
+        list.Add(400);
+        list.Add(500);
+        
+        // Should have transitioned to List<T>
+        Assert.Equal(5, list.Count);
+        Assert.Equal(100, list[0]);
+        Assert.Equal(500, list[4]);
+    }
+}

--- a/test/Parlot.Tests/Parlot.Tests.csproj
+++ b/test/Parlot.Tests/Parlot.Tests.csproj
@@ -12,6 +12,10 @@
     <ProjectReference Include="..\..\src\Samples\Samples.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="../../src/Parlot/Fluent/HybridList.cs" Link="HybridList.cs" />
+  </ItemGroup>
+
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <ProjectReference Include="../../test/Parlot.Benchmarks/Parlot.Benchmarks.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- Reduce Sql Parser allocations
  - cast to string early to prevent Select/ToArray calls
  - cache and optimize Identifier.ToString
- Implement `ISeekable` on `When`
- Reduce array allocations with `HybridList`
- Refactor Comments builder (limited breaking change)