### PR TITLE
Apply ref modifier to ParseResult structure

### DIFF
--- a/src/Parlot/Fluent/ParseResult.cs
+++ b/src/Parlot/Fluent/ParseResult.cs
@@ -1,6 +1,6 @@
 ﻿namespace Parlot;
 
-public struct ParseResult<T>
+public ref struct ParseResult<T>
 {
     public ParseResult(int start, int end, T value)
     {


### PR DESCRIPTION
Change the `ParseResult` structure to a `ref struct` to ensure the class is not boxed.