### PR TITLE
Add typed hexadecimal, octal, and binary parsers

### DIFF
--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -269,6 +269,25 @@ Result:
 -12345.6
 ```
 
+### Hexadecimal, Octal and Binary
+
+Match integer digits in a specific radix and return any integer .NET type. These parsers don't consume
+a radix prefix or a leading sign.
+
+```c#
+Parser<T> Hexadecimal<T>() where T : IBinaryInteger<T>
+Parser<T> Octal<T>() where T : IBinaryInteger<T>
+Parser<T> Binary<T>() where T : IBinaryInteger<T>
+```
+
+Prefixes can be composed independently:
+
+```c#
+var hexadecimal = Terms.Text("0x").SkipAnd(Literals.Hexadecimal<int>());
+var octal = Terms.Text("0o").SkipAnd(Literals.Octal<int>());
+var binary = Terms.Text("0b").SkipAnd(Literals.Binary<int>());
+```
+
 ### String
 
 Matches a quoted string literal with escape sequences. Use this parser to parse strings from a programming language.

--- a/src/Parlot/Fluent/NumberLiterals.cs
+++ b/src/Parlot/Fluent/NumberLiterals.cs
@@ -82,4 +82,58 @@ public static class NumberLiterals
         }
 #endif
     }
+
+    public static Parser<T> CreateRadixNumberLiteralParser<T>(int radix)
+#if NET8_0_OR_GREATER
+    where T : IBinaryInteger<T>
+#endif
+    {
+        if (typeof(T) == typeof(byte))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<byte>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(sbyte))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<sbyte>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(short))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<short>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(ushort))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<ushort>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(int))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<int>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(uint))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<uint>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(long))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<long>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(ulong))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<ulong>(radix, Numbers.TryParseRadix);
+        }
+        else if (typeof(T) == typeof(BigInteger))
+        {
+            return (Parser<T>)(object)new RadixNumberLiteral<BigInteger>(radix, Numbers.TryParseRadix);
+        }
+#if NET8_0_OR_GREATER
+        else
+        {
+            return new RadixNumberLiteral<T>(radix, Numbers.TryParseRadix<T>);
+        }
+#else
+        else
+        {
+            throw new NotSupportedException($"The type '{typeof(T)}' is not supported as a radix number type.");
+        }
+#endif
+    }
 }

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -180,6 +180,33 @@ public class LiteralBuilder
     => NumberLiterals.CreateNumberLiteralParser<T>(numberOptions, decimalSeparator, groupSeparator);
 
     /// <summary>
+    /// Builds a parser that matches hexadecimal digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Hexadecimal<T>()
+#if NET8_0_OR_GREATER
+    where T : IBinaryInteger<T>
+#endif
+    => NumberLiterals.CreateRadixNumberLiteralParser<T>(16);
+
+    /// <summary>
+    /// Builds a parser that matches octal digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Octal<T>()
+#if NET8_0_OR_GREATER
+    where T : IBinaryInteger<T>
+#endif
+    => NumberLiterals.CreateRadixNumberLiteralParser<T>(8);
+
+    /// <summary>
+    /// Builds a parser that matches binary digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Binary<T>()
+#if NET8_0_OR_GREATER
+    where T : IBinaryInteger<T>
+#endif
+    => NumberLiterals.CreateRadixNumberLiteralParser<T>(2);
+
+    /// <summary>
     /// Builds a parser that matches an integer with an option leading sign.
     /// </summary>
     public Parser<long> Integer(NumberOptions numberOptions = NumberOptions.Integer) => Number<long>(numberOptions);
@@ -348,6 +375,33 @@ public class TermBuilder
         where T : INumber<T>
 #endif
         => Parsers.SkipWhiteSpace(NumberLiterals.CreateNumberLiteralParser<T>(numberOptions, decimalSeparator, groupSeparator));
+
+    /// <summary>
+    /// Builds a parser that matches hexadecimal digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Hexadecimal<T>()
+#if NET8_0_OR_GREATER
+        where T : IBinaryInteger<T>
+#endif
+        => Parsers.SkipWhiteSpace(NumberLiterals.CreateRadixNumberLiteralParser<T>(16));
+
+    /// <summary>
+    /// Builds a parser that matches octal digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Octal<T>()
+#if NET8_0_OR_GREATER
+        where T : IBinaryInteger<T>
+#endif
+        => Parsers.SkipWhiteSpace(NumberLiterals.CreateRadixNumberLiteralParser<T>(8));
+
+    /// <summary>
+    /// Builds a parser that matches binary digits without a prefix and returns any integer type.
+    /// </summary>
+    public Parser<T> Binary<T>()
+#if NET8_0_OR_GREATER
+        where T : IBinaryInteger<T>
+#endif
+        => Parsers.SkipWhiteSpace(NumberLiterals.CreateRadixNumberLiteralParser<T>(2));
 
     /// <summary>
     /// Builds a parser that matches an integer with an option leading sign.

--- a/src/Parlot/Fluent/RadixNumberLiteral.cs
+++ b/src/Parlot/Fluent/RadixNumberLiteral.cs
@@ -1,0 +1,97 @@
+using Parlot.Rewriting;
+using Parlot.SourceGeneration;
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Parlot.Fluent;
+
+internal delegate bool TryParseRadix<T>(ReadOnlySpan<char> span, int radix, out int charsRead, [MaybeNullWhen(false)] out T value);
+
+internal sealed class RadixNumberLiteral<T> : Parser<T>, ISeekable, ISourceable
+{
+    private readonly int _radix;
+    private readonly TryParseRadix<T> _tryParse;
+
+    public RadixNumberLiteral(int radix, TryParseRadix<T> tryParse)
+    {
+        _radix = radix;
+        _tryParse = tryParse;
+        ExpectedChars = GetDigits(radix).ToCharArray();
+        Name = radix switch
+        {
+            2 => "BinaryNumberLiteral",
+            8 => "OctalNumberLiteral",
+            16 => "HexadecimalNumberLiteral",
+            _ => throw new ArgumentOutOfRangeException(nameof(radix)),
+        };
+    }
+
+    public bool CanSeek => true;
+
+    public char[] ExpectedChars { get; }
+
+    public bool SkipWhitespace => false;
+
+    public override bool Parse(ParseContext context, ref ParseResult<T> result)
+    {
+        context.EnterParser(this);
+
+        var cursor = context.Scanner.Cursor;
+        var start = cursor.Offset;
+
+        if (_tryParse(cursor.Span, _radix, out var charsRead, out var value))
+        {
+            cursor.AdvanceNoNewLines(charsRead);
+            result.Set(start, start + charsRead, value);
+
+            context.ExitParser(this);
+            return true;
+        }
+
+        context.ExitParser(this);
+        return false;
+    }
+
+    public SourceResult GenerateSource(SourceGenerationContext context)
+    {
+        ThrowHelper.ThrowIfNull(context, nameof(context));
+
+        var result = context.CreateResult(typeof(T));
+        var cursorName = context.CursorName;
+        var valueTypeName = SourceGenerationContext.GetTypeName(typeof(T));
+        var charsReadName = $"charsRead{context.NextNumber()}";
+        var parsedValueName = $"parsedValue{context.NextNumber()}";
+        var supportsGenericMath =
+            context.TargetFramework.Identifier == TargetFrameworkIdentifier.NetCoreApp &&
+            context.TargetFramework.Version >= new Version(8, 0);
+        var tryParseMethod = Numbers.HasTryParseRadixOverload(typeof(T))
+            ? "global::Parlot.Numbers.TryParseRadix"
+            : supportsGenericMath
+                ? $"global::Parlot.Numbers.TryParseRadix<{valueTypeName}>"
+                : throw new NotSupportedException($"Source generation for radix numbers of type '{typeof(T)}' requires .NET 8 or later.");
+
+        result.Body.Add($"var {charsReadName} = 0;");
+        result.Body.Add($"{valueTypeName} {parsedValueName} = default;");
+        result.Body.Add($"{result.SuccessVariable} = {tryParseMethod}({cursorName}.Span, {_radix}, out {charsReadName}, out {parsedValueName});");
+        result.Body.Add($"if ({result.SuccessVariable})");
+        result.Body.Add("{");
+        result.Body.Add($"    {cursorName}.AdvanceNoNewLines({charsReadName});");
+
+        if (!context.DiscardResult)
+        {
+            result.Body.Add($"    {result.ValueVariable} = {parsedValueName};");
+        }
+
+        result.Body.Add("}");
+
+        return result;
+    }
+
+    private static string GetDigits(int radix) => radix switch
+    {
+        2 => Character.BinaryDigits,
+        8 => Character.OctalDigits,
+        16 => Character.HexDigits,
+        _ => throw new ArgumentOutOfRangeException(nameof(radix)),
+    };
+}

--- a/src/Parlot/Numbers.cs
+++ b/src/Parlot/Numbers.cs
@@ -13,6 +13,142 @@ namespace Parlot;
 /// </summary>
 public static class Numbers
 {
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out byte value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, byte.MaxValue, out charsRead, out var parsed);
+        value = (byte)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out sbyte value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, (ulong)sbyte.MaxValue, out charsRead, out var parsed);
+        value = (sbyte)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out short value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, (ulong)short.MaxValue, out charsRead, out var parsed);
+        value = (short)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out ushort value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, ushort.MaxValue, out charsRead, out var parsed);
+        value = (ushort)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out int value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, int.MaxValue, out charsRead, out var parsed);
+        value = (int)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out uint value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, uint.MaxValue, out charsRead, out var parsed);
+        value = (uint)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out long value)
+    {
+        var success = TryParseUnsignedRadix(span, radix, long.MaxValue, out charsRead, out var parsed);
+        value = (long)parsed;
+        return success;
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out ulong value)
+    {
+        return TryParseUnsignedRadix(span, radix, ulong.MaxValue, out charsRead, out value);
+    }
+
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix(ReadOnlySpan<char> span, int radix, out int charsRead, out BigInteger value)
+    {
+        value = BigInteger.Zero;
+        charsRead = 0;
+
+        if (!IsValidRadix(radix))
+        {
+            return false;
+        }
+
+        while (charsRead < span.Length && TryGetDigit(span[charsRead], radix, out var digit))
+        {
+            value = (value * radix) + digit;
+            charsRead++;
+        }
+
+        return charsRead > 0;
+    }
+
+#if NET8_0_OR_GREATER
+    /// <summary>
+    /// Parses digits in the specified radix.
+    /// </summary>
+    public static bool TryParseRadix<TNumber>(ReadOnlySpan<char> span, int radix, out int charsRead, [MaybeNullWhen(false)] out TNumber value)
+        where TNumber : IBinaryInteger<TNumber>
+    {
+        value = TNumber.Zero;
+        charsRead = 0;
+
+        if (!IsValidRadix(radix))
+        {
+            return false;
+        }
+
+        var radixValue = TNumber.CreateChecked(radix);
+
+        try
+        {
+            while (charsRead < span.Length && TryGetDigit(span[charsRead], radix, out var digit))
+            {
+                value = checked((value * radixValue) + TNumber.CreateChecked(digit));
+                charsRead++;
+            }
+        }
+        catch (OverflowException)
+        {
+            value = default;
+            charsRead = 0;
+            return false;
+        }
+
+        return charsRead > 0;
+    }
+#endif
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider provider, out byte value)
     {
@@ -174,6 +310,74 @@ public static class Numbers
                 }
         }
 #endif
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool TryGetDigit(char c, int radix, out int digit)
+    {
+        if ((uint)(c - '0') <= 9)
+        {
+            digit = c - '0';
+        }
+        else if ((uint)(c - 'A') <= 5)
+        {
+            digit = c - 'A' + 10;
+        }
+        else if ((uint)(c - 'a') <= 5)
+        {
+            digit = c - 'a' + 10;
+        }
+        else
+        {
+            digit = 0;
+            return false;
+        }
+
+        return digit < radix;
+    }
+
+    private static bool TryParseUnsignedRadix(ReadOnlySpan<char> span, int radix, ulong maxValue, out int charsRead, out ulong value)
+    {
+        value = 0;
+        charsRead = 0;
+
+        if (!IsValidRadix(radix))
+        {
+            return false;
+        }
+
+        var unsignedRadix = (uint)radix;
+
+        while (charsRead < span.Length && TryGetDigit(span[charsRead], radix, out var digit))
+        {
+            if (value > (maxValue - (uint)digit) / unsignedRadix)
+            {
+                value = default;
+                charsRead = 0;
+                return false;
+            }
+
+            value = (value * unsignedRadix) + (uint)digit;
+            charsRead++;
+        }
+
+        return charsRead > 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private static bool IsValidRadix(int radix) => (uint)(radix - 2) <= 14;
+
+    internal static bool HasTryParseRadixOverload(Type type)
+    {
+        return type == typeof(byte)
+            || type == typeof(sbyte)
+            || type == typeof(short)
+            || type == typeof(ushort)
+            || type == typeof(int)
+            || type == typeof(uint)
+            || type == typeof(long)
+            || type == typeof(ulong)
+            || type == typeof(BigInteger);
+    }
 
         /// <summary>
         /// Gets the Numbers.TryParse method for a specific numeric type.

--- a/test/Parlot.Benchmarks/RadixNumberBenchmarks.cs
+++ b/test/Parlot.Benchmarks/RadixNumberBenchmarks.cs
@@ -1,0 +1,58 @@
+using BenchmarkDotNet.Attributes;
+using Parlot.Fluent;
+using System;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, ShortRunJob]
+public class RadixNumberBenchmarks
+{
+    private static readonly Parser<uint> _hexadecimal = Literals.Hexadecimal<uint>();
+    private static readonly Parser<uint> _octal = Literals.Octal<uint>();
+    private static readonly Parser<uint> _binary = Literals.Binary<uint>();
+
+    private const string HexadecimalText = "deadbeef";
+    private const string OctalText = "33653337357";
+    private const string BinaryText = "11011110101011011011111011101111";
+    private const uint Expected = 0xdeadbeef;
+
+    private readonly ParseContext _hexadecimalContext = new(new Scanner(HexadecimalText));
+    private readonly ParseContext _octalContext = new(new Scanner(OctalText));
+    private readonly ParseContext _binaryContext = new(new Scanner(BinaryText));
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (Hexadecimal() != Expected) throw new InvalidOperationException(nameof(Hexadecimal));
+        if (Octal() != Expected) throw new InvalidOperationException(nameof(Octal));
+        if (Binary() != Expected) throw new InvalidOperationException(nameof(Binary));
+    }
+
+    [Benchmark]
+    public uint Hexadecimal()
+    {
+        _hexadecimalContext.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<uint>();
+        _hexadecimal.Parse(_hexadecimalContext, ref result);
+        return result.Value;
+    }
+
+    [Benchmark]
+    public uint Octal()
+    {
+        _octalContext.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<uint>();
+        _octal.Parse(_octalContext, ref result);
+        return result.Value;
+    }
+
+    [Benchmark]
+    public uint Binary()
+    {
+        _binaryContext.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<uint>();
+        _binary.Parse(_binaryContext, ref result);
+        return result.Value;
+    }
+}

--- a/test/Parlot.SourceGenerator.Tests/Grammars.cs
+++ b/test/Parlot.SourceGenerator.Tests/Grammars.cs
@@ -674,5 +674,14 @@ public static partial class Grammars
     public static Parser<decimal> DecimalNumberLiteralCustomCultureParser() => 
         Terms.Number<decimal>(NumberOptions.Number | NumberOptions.AllowGroupSeparators, decimalSeparator: ',', groupSeparator: '_');
 
+    [GenerateParser]
+    public static Parser<int> HexadecimalNumberLiteralParser() => Terms.Hexadecimal<int>();
+
+    [GenerateParser]
+    public static Parser<long> OctalNumberLiteralParser() => Terms.Octal<long>();
+
+    [GenerateParser]
+    public static Parser<byte> BinaryNumberLiteralParser() => Terms.Binary<byte>();
+
     #endregion
 }

--- a/test/Parlot.SourceGenerator.Tests/NumberLiteralTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/NumberLiteralTests.cs
@@ -217,6 +217,43 @@ public class NumberLiteralTests
         Assert.Equal(expected, value);
     }
 
+    [Theory]
+    [InlineData("2a", true, 42)]
+    [InlineData("  CAFE", true, 51966)]
+    [InlineData("xyz", false, 0)]
+    public void HexadecimalNumberLiteral_VariousInputs(string input, bool shouldSucceed, int expected)
+    {
+        var result = Grammars.HexadecimalNumberLiteralParser().TryParse(input, out var value);
+
+        Assert.Equal(shouldSucceed, result);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("52", true, 42)]
+    [InlineData("  177777", true, 65535)]
+    [InlineData("8", false, 0)]
+    public void OctalNumberLiteral_VariousInputs(string input, bool shouldSucceed, long expected)
+    {
+        var result = Grammars.OctalNumberLiteralParser().TryParse(input, out var value);
+
+        Assert.Equal(shouldSucceed, result);
+        Assert.Equal(expected, value);
+    }
+
+    [Theory]
+    [InlineData("101010", true, 42)]
+    [InlineData("  11111111", true, 255)]
+    [InlineData("100000000", false, 0)]
+    [InlineData("2", false, 0)]
+    public void BinaryNumberLiteral_VariousInputs(string input, bool shouldSucceed, byte expected)
+    {
+        var result = Grammars.BinaryNumberLiteralParser().TryParse(input, out var value);
+
+        Assert.Equal(shouldSucceed, result);
+        Assert.Equal(expected, value);
+    }
+
     #endregion
 
     #region Combined Custom Culture Tests

--- a/test/Parlot.Tests/NumberLiteralTests.cs
+++ b/test/Parlot.Tests/NumberLiteralTests.cs
@@ -196,6 +196,87 @@ public class NumberLiteralTests
         Assert.Equal(BigInteger.Parse("-123456789012345678901234567890"), result3);
     }
 
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("2a", 42)]
+    [InlineData("CAFE", 51966)]
+    public void HexadecimalNumberLiteralShouldParseValidNumbers(string source, int expected)
+    {
+        Assert.True(Literals.Hexadecimal<int>().TryParse(source, out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("52", 42)]
+    [InlineData("177777", 65535)]
+    public void OctalNumberLiteralShouldParseValidNumbers(string source, long expected)
+    {
+        Assert.True(Literals.Octal<long>().TryParse(source, out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("0", 0)]
+    [InlineData("101010", 42)]
+    [InlineData("11111111", 255)]
+    public void BinaryNumberLiteralShouldParseValidNumbers(string source, byte expected)
+    {
+        Assert.True(Literals.Binary<byte>().TryParse(source, out var result));
+        Assert.Equal(expected, result);
+    }
+
+    [Fact]
+    public void RadixNumberLiteralsShouldSupportDifferentNumericTypes()
+    {
+        Assert.Equal(255u, Literals.Hexadecimal<uint>().Parse("ff"));
+        Assert.Equal(uint.MaxValue, Literals.Hexadecimal<uint>().Parse("ffffffff"));
+        Assert.Equal(int.MaxValue, Literals.Hexadecimal<int>().Parse("7fffffff"));
+        Assert.Equal((ushort)511, Literals.Octal<ushort>().Parse("777"));
+        Assert.Equal(10L, Literals.Binary<long>().Parse("1010"));
+        Assert.Equal(new BigInteger(255), Literals.Hexadecimal<BigInteger>().Parse("ff"));
+    }
+
+    [Fact]
+    public void RadixNumberLiteralsShouldNotConsumePrefixes()
+    {
+        var parser = Literals.Text("0x").SkipAnd(Literals.Hexadecimal<int>());
+
+        Assert.True(parser.TryParse("0x2a", out var result));
+        Assert.Equal(42, result);
+    }
+
+    [Fact]
+    public void RadixNumberLiteralsShouldFailOnInvalidOrOverflowingNumbers()
+    {
+        Assert.False(Literals.Hexadecimal<int>().TryParse("xyz", out _));
+        Assert.False(Literals.Octal<int>().TryParse("89", out _));
+        Assert.False(Literals.Binary<int>().TryParse("2", out _));
+        Assert.False(Literals.Hexadecimal<byte>().TryParse("100", out _));
+        Assert.False(Literals.Hexadecimal<int>().TryParse("80000000", out _));
+        Assert.False(Literals.Octal<byte>().TryParse("400", out _));
+        Assert.False(Literals.Binary<byte>().TryParse("100000000", out _));
+    }
+
+    [Fact]
+    public void RadixNumberLiteralsShouldResetPositionWhenTheyFail()
+    {
+        var parser = OneOf(
+            Literals.Hexadecimal<byte>().Then(static _ => "number"),
+            Literals.Text("100").Then(static _ => "text"));
+
+        Assert.True(parser.TryParse("100", out var result));
+        Assert.Equal("text", result);
+    }
+
+    [Fact]
+    public void RadixNumberTermsShouldSkipWhiteSpace()
+    {
+        Assert.Equal(42, Terms.Hexadecimal<int>().Parse("  2a"));
+        Assert.Equal(42, Terms.Octal<int>().Parse("  52"));
+        Assert.Equal(42, Terms.Binary<int>().Parse("  101010"));
+    }
+
     [Fact]
     public void NumberLiteralsShouldSupportExponent()
     {


### PR DESCRIPTION
Parlot's typed number parser only handles decimal notation, so grammars currently need custom character matching and conversion logic for radix-based integers. This adds predefined, prefix-free radix parsers that compose naturally with existing literals while preserving the requested result type.

## Summary

- Add `Hexadecimal<T>()`, `Octal<T>()`, and `Binary<T>()` to both `Literals` and `Terms`
- Restrict results to integral `IBinaryInteger<T>` types on modern frameworks, with built-in integer and `BigInteger` support on downlevel targets
- Reject overflow without advancing the cursor and keep prefixes independent for composition such as `Text("0x").SkipAnd(Hexadecimal<int>())`
- Support seek optimization and source-generated parsers
- Document the APIs and cover runtime, whitespace, overflow, prefix composition, and generated-parser behavior

## Performance

The parser hot path performs no managed allocations in the added benchmarks:

| Parser | Mean | Allocated |
| --- | ---: | ---: |
| Hexadecimal | 11.61 ns | 0 B |
| Octal | 14.45 ns | 0 B |
| Binary | 45.83 ns | 0 B |

## Validation

- Full multi-target build
- 765 runtime tests
- 259 source-generator tests