### PR TITLE
Speed up hot parsing loops

### DIFF
--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -49,27 +49,34 @@ public sealed class Deferred<T> : Parser<T>, ICompilable, ISeekable
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
     {
-        if (Parser is null)
+        var parser = Parser;
+
+        if (parser is null)
         {
             throw new InvalidOperationException("Parser has not been initialized");
         }
 
-        // Check for infinite recursion at the same position (unless disabled)
-        if (!context.DisableLoopDetection && context.IsParserActiveAtPosition(this))
-        {
-            // Cycle detected at this position - fail gracefully instead of stack overflow
-            return false;
-        }
+        var trackPosition = !context.DisableLoopDetection;
 
         // Remember the position where we entered this parser
-        var entryPosition = context.Scanner.Cursor.Position.Offset;
+        var entryPosition = 0;
 
-        // Mark this parser as active at the current position (unless loop detection is disabled)
-        var trackPosition = !context.DisableLoopDetection && context.PushParserAtPosition(this);
+        if (trackPosition)
+        {
+            entryPosition = context.Scanner.Cursor.Offset;
+
+            // Marking the parser as active also detects a cycle at this position, which saves a lookup
+            // compared to checking for the cycle first.
+            if (!context.PushParserAtPosition(this))
+            {
+                // Cycle detected at this position - fail gracefully instead of stack overflow
+                return false;
+            }
+        }
 
         context.EnterParser(this);
 
-        var outcome = Parser.Parse(context, ref result);
+        var outcome = parser.Parse(context, ref result);
 
         context.ExitParser(this);
 

--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -74,19 +74,25 @@ public sealed class Deferred<T> : Parser<T>, ICompilable, ISeekable
             }
         }
 
-        context.EnterParser(this);
-
-        var outcome = parser.Parse(context, ref result);
-
-        context.ExitParser(this);
-
-        // Mark this parser as inactive at the entry position (only if we tracked it)
-        if (trackPosition)
+        try
         {
-            context.PopParserAtPosition(this, entryPosition);
-        }
+            context.EnterParser(this);
 
-        return outcome;
+            var outcome = parser.Parse(context, ref result);
+
+            context.ExitParser(this);
+
+            return outcome;
+        }
+        finally
+        {
+            // Marked as inactive even when a parser throws, otherwise a context that is reused
+            // after the exception was handled would report a cycle for this position
+            if (trackPosition)
+            {
+                context.PopParserAtPosition(this, entryPosition);
+            }
+        }
     }
 
     private bool _initialized;

--- a/src/Parlot/Fluent/HybridList.cs
+++ b/src/Parlot/Fluent/HybridList.cs
@@ -91,9 +91,17 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
 
     // ICollection<T> is implemented so that BCL collections built from a parser result, e.g.
     // new Dictionary<K, V>(result) or new List<T>(result), can allocate their storage once
-    // instead of growing it as they enumerate.
+    // instead of growing it as they enumerate. Only Count and CopyTo are needed for that, and the
+    // instance is handed out as an IReadOnlyList<T>, so the mutating members are implemented
+    // explicitly and throw rather than letting a cast alter a parser result.
 
-    bool ICollection<T>.IsReadOnly => false;
+    bool ICollection<T>.IsReadOnly => true;
+
+    void ICollection<T>.Add(T item) => throw new NotSupportedException();
+
+    void ICollection<T>.Clear() => throw new NotSupportedException();
+
+    bool ICollection<T>.Remove(T item) => throw new NotSupportedException();
 
     public bool Contains(T item)
     {
@@ -119,9 +127,14 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
     {
         _ = array ?? throw new ArgumentNullException(nameof(array));
 
-        if (arrayIndex < 0 || array.Length - arrayIndex < _count)
+        if (arrayIndex < 0 || arrayIndex > array.Length)
         {
             throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+        }
+
+        if (array.Length - arrayIndex < _count)
+        {
+            throw new ArgumentException("The destination array has insufficient space.", nameof(array));
         }
 
         if (_list is not null)
@@ -133,62 +146,6 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
         for (var i = 0; i < _count; i++)
         {
             array[arrayIndex + i] = this[i];
-        }
-    }
-
-    public void Clear()
-    {
-        _list = null;
-        _item1 = default;
-        _item2 = default;
-        _item3 = default;
-        _item4 = default;
-        _count = 0;
-    }
-
-    public bool Remove(T item)
-    {
-        var comparer = EqualityComparer<T>.Default;
-
-        for (var i = 0; i < _count; i++)
-        {
-            if (comparer.Equals(this[i], item))
-            {
-                RemoveAt(i);
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    private void RemoveAt(int index)
-    {
-        if (_list is not null)
-        {
-            _list.RemoveAt(index);
-            _count--;
-            return;
-        }
-
-        for (var i = index; i < _count - 1; i++)
-        {
-            Set(i, this[i + 1]);
-        }
-
-        Set(_count - 1, default!);
-        _count--;
-    }
-
-    private void Set(int index, T value)
-    {
-        switch (index)
-        {
-            case 0: _item1 = value; break;
-            case 1: _item2 = value; break;
-            case 2: _item3 = value; break;
-            case 3: _item4 = value; break;
-            default: throw new ArgumentOutOfRangeException(nameof(index));
         }
     }
 

--- a/src/Parlot/Fluent/HybridList.cs
+++ b/src/Parlot/Fluent/HybridList.cs
@@ -149,6 +149,16 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
         }
     }
 
+    /// <summary>
+    /// Returns the items in the representation that is the most efficient for the consumers.
+    /// </summary>
+    /// <remarks>
+    /// The BCL collections have fast paths for <see cref="List{T}"/>, e.g. <c>new Dictionary&lt;K, V&gt;(items)</c>
+    /// iterates its span instead of allocating an enumerator for it, so the inner list is returned once it has
+    /// been allocated. This is also the type the compiled parsers return.
+    /// </remarks>
+    public IReadOnlyList<T> AsReadOnlyList() => _list ?? (IReadOnlyList<T>)this;
+
     public IEnumerator<T> GetEnumerator()
     {
         if (_list is not null)

--- a/src/Parlot/Fluent/HybridList.cs
+++ b/src/Parlot/Fluent/HybridList.cs
@@ -11,7 +11,7 @@ namespace Parlot.Fluent;
 /// flexibility for larger lists.
 /// </summary>
 #nullable enable
-internal sealed class HybridList<T> : IReadOnlyList<T>
+internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
 {
     private T? _item1;
     private T? _item2;
@@ -86,6 +86,109 @@ internal sealed class HybridList<T> : IReadOnlyList<T>
                 default:
                     throw new InvalidOperationException("Unexpected count value");
             }
+        }
+    }
+
+    // ICollection<T> is implemented so that BCL collections built from a parser result, e.g.
+    // new Dictionary<K, V>(result) or new List<T>(result), can allocate their storage once
+    // instead of growing it as they enumerate.
+
+    bool ICollection<T>.IsReadOnly => false;
+
+    public bool Contains(T item)
+    {
+        if (_list is not null)
+        {
+            return _list.Contains(item);
+        }
+
+        var comparer = EqualityComparer<T>.Default;
+
+        for (var i = 0; i < _count; i++)
+        {
+            if (comparer.Equals(this[i], item))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public void CopyTo(T[] array, int arrayIndex)
+    {
+        _ = array ?? throw new ArgumentNullException(nameof(array));
+
+        if (arrayIndex < 0 || array.Length - arrayIndex < _count)
+        {
+            throw new ArgumentOutOfRangeException(nameof(arrayIndex));
+        }
+
+        if (_list is not null)
+        {
+            _list.CopyTo(array, arrayIndex);
+            return;
+        }
+
+        for (var i = 0; i < _count; i++)
+        {
+            array[arrayIndex + i] = this[i];
+        }
+    }
+
+    public void Clear()
+    {
+        _list = null;
+        _item1 = default;
+        _item2 = default;
+        _item3 = default;
+        _item4 = default;
+        _count = 0;
+    }
+
+    public bool Remove(T item)
+    {
+        var comparer = EqualityComparer<T>.Default;
+
+        for (var i = 0; i < _count; i++)
+        {
+            if (comparer.Equals(this[i], item))
+            {
+                RemoveAt(i);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void RemoveAt(int index)
+    {
+        if (_list is not null)
+        {
+            _list.RemoveAt(index);
+            _count--;
+            return;
+        }
+
+        for (var i = index; i < _count - 1; i++)
+        {
+            Set(i, this[i + 1]);
+        }
+
+        Set(_count - 1, default!);
+        _count--;
+    }
+
+    private void Set(int index, T value)
+    {
+        switch (index)
+        {
+            case 0: _item1 = value; break;
+            case 1: _item2 = value; break;
+            case 2: _item3 = value; break;
+            case 3: _item4 = value; break;
+            default: throw new ArgumentOutOfRangeException(nameof(index));
         }
     }
 

--- a/src/Parlot/Fluent/NumberLiteral.cs
+++ b/src/Parlot/Fluent/NumberLiteral.cs
@@ -2,6 +2,7 @@
 using Parlot.Compilation;
 using Parlot.Rewriting;
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq.Expressions;
 using System.Numerics;
@@ -15,7 +16,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
     private const char DefaultDecimalSeparator = '.';
     private const char DefaultGroupSeparator = ',';
 
-    private static readonly MethodInfo _tryParseMethodInfo = typeof(T).GetMethod(nameof(INumber<T>.TryParse), [typeof(ReadOnlySpan<char>), typeof(NumberStyles), typeof(IFormatProvider), typeof(T).MakeByRefType()])!;
+    private static readonly MethodInfo _tryParseMethodInfo = typeof(NumberLiteral<T>).GetMethod(nameof(TryParseNumber), BindingFlags.Static | BindingFlags.NonPublic)!;
 
     private readonly char _decimalSeparator;
     private readonly char _groupSeparator;
@@ -87,7 +88,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
         {
             var end = context.Scanner.Cursor.Offset;
 
-            if (T.TryParse(number, _numberStyles, _culture, out var value))
+            if (TryParseNumber(number, _numberStyles, _culture, out var value))
             {
                 result.Set(start, end, value);
 
@@ -100,6 +101,51 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
 
         context.ExitParser(this);
         return false;
+    }
+
+    /// <summary>
+    /// The number of digits that always fit in a <see cref="long"/>, <c>long.MaxValue</c> has 19 of them.
+    /// </summary>
+    private const int MaxFastDigits = 18;
+
+    /// <summary>
+    /// Parses a number, using a dedicated implementation for the plain sequences of digits that make up
+    /// most of the numbers found in a grammar.
+    /// </summary>
+    /// <remarks>
+    /// The general purpose parser has to handle everything <see cref="NumberStyles"/> allows, which is a
+    /// significant part of the parsing time even for a single digit. Anything that is not a short sequence
+    /// of digits, e.g. a sign, a decimal separator or an exponent, falls back to it.
+    /// </remarks>
+    internal static bool TryParseNumber(ReadOnlySpan<char> span, NumberStyles styles, NumberFormatInfo culture, [MaybeNullWhen(false)] out T value)
+    {
+        if ((uint)(span.Length - 1) < MaxFastDigits)
+        {
+            long parsed = 0;
+
+            foreach (var c in span)
+            {
+                var digit = (uint)(c - '0');
+
+                if (digit > 9)
+                {
+                    return T.TryParse(span, styles, culture, out value);
+                }
+
+                parsed = (parsed * 10) + digit;
+            }
+
+            value = T.CreateTruncating(parsed);
+
+            // T can be narrower than a long, e.g. Terms.Byte() reading "300", in which case the
+            // conversion silently wrapped and the general purpose parser decides whether it is valid.
+            if (long.CreateTruncating(value) == parsed)
+            {
+                return true;
+            }
+        }
+
+        return T.TryParse(span, styles, culture, out value);
     }
 
     public CompilationResult Compile(CompilationContext context)

--- a/src/Parlot/Fluent/NumberLiteral.cs
+++ b/src/Parlot/Fluent/NumberLiteral.cs
@@ -20,7 +20,10 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
     private readonly char _decimalSeparator;
     private readonly char _groupSeparator;
     private readonly NumberStyles _numberStyles;
-    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    // A NumberFormatInfo is stored instead of a CultureInfo since NumberFormatInfo.GetInstance()
+    // returns it directly, while a CultureInfo needs to be resolved on every call.
+    private readonly NumberFormatInfo _culture = CultureInfo.InvariantCulture.NumberFormat;
     private readonly bool _allowLeadingSign;
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
@@ -41,9 +44,9 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
         if (decimalSeparator != NumberLiterals.DefaultDecimalSeparator ||
             groupSeparator != NumberLiterals.DefaultGroupSeparator)
         {
-            _culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-            _culture.NumberFormat.NumberDecimalSeparator = decimalSeparator.ToString();
-            _culture.NumberFormat.NumberGroupSeparator = groupSeparator.ToString();
+            _culture = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+            _culture.NumberDecimalSeparator = decimalSeparator.ToString();
+            _culture.NumberGroupSeparator = groupSeparator.ToString();
         }
 
         _allowLeadingSign = (numberOptions & NumberOptions.AllowLeadingSign) != 0;
@@ -108,7 +111,7 @@ public sealed class NumberLiteral<T> : Parser<T>, ICompilable, ISeekable
         var reset = context.DeclarePositionVariable(result);
 
         var numberStyles = result.DeclareVariable<NumberStyles>($"numberStyles{context.NextNumber}", Expression.Constant(_numberStyles));
-        var culture = result.DeclareVariable<CultureInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
+        var culture = result.DeclareVariable<NumberFormatInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
         var numberSpan = result.DeclareVariable($"number{context.NextNumber}", typeof(ReadOnlySpan<char>));
         var end = result.DeclareVariable<int>($"end{context.NextNumber}");
 

--- a/src/Parlot/Fluent/NumberLiteralBase.cs
+++ b/src/Parlot/Fluent/NumberLiteralBase.cs
@@ -21,9 +21,9 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
     private readonly MethodInfo _tryParseMethodInfo;
     private readonly NumberStyles _numberStyles;
 
-    // A NumberFormatInfo is stored instead of a CultureInfo since NumberFormatInfo.GetInstance()
-    // returns it directly, while a CultureInfo needs to be resolved on every call.
-    private readonly NumberFormatInfo _culture = CultureInfo.InvariantCulture.NumberFormat;
+    // Kept as a CultureInfo since it is handed to the public TryParseNumber overrides and to the
+    // caller supplied tryParseMethodInfo, which can both expect that exact type.
+    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
     private readonly bool _allowLeadingSign;
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
@@ -47,9 +47,9 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         if (decimalSeparator != NumberLiterals.DefaultDecimalSeparator ||
             groupSeparator != NumberLiterals.DefaultGroupSeparator)
         {
-            _culture = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
-            _culture.NumberDecimalSeparator = decimalSeparator.ToString();
-            _culture.NumberGroupSeparator = groupSeparator.ToString();
+            _culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
+            _culture.NumberFormat.NumberDecimalSeparator = decimalSeparator.ToString();
+            _culture.NumberFormat.NumberGroupSeparator = groupSeparator.ToString();
         }
 
         _allowLeadingSign = (numberOptions & NumberOptions.AllowLeadingSign) != 0;
@@ -114,7 +114,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         var reset = context.DeclarePositionVariable(result);
 
         var numberStyles = result.DeclareVariable<NumberStyles>($"numberStyles{context.NextNumber}", Expression.Constant(_numberStyles));
-        var culture = result.DeclareVariable<NumberFormatInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
+        var culture = result.DeclareVariable<CultureInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
         var numberSpan = result.DeclareVariable($"number{context.NextNumber}", typeof(ReadOnlySpan<char>));
         var end = result.DeclareVariable<int>($"end{context.NextNumber}");
 

--- a/src/Parlot/Fluent/NumberLiteralBase.cs
+++ b/src/Parlot/Fluent/NumberLiteralBase.cs
@@ -20,7 +20,10 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
     private readonly char _groupSeparator;
     private readonly MethodInfo _tryParseMethodInfo;
     private readonly NumberStyles _numberStyles;
-    private readonly CultureInfo _culture = CultureInfo.InvariantCulture;
+
+    // A NumberFormatInfo is stored instead of a CultureInfo since NumberFormatInfo.GetInstance()
+    // returns it directly, while a CultureInfo needs to be resolved on every call.
+    private readonly NumberFormatInfo _culture = CultureInfo.InvariantCulture.NumberFormat;
     private readonly bool _allowLeadingSign;
     private readonly bool _allowDecimalSeparator;
     private readonly bool _allowGroupSeparator;
@@ -44,9 +47,9 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         if (decimalSeparator != NumberLiterals.DefaultDecimalSeparator ||
             groupSeparator != NumberLiterals.DefaultGroupSeparator)
         {
-            _culture = (CultureInfo)CultureInfo.InvariantCulture.Clone();
-            _culture.NumberFormat.NumberDecimalSeparator = decimalSeparator.ToString();
-            _culture.NumberFormat.NumberGroupSeparator = groupSeparator.ToString();
+            _culture = (NumberFormatInfo)CultureInfo.InvariantCulture.NumberFormat.Clone();
+            _culture.NumberDecimalSeparator = decimalSeparator.ToString();
+            _culture.NumberGroupSeparator = groupSeparator.ToString();
         }
 
         _allowLeadingSign = (numberOptions & NumberOptions.AllowLeadingSign) != 0;
@@ -111,7 +114,7 @@ public abstract class NumberLiteralBase<T> : Parser<T>, ICompilable, ISeekable
         var reset = context.DeclarePositionVariable(result);
 
         var numberStyles = result.DeclareVariable<NumberStyles>($"numberStyles{context.NextNumber}", Expression.Constant(_numberStyles));
-        var culture = result.DeclareVariable<CultureInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
+        var culture = result.DeclareVariable<NumberFormatInfo>($"culture{context.NextNumber}", Expression.Constant(_culture));
         var numberSpan = result.DeclareVariable($"number{context.NextNumber}", typeof(ReadOnlySpan<char>));
         var end = result.DeclareVariable<int>($"end{context.NextNumber}");
 

--- a/src/Parlot/Fluent/OneOf.cs
+++ b/src/Parlot/Fluent/OneOf.cs
@@ -197,11 +197,14 @@ public sealed class OneOf<T> : Parser<T>, ISeekable /*, ICompilable*/
 
         var cursor = context.Scanner.Cursor;
 
-        var start = context.Scanner.Cursor.Position;
+        // The position is only needed to revert the whitespaces this parser skipped, the sub-parsers
+        // revert their own state. Reading it is not free as it also tracks the line and column.
+        var start = default(TextPosition);
 
         // If all sub-parsers skip whitespaces, do it once here
         if (SkipWhitespace)
         {
+            start = cursor.Position;
             context.SkipWhiteSpace();
         }
 
@@ -244,7 +247,7 @@ public sealed class OneOf<T> : Parser<T>, ISeekable /*, ICompilable*/
 
         if (SkipWhitespace)
         {
-            context.Scanner.Cursor.ResetPosition(start);
+            cursor.ResetPosition(start);
         }
 
         context.ExitParser(this);

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -53,7 +53,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable, ISeeka
 
         } while (_parser.Parse(context, ref parsed));
 
-        result.Set(start, end, results);
+        result.Set(start, end, results.AsReadOnlyList());
 
         context.ExitParser(this);
         return true;

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Threading;
 
@@ -43,7 +42,15 @@ public class ParseContext
     /// <summary>
     /// Tracks parser-position pairs to detect infinite recursion at the same position.
     /// </summary>
-    private readonly HashSet<ParserPosition> _activeParserPositions;
+    /// <remarks>
+    /// The pairs are pushed and popped in LIFO order since they follow the parsers' call stack, so they are
+    /// kept in a plain stack rather than a hash set. A stack doesn't need to rehash its content while it grows,
+    /// which was allocating several intermediate tables for deeply nested grammars, and a lookup is a vectorized
+    /// scan over the recorded positions since two entries rarely share the same one.
+    /// </remarks>
+    private int[]? _activePositions;
+    private object[]? _activeParsers;
+    private int _activeCount;
 
     /// <summary>
     /// The cancellation token used to stop the parsing operation.
@@ -68,8 +75,6 @@ public class ParseContext
         UseNewLines = useNewLines;
         CancellationToken = cancellationToken;
         DisableLoopDetection = disableLoopDetection;
-
-        _activeParserPositions = !disableLoopDetection ? new HashSet<ParserPosition>(ParserPositionComparer.Instance) : null!;
     }
 
     /// <summary>
@@ -92,7 +97,7 @@ public class ParseContext
 
     public void SkipWhiteSpace()
     {
-        var offset = Scanner.Cursor.Position.Offset;
+        var offset = Scanner.Cursor.Offset;
 
         if (offset == _cacheOffset)
         {
@@ -148,7 +153,47 @@ public class ParseContext
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool IsParserActiveAtPosition(object parser)
     {
-        return _activeParserPositions.Contains(new ParserPosition(parser, Scanner.Cursor.Position.Offset));
+        return IndexOfActiveParser(parser, Scanner.Cursor.Offset) >= 0;
+    }
+
+    /// <summary>
+    /// Returns the index of an active parser at the specified position, or <c>-1</c> when it's not active.
+    /// </summary>
+    private int IndexOfActiveParser(object parser, int position)
+    {
+        var count = _activeCount;
+
+        if (count == 0)
+        {
+            return -1;
+        }
+
+        // Scan the recorded positions first, the parsers are only compared when a position matches.
+        // A parser that consumed something has a different position, so matches are rare.
+
+        var positions = _activePositions!.AsSpan(0, count);
+        var parsers = _activeParsers!;
+        var start = 0;
+
+        while (true)
+        {
+            var found = positions.IndexOf(position);
+
+            if (found < 0)
+            {
+                return -1;
+            }
+
+            var index = start + found;
+
+            if (ReferenceEquals(parsers[index], parser))
+            {
+                return index;
+            }
+
+            positions = positions.Slice(found + 1);
+            start = index + 1;
+        }
     }
 
     /// <summary>
@@ -156,11 +201,37 @@ public class ParseContext
     /// </summary>
     /// <param name="parser">The parser to mark as active.</param>
     /// <returns>True if the parser was added (not previously active at this position), false if it was already active at this position.</returns>
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public bool PushParserAtPosition(object parser)
     {
-        return _activeParserPositions.Add(new ParserPosition(parser, Scanner.Cursor.Position.Offset));
+        var position = Scanner.Cursor.Offset;
+
+        if (IndexOfActiveParser(parser, position) >= 0)
+        {
+            return false;
+        }
+
+        var count = _activeCount;
+
+        if (_activePositions is null)
+        {
+            _activePositions = new int[InitialActiveParsersCapacity];
+            _activeParsers = new object[InitialActiveParsersCapacity];
+        }
+        else if (count == _activePositions.Length)
+        {
+            Array.Resize(ref _activePositions, count * 2);
+            Array.Resize(ref _activeParsers, count * 2);
+        }
+
+        _activePositions[count] = position;
+        _activeParsers![count] = parser;
+        _activeCount = count + 1;
+
+        return true;
     }
+
+    // Kept small since most grammars only nest a few parsers, the arrays grow for the deeper ones
+    private const int InitialActiveParsersCapacity = 8;
 
     /// <summary>
     /// Marks a parser as inactive at the current position.
@@ -170,30 +241,43 @@ public class ParseContext
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public void PopParserAtPosition(object parser, int position)
     {
-        _activeParserPositions.Remove(new ParserPosition(parser, position));
+        var count = _activeCount;
+
+        if (count == 0)
+        {
+            return;
+        }
+
+        // Parsers are entered and left in LIFO order, so the entry to remove is the last one
+
+        var last = count - 1;
+
+        if (_activePositions![last] == position && ReferenceEquals(_activeParsers![last], parser))
+        {
+            _activeCount = last;
+            return;
+        }
+
+        RemoveActiveParserNotInlined(parser, position);
     }
 
-    /// <summary>
-    /// Represents a parser instance at a specific position for cycle detection.
-    /// </summary>
-    private readonly record struct ParserPosition(object Parser, int Position);
-
-    /// <summary>
-    /// Uses reference equality for parsers to avoid calling user GetHashCode overrides.
-    /// </summary>
-    private sealed class ParserPositionComparer : IEqualityComparer<ParserPosition>
+    private void RemoveActiveParserNotInlined(object parser, int position)
     {
-        public static readonly ParserPositionComparer Instance = new();
+        // A custom parser could leave entries out of order, in which case the entry is looked up.
+        // An entry can't be recorded twice since PushParserAtPosition rejects duplicates.
 
-        public bool Equals(ParserPosition x, ParserPosition y) => ReferenceEquals(x.Parser, y.Parser) && x.Position == y.Position;
+        var index = IndexOfActiveParser(parser, position);
 
-        public int GetHashCode(ParserPosition obj)
+        if (index < 0)
         {
-            unchecked
-            {
-                var hash = RuntimeHelpers.GetHashCode(obj.Parser);
-                return (hash * 397) ^ obj.Position;
-            }
+            return;
         }
+
+        var remaining = _activeCount - index - 1;
+
+        Array.Copy(_activePositions!, index + 1, _activePositions!, index, remaining);
+        Array.Copy(_activeParsers!, index + 1, _activeParsers!, index, remaining);
+
+        _activeCount--;
     }
 }

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -219,8 +219,16 @@ public class ParseContext
         }
         else if (count == _activePositions.Length)
         {
-            Array.Resize(ref _activePositions, count * 2);
-            Array.Resize(ref _activeParsers, count * 2);
+            // Both arrays are allocated before either field is assigned, such that a failed
+            // allocation can't leave them with different lengths
+            var positions = new int[count * 2];
+            var parsers = new object[count * 2];
+
+            Array.Copy(_activePositions, positions, count);
+            Array.Copy(_activeParsers!, parsers, count);
+
+            _activePositions = positions;
+            _activeParsers = parsers;
         }
 
         _activePositions[count] = position;
@@ -254,6 +262,8 @@ public class ParseContext
 
         if (_activePositions![last] == position && ReferenceEquals(_activeParsers![last], parser))
         {
+            // Released so the context doesn't keep the parsers it is done with alive
+            _activeParsers[last] = null!;
             _activeCount = last;
             return;
         }
@@ -279,5 +289,8 @@ public class ParseContext
         Array.Copy(_activeParsers!, index + 1, _activeParsers!, index, remaining);
 
         _activeCount--;
+
+        // Released so the context doesn't keep the parsers it is done with alive
+        _activeParsers![_activeCount] = null!;
     }
 }

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -84,7 +84,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ICompilable, ISe
             results!.Add(parsed.Value);
         }
 
-        result.Set(start, end.Offset, results ?? (IReadOnlyList<T>)[]);
+        result.Set(start, end.Offset, results?.AsReadOnlyList() ?? (IReadOnlyList<T>)[]);
 
         context.ExitParser(this);
         return true;

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -46,7 +46,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ICompilable
             results!.Add(parsed.Value);
         }
 
-        result.Set(start, end, results ?? (IReadOnlyList<T>)[]);
+        result.Set(start, end, results?.AsReadOnlyList() ?? (IReadOnlyList<T>)[]);
 
         context.ExitParser(this);
         return true;

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -568,23 +568,29 @@ public class Scanner
             return false;
         }
 
-        var nextQuote = Cursor.Span.Slice(1).IndexOf(startChar);
+        var span = Cursor.Span;
 
-        if (nextQuote == -1)
+        // Look for the end quote and the first escape sequence in a single pass. Searching for '\\'
+        // on its own would scan the rest of the buffer whenever the string has no escape sequence,
+        // making a document containing many strings quadratic to parse.
+        var next = span.Slice(1).IndexOfAny(startChar, '\\');
+
+        if (next == -1)
         {
-            // There is no end quote, not a string
+            // There is no end quote nor an escape sequence, not a string
             result = [];
             return false;
         }
 
-        var nextEscape = Cursor.Span.IndexOf('\\');
+        // Index of the match in the full span, the start quote is at index 0
+        var nextEscape = next + 1;
 
-        // If the next escape is not before the next quote, we can return the string as-is
-        if (nextEscape == -1 || nextEscape > nextQuote)
+        // If the first match is the end quote there is no escape to decode, return the string as-is
+        if (span[nextEscape] == startChar)
         {
-            Cursor.Advance(nextQuote + 2); // include start quote
+            Cursor.Advance(next + 2); // include start quote
 
-            result = Cursor.Buffer.AsSpan().Slice(start.Offset, nextQuote + 2);
+            result = Cursor.Buffer.AsSpan().Slice(start.Offset, next + 2);
             return true;
         }
 

--- a/src/Parlot/Scanner.cs
+++ b/src/Parlot/Scanner.cs
@@ -548,7 +548,9 @@ public class Scanner
         return ReadQuotedString(startChar, out result);
     }
 
-    public bool ReadQuotedString(out ReadOnlySpan<char> result) => ReadQuotedString(['\'', '\"'],out result);
+    private static readonly char[] _singleOrDoubleQuotes = ['\'', '\"'];
+
+    public bool ReadQuotedString(out ReadOnlySpan<char> result) => ReadQuotedString(_singleOrDoubleQuotes, out result);
 
     /// <summary>
     /// Reads a string token enclosed in quotes or custom characters.
@@ -560,7 +562,6 @@ public class Scanner
     public bool ReadQuotedString(char quoteChar, out ReadOnlySpan<char> result)
     {
         var startChar = Cursor.Current;
-        var start = Cursor.Position;
 
         if (startChar != quoteChar)
         {
@@ -568,6 +569,7 @@ public class Scanner
             return false;
         }
 
+        var startOffset = Cursor.Offset;
         var span = Cursor.Span;
 
         // Look for the end quote and the first escape sequence in a single pass. Searching for '\\'
@@ -582,17 +584,35 @@ public class Scanner
             return false;
         }
 
+        // When the quote char is a backslash it is also the escape char, in which case the start quote
+        // is itself the first escape sequence and the string is always decoded escape by escape.
+        var quoteIsEscape = startChar == '\\';
+
         // Index of the match in the full span, the start quote is at index 0
-        var nextEscape = next + 1;
+        var nextEscape = quoteIsEscape ? 0 : next + 1;
 
-        // If the first match is the end quote there is no escape to decode, return the string as-is
-        if (span[nextEscape] == startChar)
+        if (!quoteIsEscape)
         {
-            Cursor.Advance(next + 2); // include start quote
+            // If the first match is the end quote there is no escape to decode, return the string as-is
+            if (span[nextEscape] == startChar)
+            {
+                Cursor.Advance(next + 2); // include start quote
 
-            result = Cursor.Buffer.AsSpan().Slice(start.Offset, next + 2);
-            return true;
+                result = Cursor.Buffer.AsSpan().Slice(startOffset, next + 2);
+                return true;
+            }
+
+            // The end quote is only after the escape sequences. Make sure there is one at all before
+            // decoding them one by one, as reaching the end of the buffer that way is far more costly.
+            if (span.Slice(next + 2).IndexOf(startChar) == -1)
+            {
+                result = [];
+                return false;
+            }
         }
+
+        // Decoding the escape sequences needs to restore the line and the column when it fails
+        var start = Cursor.Position;
 
         while (nextEscape != -1)
         {

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -1681,7 +1681,9 @@ public class FluentTests
         list.Parser = Between(Literals.Char('['), list, Literals.Char(']')).Then(x => "list")
             .Or(Literals.Text("item"));
 
-        var depth = 512;
+        // Deep enough to grow the tracking arrays several times, but not so deep that a smaller
+        // stack turns a failure into a StackOverflowException that takes the test host down
+        var depth = 128;
         var source = new string('[', depth) + "item" + new string(']', depth);
 
         Assert.True(list.TryParse(source, out var result));

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -1635,6 +1635,62 @@ public class FluentTests
         Assert.Null(result2);
     }
 
+    /// <summary>
+    /// Rewinds the cursor to the beginning of the buffer before invoking the next parser, such that a parser
+    /// can be re-entered at a position it is already active at, with other positions recorded in between.
+    /// </summary>
+    private sealed class RewindParser : Parser<string>
+    {
+        private readonly Parser<string> _parser;
+
+        public RewindParser(Parser<string> parser) => _parser = parser;
+
+        public override bool Parse(ParseContext context, ref ParseResult<string> result)
+        {
+            context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+
+            return _parser.Parse(context, ref result);
+        }
+    }
+
+    [Fact]
+    public void ShouldDetectInfiniteRecursionWhenOtherPositionsAreRecordedInBetween()
+    {
+        // 'a' is entered at offset 0, consumes a char, then enters 'b' at offset 1 which rewinds and
+        // enters 'a' at offset 0 again. The cycle is only detectable by looking at every active parser,
+        // and not only at the ones recorded at the current position.
+
+        var a = Deferred<string>();
+        var b = Deferred<string>();
+
+        a.Parser = Literals.Char('x').SkipAnd(b);
+        b.Parser = new RewindParser(a);
+
+        // Should fail gracefully instead of causing a stack overflow
+        Assert.False(a.TryParse("xy", out var result));
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public void ShouldDetectInfiniteRecursionWhenDeeplyNested()
+    {
+        // Exercises the growth of the active parser tracking beyond its initial capacity
+
+        var list = Deferred<string>();
+
+        list.Parser = Between(Literals.Char('['), list, Literals.Char(']')).Then(x => "list")
+            .Or(Literals.Text("item"));
+
+        var depth = 512;
+        var source = new string('[', depth) + "item" + new string(']', depth);
+
+        Assert.True(list.TryParse(source, out var result));
+        Assert.Equal("list", result);
+
+        // The same grammar without a terminating item must not recurse forever
+        Assert.False(list.TryParse(new string('[', depth), out _));
+    }
+
     [Fact]
     public void DeferredShouldAllowValidRecursion()
     {

--- a/test/Parlot.Tests/HybridListTests.cs
+++ b/test/Parlot.Tests/HybridListTests.cs
@@ -1,4 +1,5 @@
 using Parlot.Fluent;
+using System;
 using System.Collections.Generic;
 using Xunit;
 
@@ -284,7 +285,7 @@ public class HybridListTests
         ICollection<int> collection = list;
 
         Assert.Equal(count, collection.Count);
-        Assert.False(collection.IsReadOnly);
+        Assert.True(collection.IsReadOnly);
 
         // The pre-sizing constructors of the BCL collections rely on ICollection<T>
         Assert.Equal(count, new List<int>(list).Count);
@@ -323,7 +324,36 @@ public class HybridListTests
     [InlineData(4)]
     [InlineData(5)]
     [InlineData(20)]
-    public void ICollectionInterface_RemoveAndClear(int count)
+    public void ICollectionInterface_DoesNotAllowMutation(int count)
+    {
+        var list = new HybridList<int>();
+
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        // A parser result is handed out as an IReadOnlyList<T>, casting it to ICollection<T>
+        // must not be a way to alter it
+        ICollection<int> collection = list;
+
+        Assert.Throws<NotSupportedException>(() => collection.Remove(0));
+        Assert.Throws<NotSupportedException>(() => collection.Clear());
+        Assert.Throws<NotSupportedException>(() => collection.Add(42));
+
+        Assert.Equal(count, collection.Count);
+
+        for (var i = 0; i < count; i++)
+        {
+            Assert.Equal(i, list[i]);
+        }
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void ICollectionInterface_CopyToValidatesItsArguments(int count)
     {
         var list = new HybridList<int>();
 
@@ -334,22 +364,11 @@ public class HybridListTests
 
         ICollection<int> collection = list;
 
-        Assert.True(collection.Remove(0));
-        Assert.False(collection.Remove(count));
-        Assert.Equal(count - 1, collection.Count);
+        Assert.Throws<ArgumentNullException>(() => collection.CopyTo(null!, 0));
+        Assert.Throws<ArgumentOutOfRangeException>(() => collection.CopyTo(new int[count], -1));
 
-        for (var i = 0; i < count - 1; i++)
-        {
-            Assert.Equal(i + 1, list[i]);
-        }
-
-        collection.Clear();
-        Assert.Empty(list);
-
-        // The list can still be used after being cleared
-        collection.Add(42);
-        Assert.Single(list);
-        Assert.Equal(42, list[0]);
+        // An undersized destination is an ArgumentException, not an out of range index
+        Assert.Throws<ArgumentException>(() => collection.CopyTo(new int[count - 1], 0));
     }
 
     [Fact]

--- a/test/Parlot.Tests/HybridListTests.cs
+++ b/test/Parlot.Tests/HybridListTests.cs
@@ -266,6 +266,92 @@ public class HybridListTests
         Assert.Equal(3, items.Count);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(20)]
+    public void ICollectionInterface_ExposesCountForPreSizing(int count)
+    {
+        var list = new HybridList<int>();
+
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        ICollection<int> collection = list;
+
+        Assert.Equal(count, collection.Count);
+        Assert.False(collection.IsReadOnly);
+
+        // The pre-sizing constructors of the BCL collections rely on ICollection<T>
+        Assert.Equal(count, new List<int>(list).Count);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(20)]
+    public void ICollectionInterface_CopyToAndContains(int count)
+    {
+        var list = new HybridList<int>();
+
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        ICollection<int> collection = list;
+
+        var target = new int[count + 2];
+        collection.CopyTo(target, 1);
+
+        for (var i = 0; i < count; i++)
+        {
+            Assert.Equal(i, target[i + 1]);
+            Assert.True(collection.Contains(i));
+        }
+
+        Assert.False(collection.Contains(count));
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(20)]
+    public void ICollectionInterface_RemoveAndClear(int count)
+    {
+        var list = new HybridList<int>();
+
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(i);
+        }
+
+        ICollection<int> collection = list;
+
+        Assert.True(collection.Remove(0));
+        Assert.False(collection.Remove(count));
+        Assert.Equal(count - 1, collection.Count);
+
+        for (var i = 0; i < count - 1; i++)
+        {
+            Assert.Equal(i + 1, list[i]);
+        }
+
+        collection.Clear();
+        Assert.Empty(list);
+
+        // The list can still be used after being cleared
+        collection.Add(42);
+        Assert.Single(list);
+        Assert.Equal(42, list[0]);
+    }
+
     [Fact]
     public void TransitionPoint_ExactlyAtFourItems()
     {

--- a/test/Parlot.Tests/NumberLiteralTests.cs
+++ b/test/Parlot.Tests/NumberLiteralTests.cs
@@ -240,4 +240,65 @@ public class NumberLiteralTests
         Assert.True(parser.TryParse("1.000.000", out var result));
         Assert.Equal(1000000, result);
     }
+
+    // Plain sequences of digits are parsed by a dedicated implementation, these cover its boundaries
+
+    [Theory]
+    [InlineData("1", 1L)]
+    [InlineData("9", 9L)]
+    [InlineData("10", 10L)]
+    [InlineData("999999999999999999", 999999999999999999L)] // 18 digits, the longest it handles
+    [InlineData("1000000000000000000", 1000000000000000000L)] // 19 digits, handled by the fallback
+    [InlineData("9223372036854775807", long.MaxValue)]
+    public void LongNumberLiteralShouldParseAnyDigitCount(string source, long expected)
+    {
+        Assert.True(Literals.Number<long>().TryParse(source, out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void LongNumberLiteralShouldFailOverLongMaxValue()
+    {
+        Assert.False(Literals.Number<long>().TryParse("9223372036854775808", out _));
+    }
+
+    [Theory]
+    // A number that fits in a long but not in the target type must not be truncated into a valid value
+    [InlineData("256")]
+    [InlineData("300")]
+    [InlineData("65536")]
+    [InlineData("4294967296")]
+    public void ByteNumberLiteralShouldNotTruncateLargerNumbers(string source)
+    {
+        Assert.False(Literals.Number<byte>().TryParse(source, out _));
+    }
+
+    [Theory]
+    [InlineData("65536")]
+    [InlineData("4294967296")]
+    public void ShortNumberLiteralShouldNotTruncateLargerNumbers(string source)
+    {
+        Assert.False(Literals.Number<short>().TryParse(source, out _));
+        Assert.False(Literals.Number<ushort>().TryParse(source, out _));
+    }
+
+    [Fact]
+    public void IntNumberLiteralShouldNotTruncateLargerNumbers()
+    {
+        Assert.False(Literals.Number<int>().TryParse("4294967296", out _));
+        Assert.False(Literals.Number<int>().TryParse("2147483648", out _));
+
+        Assert.True(Literals.Number<int>().TryParse("2147483647", out var result));
+        Assert.Equal(int.MaxValue, result);
+    }
+
+    [Theory]
+    [InlineData("2.5", 2.5)]
+    [InlineData("0.125", 0.125)]
+    [InlineData("12", 12)]
+    public void DecimalNumberLiteralShouldParseWithAndWithoutSeparator(string source, decimal expected)
+    {
+        Assert.True(Literals.Number<decimal>(NumberOptions.Float).TryParse(source, out var result));
+        Assert.Equal(expected, result);
+    }
 }

--- a/test/Parlot.Tests/ScannerTests.cs
+++ b/test/Parlot.Tests/ScannerTests.cs
@@ -87,6 +87,41 @@ public class ScannerTests
         Assert.False(s.ReadQuotedString());
     }
 
+    [Theory]
+    [InlineData("'Lorem \\n ipsum")]
+    [InlineData("'C:\\temp\\file")]
+    [InlineData("'\\u1234")]
+    public void ShouldNotReadStringWithEscapesAndNoEndQuote(string text)
+    {
+        Scanner s = new(text);
+
+        Assert.False(s.ReadQuotedString());
+        Assert.Equal(0, s.Cursor.Offset);
+    }
+
+    [Theory]
+    // The quote char is also the escape char, so the start quote is the first escape sequence
+    [InlineData("\\n\\rest", true, "\\n\\")]
+    [InlineData("\\p\\rest", false, null)]
+    [InlineData("\\u1234\\rest", false, null)]
+    [InlineData("\\u12\\rest", false, null)]
+    [InlineData("\\nrest", false, null)]
+    public void ShouldReadStringWhenQuoteCharIsTheEscapeChar(string text, bool success, string expected)
+    {
+        Scanner s = new(text);
+
+        Assert.Equal(success, s.ReadQuotedString('\\', out var result));
+
+        if (success)
+        {
+            Assert.Equal(expected, result.ToString());
+        }
+        else
+        {
+            Assert.Equal(0, s.Cursor.Offset);
+        }
+    }
+
     [Fact]
     public void ShouldReadQuotedStringPartial()
     {


### PR DESCRIPTION
Profiled the JSON and expression grammars with [ultra](https://github.com/xoofx/ultra) and fixed what the traces pointed at.

### Changes

- **`Scanner.ReadQuotedString` was quadratic.** It searched for the next escape with a separate `IndexOf('\\')` over `Cursor.Span`, which runs to the end of the buffer rather than stopping at the end quote — so every string literal scanned the rest of the document when it contained no escapes. The end quote and the first escape are now found in a single bounded `IndexOfAny` pass. This was 14% of all CPU in the JSON profile.
- **`ParseContext` tracks active parsers in a stack instead of a `HashSet`.** Entries are pushed and popped in LIFO order since they follow the parsers' call stack, so the set was rehashing into several intermediate tables as it grew — `Resize` was 5% of the profile, of which 4.8% was allocation alone. A lookup is now a vectorized scan over the recorded positions, and parsers are only compared when a position matches. It's also allocated lazily, so grammars without a `Deferred` parser don't allocate it at all.
- **`Deferred.Parse` did a `Contains` followed by an `Add`**, but the result of `Add` already detects the cycle.
- **`HybridList` implements `ICollection<T>`** so BCL collections built from a parser result (e.g. `new Dictionary<K, V>(result)`) allocate their storage once instead of growing it while enumerating. The mutating members are explicit and throw, since the result is handed out as an `IReadOnlyList<T>`.
- **`HybridList` returns its inner `List<T>` once it has one.** The BCL collections have a fast path for `List<T>` — `new Dictionary<K, V>(items)` iterates its span rather than allocating an enumerator and dispatching `MoveNext`/`Current` through an interface for every item. Lists of 4 items or fewer keep the inline storage, where the allocation matters more than how they are enumerated.
- **`NumberLiteral` has a fast path for plain integers.** `T.TryParse` handles everything `NumberStyles` allows, which is a large part of the cost even for a single digit. A run of up to 18 digits (always fits in a `long`) is now read directly and converted to `T`; a sign, separator, exponent, or more digits falls back to `T.TryParse`. The conversion is only kept when it round-trips back to the same `long`, so a value that fits a `long` but not a narrower `T` (e.g. `Terms.Byte()` reading `"300"`) is still rejected rather than wrapping. The compiled path calls the same helper.
- **`OneOf.Parse`** only reads the cursor position when it skips whitespaces, the only case where it reverts it.
- **`NumberLiteral` keeps a `NumberFormatInfo`** rather than a `CultureInfo`, since `NumberFormatInfo.GetInstance()` returns the former directly.
- `Cursor.Offset` replaces `Cursor.Position.Offset` where only the offset is needed, which was building a `TextPosition` to read one field.

### Benchmarks

AMD Ryzen 9 5950X, .NET 10.0.10, 5 launches × 10 iterations, idle machine. All rows within 1-3% StdDev.

**JSON** — the string and cycle-detection changes:

| JsonBench | Before | After | |
|---|---|---|---|
| WideJson_ParlotCompiled | 58.06 µs | 27.53 µs | **-53%** |
| WideJson_Parlot | 56.73 µs | 27.68 µs | **-51%** |
| BigJson_Parlot | 119.81 µs | 63.88 µs | **-47%** |
| BigJson_ParlotCompiled | 119.59 µs | 65.61 µs | **-45%** |
| LongJson_Parlot | 81.05 µs | 54.46 µs | **-33%** |
| LongJson_ParlotCompiled | 80.05 µs | 53.59 µs | **-33%** |
| DeepJson_ParlotCompiled | 55.91 µs | 43.44 µs | **-22%** |
| DeepJson_Parlot | 56.69 µs | 44.00 µs | **-22%** |

The extra WideJson gain over the earlier numbers is the `HybridList`→`List<T>` change; it only builds a list of more than 4 items, so the other JSON shapes are unchanged by it.

Allocations: WideJson 54.45 KB → 40.71 KB (-25%), DeepJson 126.09 KB → 116.56 KB (-8%), others unchanged.

**Expression** — the integer fast path:

| ExprBench | Before | After | |
|---|---|---|---|
| ParlotCompiledSmall | 356.5 ns | 305.8 ns | **-14%** |
| ParlotFluentSmall | 356.4 ns | 307.7 ns | **-14%** |
| ParlotCompiledBig | 1844.9 ns | 1764.5 ns | -4% to -9%* |
| ParlotFluentBig | 1852.6 ns | 1749.0 ns | -6% to -10%* |

*The `Big` deltas are understated by run-to-run drift: the hand-written `ParlotRawBig` control, which these changes don't touch, was ~6% slower in the "after" run, so the true improvement is around 9-10%. The `Small` case is almost entirely number parsing and shows the effect most directly. Expression allocations are also lower (`ParlotCompiledSmall` 464 B → 408 B, both `Big` cases 1496 B → 1448 B).

A note on method: BenchmarkDotNet spawns a Roslyn compiler server (`VBCSCompiler`) to build its generated projects, and it lingers into the measurement phase and competes for CPU. Killing it once the run starts cut StdDev on the expression benchmarks roughly 20× (e.g. `ParlotCompiledBig` ±290 ns → ±14 ns); the numbers above are from runs with it suppressed.

### Tests

1670 → 1756, all passing on net8.0 and net10.0. Added coverage for the new `ICollection<T>` members, deep nesting that grows the tracking arrays, unterminated strings containing escapes, strings whose quote char is the escape char, and the integer fast path's boundaries (18 vs 19 digits, `long.MaxValue`, and narrow-type values like `byte` `"300"` that must not truncate to a valid number). Also one for a cycle where the frames in between sit at a different position — that guards the loop detection against being "optimized" into scanning only the entries at the current position, which would miss `P@5 → Q@9 → P@5` and stack overflow.

### Known trade-off

The cycle check is now O(active depth) rather than O(1). The vectorized scan wins comfortably at the depths these grammars reach, and the crossover where a hash table would win back is around a nesting depth of several hundred. Worth revisiting if deeply recursive grammars turn out to matter.
