### PR TITLE
Add configurable parser recursion safeguards

### DIFF
--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -11,6 +11,21 @@
 
 > Note: when samples use a local `input` variable representing the input text to parse, and a `parser` variable, the result is usually the outcome of calling `var result = parser.Parse(input)` or `var success = parser.TryParse(input, out var result)`.
 
+## Limiting parser recursion
+
+Recursive grammars can limit the nesting depth accepted from untrusted input by setting
+`maxRecursionDepth` on the `ParseContext`. The default value is `0`, which applies no limit.
+The limit applies to both runtime and source-generated parsers.
+
+```c#
+var context = new ParseContext(new Scanner(input), maxRecursionDepth: 128);
+
+if (!parser.TryParse(context, out var result, out var error))
+{
+    // error reports when the configured recursion limit was exceeded
+}
+```
+
 ## Terms and Literals
 
 These are lowest level elements of a grammar, like a `'.'` (dot), predefined strings like `"hello"`, numbers, and more.

--- a/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
+++ b/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
@@ -1456,8 +1456,28 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             {
                 sb.AppendLine($"        // {deferredParserName}");
             }
-            AppendAggressiveInliningIfSmall(sb, deferredResult);
+            sb.AppendLine("        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
             sb.AppendLine($"        private static bool {deferredMethodName}(ParseContext context, out {deferredValueTypeName} value)");
+            sb.AppendLine("        {");
+            sb.AppendLine("            if (context.MaxRecursionDepth > 0)");
+            sb.AppendLine("            {");
+            sb.AppendLine("                context.EnterRecursion();");
+            sb.AppendLine();
+            sb.AppendLine("                try");
+            sb.AppendLine("                {");
+            sb.AppendLine($"                    return {deferredMethodName}_Core(context, out value);");
+            sb.AppendLine("                }");
+            sb.AppendLine("                finally");
+            sb.AppendLine("                {");
+            sb.AppendLine("                    context.ExitRecursion();");
+            sb.AppendLine("                }");
+            sb.AppendLine("            }");
+            sb.AppendLine();
+            sb.AppendLine($"            return {deferredMethodName}_Core(context, out value);");
+            sb.AppendLine("        }");
+            sb.AppendLine();
+            AppendAggressiveInliningIfSmall(sb, deferredResult);
+            sb.AppendLine($"        private static bool {deferredMethodName}_Core(ParseContext context, out {deferredValueTypeName} value)");
             sb.AppendLine("        {");
             sb.AppendLine("            context.CheckCancellation();");
             sb.AppendLine("            var scanner = context.Scanner;");

--- a/src/Parlot/Fluent/Deferred.cs
+++ b/src/Parlot/Fluent/Deferred.cs
@@ -50,6 +50,13 @@ public sealed class Deferred<T> : Parser<T>, ISeekable, ISourceable
             throw new InvalidOperationException("Parser has not been initialized");
         }
 
+        var limitRecursion = context.MaxRecursionDepth > 0;
+
+        if (limitRecursion)
+        {
+            context.EnterRecursion();
+        }
+
         var trackPosition = !context.DisableLoopDetection;
 
         // Remember the position where we entered this parser
@@ -64,6 +71,11 @@ public sealed class Deferred<T> : Parser<T>, ISeekable, ISourceable
             if (!context.PushParserAtPosition(this))
             {
                 // Cycle detected at this position - fail gracefully instead of stack overflow
+                if (limitRecursion)
+                {
+                    context.ExitRecursion();
+                }
+
                 return false;
             }
         }
@@ -85,6 +97,11 @@ public sealed class Deferred<T> : Parser<T>, ISeekable, ISourceable
             if (trackPosition)
             {
                 context.PopParserAtPosition(this, entryPosition);
+            }
+
+            if (limitRecursion)
+            {
+                context.ExitRecursion();
             }
         }
     }

--- a/src/Parlot/Fluent/ParseContext.cs
+++ b/src/Parlot/Fluent/ParseContext.cs
@@ -17,6 +17,11 @@ public class ParseContext
     public bool DisableLoopDetection { get; }
 
     /// <summary>
+    /// The maximum number of nested recursive parser invocations, or <c>0</c> for no limit.
+    /// </summary>
+    public int MaxRecursionDepth { get; }
+
+    /// <summary>
     /// Whether new lines are treated as normal chars or white spaces. Default is <c>false</c>.
     /// </summary>
     /// <remarks>
@@ -49,6 +54,7 @@ public class ParseContext
     public readonly CancellationToken CancellationToken;
 
     private int _cancellationCheckCount;
+    private int _recursionDepth;
 
     // TODO: For backward compatibility only, remove in future versions
     public ParseContext(Scanner scanner, bool useNewLines)
@@ -63,11 +69,24 @@ public class ParseContext
     }
 
     public ParseContext(Scanner scanner, bool useNewLines = false, bool disableLoopDetection = false, CancellationToken cancellationToken = default)
+        : this(scanner, 0, useNewLines, disableLoopDetection, cancellationToken)
     {
+    }
+
+    public ParseContext(
+        Scanner scanner,
+        int maxRecursionDepth,
+        bool useNewLines = false,
+        bool disableLoopDetection = false,
+        CancellationToken cancellationToken = default)
+    {
+        ThrowHelper.ThrowIfNegative(maxRecursionDepth, nameof(maxRecursionDepth));
+
         Scanner = scanner ?? throw new ArgumentNullException(nameof(scanner));
         UseNewLines = useNewLines;
         CancellationToken = cancellationToken;
         DisableLoopDetection = disableLoopDetection;
+        MaxRecursionDepth = maxRecursionDepth;
     }
 
     /// <summary>
@@ -162,6 +181,41 @@ public class ParseContext
     public void ExitParser<T>(Parser<T> parser)
     {
         OnExitParser?.Invoke(parser, this);
+    }
+
+    /// <summary>
+    /// Records entry into a recursive parser and throws when <see cref="MaxRecursionDepth"/> is exceeded.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void EnterRecursion()
+    {
+        var maxRecursionDepth = MaxRecursionDepth;
+
+        if (maxRecursionDepth == 0)
+        {
+            return;
+        }
+
+        if (_recursionDepth >= maxRecursionDepth)
+        {
+            throw new ParseException(
+                $"The maximum parser recursion depth of {maxRecursionDepth} was exceeded.",
+                Scanner.Cursor.Position);
+        }
+
+        _recursionDepth++;
+    }
+
+    /// <summary>
+    /// Records exit from a recursive parser.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void ExitRecursion()
+    {
+        if (_recursionDepth > 0)
+        {
+            _recursionDepth--;
+        }
     }
 
     /// <summary>

--- a/src/Parlot/Fluent/Unary.cs
+++ b/src/Parlot/Fluent/Unary.cs
@@ -1,6 +1,7 @@
 using Parlot.SourceGeneration;
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Parlot.Fluent;
 
@@ -26,7 +27,27 @@ public sealed class Unary<T, TInput> : Parser<T>, ISourceable
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
+    {
+        if (context.MaxRecursionDepth > 0)
+        {
+            context.EnterRecursion();
+
+            try
+            {
+                return ParseCore(context, ref result);
+            }
+            finally
+            {
+                context.ExitRecursion();
+            }
+        }
+
+        return ParseCore(context, ref result);
+    }
+
+    private bool ParseCore(ParseContext context, ref ParseResult<T> result)
     {
         context.EnterParser(this);
 
@@ -205,7 +226,27 @@ public sealed class UnaryWithContext<T, TInput> : Parser<T>, ISourceable
         }
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
+    {
+        if (context.MaxRecursionDepth > 0)
+        {
+            context.EnterRecursion();
+
+            try
+            {
+                return ParseCore(context, ref result);
+            }
+            finally
+            {
+                context.ExitRecursion();
+            }
+        }
+
+        return ParseCore(context, ref result);
+    }
+
+    private bool ParseCore(ParseContext context, ref ParseResult<T> result)
     {
         context.EnterParser(this);
 

--- a/src/Parlot/ThrowHelper.cs
+++ b/src/Parlot/ThrowHelper.cs
@@ -10,4 +10,17 @@ internal static class ThrowHelper
     {
         ArgumentNullException.ThrowIfNull(argument, paramName);
     }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static void ThrowIfNegative(int argument, string? paramName = null)
+    {
+#if NET8_0_OR_GREATER
+        ArgumentOutOfRangeException.ThrowIfNegative(argument, paramName);
+#else
+        if (argument < 0)
+        {
+            throw new ArgumentOutOfRangeException(paramName);
+        }
+#endif
+    }
 }

--- a/test/Parlot.SourceGenerator.Tests/GrammarsTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/GrammarsTests.cs
@@ -266,6 +266,24 @@ public class GrammarsTests
     }
 
     [Fact]
+    public void GeneratedCalculatorParser_EnforcesMaxRecursionDepth()
+    {
+        var parser = Grammars.CalculatorParser();
+        const string source = "((1))";
+
+        var allowedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 3);
+        Assert.True(parser.TryParse(allowedContext, out var result, out var error));
+        Assert.NotNull(result);
+        Assert.Null(error);
+
+        var limitedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 2);
+        Assert.False(parser.TryParse(limitedContext, out _, out error));
+        Assert.NotNull(error);
+        Assert.Equal("The maximum parser recursion depth of 2 was exceeded.", error.Message);
+        Assert.Equal(2, error.Position.Offset);
+    }
+
+    [Fact]
     public void CountingOneOf_OnlyMatchingParserInvoked()
     {
         CountingParser.Reset();

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -1728,6 +1728,66 @@ public class FluentTests
     }
 
     [Fact]
+    public void DeferredShouldEnforceMaxRecursionDepth()
+    {
+        var list = Deferred<string>();
+        list.Parser = Between(Literals.Char('['), list, Literals.Char(']')).Then(static _ => "list")
+            .Or(Literals.Text("item"));
+        var source = "[[[item]]]";
+
+        var allowedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 4);
+        Assert.True(list.TryParse(allowedContext, out var result, out var error));
+        Assert.Equal("list", result);
+        Assert.Null(error);
+
+        var limitedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 3);
+        Assert.False(list.TryParse(limitedContext, out _, out error));
+        Assert.NotNull(error);
+        Assert.Equal("The maximum parser recursion depth of 3 was exceeded.", error.Message);
+        Assert.Equal(3, error.Position.Offset);
+    }
+
+    [Fact]
+    public void UnaryShouldEnforceMaxRecursionDepth()
+    {
+        var parser = Literals.Char('a').Unary(
+            (Literals.Char('-'), static value => value));
+        const string source = "---a";
+
+        var allowedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 4);
+        Assert.True(parser.TryParse(allowedContext, out _, out var error));
+        Assert.Null(error);
+
+        var limitedContext = new ParseContext(new Scanner(source), maxRecursionDepth: 3);
+        Assert.False(parser.TryParse(limitedContext, out _, out error));
+        Assert.NotNull(error);
+        Assert.Equal("The maximum parser recursion depth of 3 was exceeded.", error.Message);
+        Assert.Equal(3, error.Position.Offset);
+    }
+
+    [Fact]
+    public void RecursionLimitShouldWorkWhenLoopDetectionIsDisabled()
+    {
+        var loop = Deferred<string>();
+        loop.Parser = loop;
+        var context = new ParseContext(
+            new Scanner("test"),
+            maxRecursionDepth: 4,
+            disableLoopDetection: true);
+
+        Assert.False(loop.TryParse(context, out _, out var error));
+        Assert.NotNull(error);
+        Assert.Equal("The maximum parser recursion depth of 4 was exceeded.", error.Message);
+    }
+
+    [Fact]
+    public void ParseContextShouldRejectNegativeMaxRecursionDepth()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            static () => new ParseContext(new Scanner("test"), maxRecursionDepth: -1));
+    }
+
+    [Fact]
     public void DeferredShouldAllowValidRecursion()
     {
         // Valid recursive parser - should still work


### PR DESCRIPTION
Untrusted input can drive valid recursive grammars deeply enough to exhaust the process stack. This adds an opt-in recursion depth limit while preserving the existing unlimited behavior and keeping its overhead to a fast branch when no limit is configured.

- Adds `ParseContext.MaxRecursionDepth`, with `0` meaning unlimited.
- Enforces the limit for `Deferred` and unary recursion in runtime parsers.
- Emits equivalent guards for source-generated recursive helpers.
- Reports limit violations through the existing parse error path and safely unwinds tracking state.
- Documents the configuration and covers runtime, generated, disabled-loop-detection, boundary, and invalid-value cases.