### PR TITLE
Harden parser generation and release security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,8 @@
 name: Build
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]
@@ -30,8 +33,10 @@ jobs:
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        persist-credentials: false
+    - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: | 
           8.0.x

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,37 +1,85 @@
 name: Publish
 
+permissions:
+  contents: read
+
 on:
   push:
     tags: 
       - 'v*.*.*'
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
+    permissions:
+      attestations: write
+      contents: read
+      id-token: write
     env:
         DOTNET_NOLOGO: true
         DOTNET_CLI_TELEMETRY_OPTOUT: 1
 
     steps:
-    - uses: actions/checkout@v6
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      with:
+        fetch-depth: 0
+        persist-credentials: false
+    - uses: actions/setup-dotnet@26b0ec14cb23fa6904739307f278c14f94c95bf1 # v5.4.0
       with:
         dotnet-version: | 
           8.0.x
           10.0.x
         global-json-file: global.json
-    
-    - name: Test
-      run: dotnet test --project test/Parlot.Tests/Parlot.Tests.csproj --configuration Release
+
+    - name: Validate release tag
+      id: release
+      shell: bash
+      run: |
+        set -euo pipefail
+        core_identifier='(0|[1-9][0-9]*)'
+        prerelease_identifier='(0|[1-9][0-9]*|[0-9A-Za-z-]*[A-Za-z-][0-9A-Za-z-]*)'
+        release_pattern="^v${core_identifier}\.${core_identifier}\.${core_identifier}(-${prerelease_identifier}(\.${prerelease_identifier})*)?$"
+        if [[ ! "$GITHUB_REF_NAME" =~ $release_pattern ]]; then
+          echo "::error::Release tags must be semantic versions such as v1.2.3 or v1.2.3-preview.1."
+          exit 1
+        fi
+
+        git fetch --no-tags origin main
+        release_commit="$(git rev-parse "${GITHUB_REF_NAME}^{commit}")"
+        if ! git merge-base --is-ancestor "$release_commit" origin/main; then
+          echo "::error::Release tags must point to a commit contained in origin/main."
+          exit 1
+        fi
+
+        echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+    - name: Build
+      run: dotnet build --configuration Release -p:Version=${{ steps.release.outputs.version }} -p:ContinuousIntegrationBuild=True
+
+    - name: Test Parlot
+      run: dotnet test test/Parlot.Tests/Parlot.Tests.csproj --configuration Release --no-build -f net10.0
+
+    - name: Test source generator
+      run: dotnet test test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj --configuration Release --no-build
 
     - name: Pack with dotnet
-      run: |
-        arrTag=(${GITHUB_REF//\// })
-        VERSION="${arrTag[2]}"
-        VERSION="${VERSION#v}"
-        echo "$VERSION"
-        dotnet pack --output artifacts --configuration Release -p:Version=$VERSION -p:ContinuousIntegrationBuild=True
+      run: dotnet pack --output artifacts --configuration Release --no-build -p:Version=${{ steps.release.outputs.version }} -p:ContinuousIntegrationBuild=True
+
+    - name: Attest NuGet packages
+      uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # v3
+      with:
+        subject-path: artifacts/*.nupkg
 
     - name: Push with dotnet
-      run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+      shell: bash
+      env:
+        NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+      run: |
+        set -euo pipefail
+        for package in artifacts/*.nupkg; do
+          dotnet nuget push "$package" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate
+        done

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ static FluentParser()
 - [Existing parsers and usage examples](docs/parsers.md)
 - [Best practices for custom parsers](docs/writing.md)
 - [Source generation guide](docs/source-generation.md)
+- [Security guidance](docs/security.md)
 
 ## Source-generated parsers
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,82 @@
+# Security guidance
+
+Parlot parses data in the caller's process and source-generates parsers in the compiler process. Applications
+and build pipelines must set resource and trust boundaries appropriate for the data and code they process.
+
+## Source generation and build-time code execution
+
+`[GenerateParser]` executes the annotated parser factory at build time to construct its parser graph. The
+factory runs inside the compiler host with that process's filesystem, network, environment-variable, and
+credential access. Treat parser factories and every method they call as trusted executable build code.
+
+`[IncludeGenerators]` loads and executes selected analyzer assemblies before Parlot emits the temporary
+compilation. Enabling it is equivalent to trusting those packages and their transitive dependencies as
+executable build dependencies. Pin and review generator dependencies and do not use `IncludeGenerators` to
+run code from an untrusted repository or package source.
+
+Build an untrusted repository only in a disposable, isolated worker or container:
+
+- do not mount developer home directories, SSH agents, package-publishing credentials, or cloud credential
+  stores;
+- provide read-only source and package caches where possible, disable unnecessary network access, and discard
+  the worker after the build;
+- do not expose unrelated CI secrets to pull-request builds or compiler processes; and
+- review project files, targets, analyzers, generators, and parser factories before running restore or build.
+
+Source-generator diagnostics can contain compiler messages and source file names. Do not publish unrestricted
+build logs from sensitive repositories.
+
+## IncludeFiles containment
+
+`[IncludeFiles]` is for C# sources needed by the temporary parser-factory compilation. Paths are relative to
+the source file containing the parser factory, but their normalized targets must remain within the MSBuild
+project root. Parlot rejects:
+
+- absolute paths and parent traversal that escapes the project root;
+- symbolic links in any included path;
+- patterns not ending in `.cs`;
+- more than 256 files, files larger than 1 MiB, total included content larger than 8 MiB, or glob traversal
+  beyond 10,000 entries.
+
+Rejected entries produce `PARLOT016` through `PARLOT020`. Diagnostics identify the attribute entry number
+instead of disclosing its original or resolved path. Prefer exact paths such as `Ast/Nodes.cs`; when a glob is
+necessary, anchor it to the narrowest directory, such as `Ast/Generated/*.cs`, instead of `**/*.cs`.
+
+## Processing untrusted input
+
+Parlot does not impose an application-wide input or result limit. Consumers should enforce all of the
+following before accepting hostile input:
+
+- reject inputs over an application-specific byte or character limit before creating a `Scanner`;
+- pass a `CancellationToken` with a deadline and set `ParseContext.MaxRecursionDepth` for recursive grammars;
+- bound repeated elements, AST depth, decoded string lengths, and other result growth in the grammar or
+  semantic actions;
+- avoid returning raw input, file paths, tokens, or source excerpts in user-visible errors and logs; map
+  diagnostics to a redacted application error at trust boundaries; and
+- run high-risk parsing in a separate process with CPU, memory, time, filesystem, and network restrictions.
+
+Repetition combinators stop when a successful child parser consumes no input, preventing empty-match loops.
+Cancellation is cooperative and checked regularly at parser entry; it is not a replacement for process-level
+resource limits in hostile multi-tenant scenarios.
+
+Semantic actions (`Then`, predicates, custom parsers, and custom `ParseContext` hooks) execute arbitrary
+application code. Use only trusted actions, avoid ambient secrets and side effects, and apply the same output
+and cancellation limits to code called from them.
+
+## Release controls
+
+The repository workflows use explicit least-privilege permissions, immutable action commits, semantic-version
+tag validation, a main-branch ancestry check, and GitHub build-provenance attestations for `.nupkg` files.
+The following controls require repository or NuGet configuration and cannot be enforced safely in source:
+
+- protect the `v*` tag namespace with a GitHub ruleset and restrict tag creation and deletion to release
+  maintainers or the release automation;
+- require reviewed pull requests and successful required checks on `main`;
+- place publishing behind a protected GitHub environment with required reviewers;
+- configure NuGet.org Trusted Publishing for this repository and `publish.yml`, then replace the long-lived
+  `NUGET_API_KEY` with the short-lived credential produced by `NuGet/login`; and
+- restrict or remove the legacy NuGet API key after Trusted Publishing is verified.
+
+The workflow intentionally retains the existing API-key publication step until the NuGet.org Trusted
+Publishing policy exists. Published package provenance can be checked with
+`gh attestation verify <package.nupkg> --repo sebastienros/parlot`.

--- a/docs/security.md
+++ b/docs/security.md
@@ -62,21 +62,3 @@ resource limits in hostile multi-tenant scenarios.
 Semantic actions (`Then`, predicates, custom parsers, and custom `ParseContext` hooks) execute arbitrary
 application code. Use only trusted actions, avoid ambient secrets and side effects, and apply the same output
 and cancellation limits to code called from them.
-
-## Release controls
-
-The repository workflows use explicit least-privilege permissions, immutable action commits, semantic-version
-tag validation, a main-branch ancestry check, and GitHub build-provenance attestations for `.nupkg` files.
-The following controls require repository or NuGet configuration and cannot be enforced safely in source:
-
-- protect the `v*` tag namespace with a GitHub ruleset and restrict tag creation and deletion to release
-  maintainers or the release automation;
-- require reviewed pull requests and successful required checks on `main`;
-- place publishing behind a protected GitHub environment with required reviewers;
-- configure NuGet.org Trusted Publishing for this repository and `publish.yml`, then replace the long-lived
-  `NUGET_API_KEY` with the short-lived credential produced by `NuGet/login`; and
-- restrict or remove the legacy NuGet API key after Trusted Publishing is verified.
-
-The workflow intentionally retains the existing API-key publication step until the NuGet.org Trusted
-Publishing policy exists. Published package provenance can be checked with
-`gh attestation verify <package.nupkg> --repo sebastienros/parlot`.

--- a/docs/source-generation.md
+++ b/docs/source-generation.md
@@ -35,10 +35,17 @@ var result = parser.Parse("hello world");
 
 ## How It Works
 
-1. The source generator executes your method at compile time to build the parser graph.
+1. The source generator executes your method at compile time inside the compiler host to build the parser graph.
 2. It traverses the graph and generates optimized C# code for each parser.
 3. C# interceptors replace calls to your method with the generated implementation.
 4. At runtime, no parser graph construction occurs—just the generated code runs.
+
+> [!WARNING]
+> `[GenerateParser]` factory methods are executable build code, not declarative metadata. They run with the
+> compiler host's process permissions and can access the build environment. `[IncludeGenerators]` additionally
+> loads and executes the selected analyzer assemblies, which is equivalent to trusting executable build
+> dependencies. Only build trusted parser factories and generators outside an isolated environment. See the
+> [security guidance](security.md#source-generation-and-build-time-code-execution).
 
 ## Requirements
 
@@ -82,8 +89,14 @@ Examples:
 [IncludeFiles("*.cs")]                    // All .cs files in same directory
 [IncludeFiles("Models/*.cs")]             // All .cs files in Models subdirectory
 [IncludeFiles("**/*.cs")]                 // All .cs files recursively
-[IncludeFiles("../Shared/**/*.cs")]       // Relative paths supported
+[IncludeFiles("../Shared/**/*.cs")]       // Parent paths are allowed only within the project root
 ```
+
+Paths are resolved from the parser source file but must remain inside the MSBuild project root. Absolute
+paths, symbolic-link traversal, and patterns not ending in `.cs` are rejected. A parser can include at most
+256 files, each no larger than 1 MiB and no larger than 8 MiB in total; glob traversal is capped at 10,000
+entries. Rejections are reported as `PARLOT016`-`PARLOT020` diagnostics without resolved filesystem paths.
+Use exact files or narrow directory globs rather than project-wide `**/*.cs` patterns.
 
 ### [IncludeUsings]
 
@@ -107,6 +120,9 @@ public static Parser<Expression> CreateParser() => ...;
 // Multiple generators
 [IncludeGenerators("PolySharp", "Microsoft.Extensions.Logging.Generators")]
 ```
+
+Included generators execute in the compiler host. Treat every named generator and its transitive package
+dependencies as trusted executable build code.
 
 ### Class-Level Attributes
 

--- a/src/Parlot.SourceGenerator/IncludeFilesAttribute.cs
+++ b/src/Parlot.SourceGenerator/IncludeFilesAttribute.cs
@@ -7,8 +7,9 @@ namespace Parlot.SourceGenerator;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <strong>Root Directory:</strong> All file paths are resolved relative to the directory containing 
-/// the source file where the <c>[GenerateParser]</c> method is defined, not the project root or solution root.
+/// <strong>Root Directory:</strong> All file paths are resolved relative to the directory containing
+/// the source file where the <c>[GenerateParser]</c> method is defined. Paths must remain within the
+/// MSBuild project root. Absolute paths, symbolic links, and patterns not ending in <c>.cs</c> are rejected.
 /// Both forward slashes (/) and backslashes (\) are accepted as path separators.
 /// </para>
 /// 
@@ -41,7 +42,7 @@ namespace Parlot.SourceGenerator;
 /// Using glob patterns to include multiple files:
 /// <code>
 /// [GenerateParser]
-/// [IncludeFiles("*.cs", "../Shared/**/*.cs")]
+/// [IncludeFiles("*.cs", "../Shared/**/*.cs")] // Shared must remain inside the project root.
 /// public static Parser&lt;Expression&gt; CreateExpressionParser() =&gt; ...;
 /// </code>
 /// 
@@ -78,7 +79,8 @@ sealed class IncludeFilesAttribute : System.Attribute
     /// Specifies additional source files to include when generating the parser.
     /// </summary>
     /// <param name="files">
-    /// Relative paths or glob patterns for files to include (relative to the file containing the parser method).
+    /// Relative paths or glob patterns for C# files to include (relative to the file containing the parser method
+    /// and contained by the MSBuild project root).
     /// Supports wildcards: * (any characters except /), ** (recursive, any characters including /), and ? (single character).
     /// Both / and \ are accepted as path separators.
     /// </param>

--- a/src/Parlot.SourceGenerator/IncludeFilesResolver.cs
+++ b/src/Parlot.SourceGenerator/IncludeFilesResolver.cs
@@ -1,0 +1,523 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Parlot.SourceGenerator;
+
+internal static class IncludeFilesResolver
+{
+    private static readonly char[] _pathSeparators = ['/', '\\'];
+    private static readonly char[] _invalidFileNameCharacters = Path.GetInvalidFileNameChars();
+
+    private const int MaxIncludedFileCount = 256;
+    private const long MaxIncludedFileSize = 1024 * 1024;
+    private const long MaxIncludedFilesTotalSize = 8 * 1024 * 1024;
+    private const int MaxGlobEntries = 10_000;
+
+    [SuppressMessage("Build", "RS1035", Justification = "IncludeFiles explicitly opts source files into the generator's temporary compilation.")]
+    public static bool TryLoad(
+        SourceProductionContext context,
+        IMethodSymbol methodSymbol,
+        Location? attributeLocation,
+        string[] patterns,
+        SyntaxTree originalSyntaxTree,
+        string projectDirectory,
+        CSharpParseOptions parseOptions,
+        IEnumerable<SyntaxTree> existingTrees,
+        out List<SyntaxTree> includedTrees)
+    {
+        includedTrees = new List<SyntaxTree>();
+        var diagnosticLocation = attributeLocation ?? methodSymbol.Locations.FirstOrDefault();
+
+        if (string.IsNullOrWhiteSpace(projectDirectory) || !Path.IsPathRooted(projectDirectory))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ParserSourceGenerator.ProjectRootUnavailableDescriptor,
+                diagnosticLocation,
+                methodSymbol.Name));
+            return false;
+        }
+
+        if (!TryGetRoots(projectDirectory, originalSyntaxTree.FilePath, out var projectRoot, out var sourceDirectory))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ParserSourceGenerator.InvalidIncludeFileDescriptor,
+                diagnosticLocation,
+                1,
+                methodSymbol.Name,
+                "the project or parser source path is invalid"));
+            return false;
+        }
+
+        if (!IsWithinProjectRoot(projectRoot, sourceDirectory))
+        {
+            context.ReportDiagnostic(Diagnostic.Create(
+                ParserSourceGenerator.InvalidIncludeFileDescriptor,
+                diagnosticLocation,
+                1,
+                methodSymbol.Name,
+                "the parser source file is outside the project root"));
+            return false;
+        }
+
+        var comparer = GetPathComparer();
+        var existingPaths = new HashSet<string>(
+            existingTrees
+                .Select(static tree => tree.FilePath)
+                .Where(static path => !string.IsNullOrWhiteSpace(path))
+                .Select(Path.GetFullPath),
+            comparer);
+        var includedPaths = new HashSet<string>(comparer);
+        long totalSize = 0;
+
+        for (var entryIndex = 0; entryIndex < patterns.Length; entryIndex++)
+        {
+            var displayIndex = entryIndex + 1;
+            if (!TryNormalizePattern(
+                projectRoot,
+                sourceDirectory,
+                patterns[entryIndex],
+                out var normalizedPattern,
+                out var rejectionReason))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ParserSourceGenerator.InvalidIncludeFileDescriptor,
+                    diagnosticLocation,
+                    displayIndex,
+                    methodSymbol.Name,
+                    rejectionReason));
+                return false;
+            }
+
+            if (!TryFindFiles(
+                context,
+                diagnosticLocation,
+                methodSymbol.Name,
+                displayIndex,
+                projectRoot,
+                normalizedPattern,
+                out var matchedFiles))
+            {
+                return false;
+            }
+
+            if (matchedFiles.Count == 0)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ParserSourceGenerator.IncludeFileNotFoundDescriptor,
+                    diagnosticLocation,
+                    displayIndex,
+                    methodSymbol.Name));
+                return false;
+            }
+
+            foreach (var matchedFile in matchedFiles)
+            {
+                if (!includedPaths.Add(matchedFile) || existingPaths.Contains(matchedFile))
+                {
+                    continue;
+                }
+
+                if (includedPaths.Count > MaxIncludedFileCount)
+                {
+                    ReportLimit(context, diagnosticLocation, displayIndex, methodSymbol.Name, $"{MaxIncludedFileCount} file");
+                    return false;
+                }
+
+                try
+                {
+                    var fileLength = new FileInfo(matchedFile).Length;
+                    if (fileLength > MaxIncludedFileSize)
+                    {
+                        ReportLimit(context, diagnosticLocation, displayIndex, methodSymbol.Name, $"{MaxIncludedFileSize / 1024} KiB per-file");
+                        return false;
+                    }
+
+                    totalSize += fileLength;
+                    if (totalSize > MaxIncludedFilesTotalSize)
+                    {
+                        ReportLimit(context, diagnosticLocation, displayIndex, methodSymbol.Name, $"{MaxIncludedFilesTotalSize / (1024 * 1024)} MiB total-size");
+                        return false;
+                    }
+
+                    var sourceText = SourceText.From(File.ReadAllText(matchedFile), Encoding.UTF8);
+                    includedTrees.Add(CSharpSyntaxTree.ParseText(sourceText, parseOptions, matchedFile));
+                }
+                catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+                {
+                    ReportReadFailure(context, diagnosticLocation, displayIndex, methodSymbol.Name, ex);
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool TryGetRoots(
+        string projectDirectory,
+        string sourcePath,
+        out string projectRoot,
+        out string sourceDirectory)
+    {
+        projectRoot = "";
+        sourceDirectory = "";
+
+        if (string.IsNullOrWhiteSpace(sourcePath))
+        {
+            return false;
+        }
+
+        try
+        {
+            projectRoot = TrimEndingDirectorySeparators(Path.GetFullPath(projectDirectory));
+            sourceDirectory = Path.GetDirectoryName(Path.GetFullPath(sourcePath)) ?? "";
+            return sourceDirectory.Length > 0;
+        }
+        catch (Exception ex) when (ex is ArgumentException or IOException or NotSupportedException)
+        {
+            return false;
+        }
+    }
+
+    private static bool TryNormalizePattern(
+        string projectRoot,
+        string sourceDirectory,
+        string pattern,
+        out string normalizedPattern,
+        out string rejectionReason)
+    {
+        normalizedPattern = "";
+        rejectionReason = "";
+
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            rejectionReason = "the path is empty";
+            return false;
+        }
+
+        if (Path.IsPathRooted(pattern) || pattern.IndexOf(':') >= 0)
+        {
+            rejectionReason = "absolute paths are not allowed";
+            return false;
+        }
+
+        if (pattern.IndexOf('\0') >= 0)
+        {
+            rejectionReason = "the path contains an invalid character";
+            return false;
+        }
+
+        var rootWithSeparator = EnsureEndingDirectorySeparator(projectRoot);
+        var relativeSourceDirectory = sourceDirectory.Length == projectRoot.Length
+            ? ""
+            : sourceDirectory.Substring(rootWithSeparator.Length);
+        var segments = relativeSourceDirectory
+            .Split(_pathSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .ToList();
+
+        foreach (var segment in pattern.Split(_pathSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (segment == ".")
+            {
+                continue;
+            }
+
+            if (segment == "..")
+            {
+                if (segments.Count == 0)
+                {
+                    rejectionReason = "the path escapes the project root";
+                    return false;
+                }
+
+                segments.RemoveAt(segments.Count - 1);
+                continue;
+            }
+
+            if (!HasOnlyValidPatternCharacters(segment))
+            {
+                rejectionReason = "the path contains an invalid character";
+                return false;
+            }
+
+            segments.Add(segment);
+        }
+
+        if (segments.Count == 0)
+        {
+            rejectionReason = "the path does not identify a C# source file";
+            return false;
+        }
+
+        normalizedPattern = string.Join("/", segments);
+        if (!normalizedPattern.EndsWith(".cs", StringComparison.OrdinalIgnoreCase))
+        {
+            rejectionReason = "only patterns ending in .cs are allowed";
+            return false;
+        }
+
+        return true;
+    }
+
+    private static bool HasOnlyValidPatternCharacters(string segment)
+    {
+        return segment.All(c => Array.IndexOf(_invalidFileNameCharacters, c) < 0 || c is '*' or '?');
+    }
+
+    [SuppressMessage("Build", "RS1035", Justification = "IncludeFiles explicitly opts source files into the generator's temporary compilation.")]
+    private static bool TryFindFiles(
+        SourceProductionContext context,
+        Location? diagnosticLocation,
+        string methodName,
+        int entryIndex,
+        string projectRoot,
+        string normalizedPattern,
+        out List<string> matchedFiles)
+    {
+        matchedFiles = new List<string>();
+
+        if (!ContainsWildcard(normalizedPattern))
+        {
+            var fullPath = Path.GetFullPath(Path.Combine(
+                projectRoot,
+                normalizedPattern.Replace('/', Path.DirectorySeparatorChar)));
+
+            if (!File.Exists(fullPath))
+            {
+                return true;
+            }
+
+            if (ContainsReparsePoint(projectRoot, fullPath))
+            {
+                ReportSymlink(context, diagnosticLocation, entryIndex, methodName);
+                return false;
+            }
+
+            matchedFiles.Add(fullPath);
+            return true;
+        }
+
+        var patternSegments = normalizedPattern.Split('/');
+        var literalSegmentCount = Array.FindIndex(patternSegments, ContainsWildcard);
+        var searchRoot = projectRoot;
+        for (var i = 0; i < literalSegmentCount; i++)
+        {
+            searchRoot = Path.Combine(searchRoot, patternSegments[i]);
+        }
+
+        if (!Directory.Exists(searchRoot))
+        {
+            return true;
+        }
+
+        if (ContainsReparsePoint(projectRoot, searchRoot))
+        {
+            ReportSymlink(context, diagnosticLocation, entryIndex, methodName);
+            return false;
+        }
+
+        var matcher = new Regex(GlobToRegex(normalizedPattern), GetRegexOptions());
+        var recursive = normalizedPattern.IndexOf("**", StringComparison.Ordinal) >= 0;
+        var maximumDirectoryDepth = patternSegments.Length - 1;
+        var directories = new Stack<(string Path, int Depth)>();
+        directories.Push((searchRoot, literalSegmentCount));
+        var visitedEntries = 0;
+
+        try
+        {
+            while (directories.Count > 0)
+            {
+                var (directory, depth) = directories.Pop();
+
+                foreach (var file in Directory.EnumerateFiles(directory))
+                {
+                    if (++visitedEntries > MaxGlobEntries)
+                    {
+                        ReportLimit(context, diagnosticLocation, entryIndex, methodName, $"{MaxGlobEntries} traversed-entry");
+                        return false;
+                    }
+
+                    var relativePath = file.Substring(EnsureEndingDirectorySeparator(projectRoot).Length)
+                        .Replace(Path.DirectorySeparatorChar, '/')
+                        .Replace(Path.AltDirectorySeparatorChar, '/');
+                    if (!matcher.IsMatch(relativePath))
+                    {
+                        continue;
+                    }
+
+                    if (ContainsReparsePoint(projectRoot, file))
+                    {
+                        ReportSymlink(context, diagnosticLocation, entryIndex, methodName);
+                        return false;
+                    }
+
+                    matchedFiles.Add(Path.GetFullPath(file));
+                }
+
+                if (!recursive && depth >= maximumDirectoryDepth)
+                {
+                    continue;
+                }
+
+                foreach (var childDirectory in Directory.EnumerateDirectories(directory))
+                {
+                    if (++visitedEntries > MaxGlobEntries)
+                    {
+                        ReportLimit(context, diagnosticLocation, entryIndex, methodName, $"{MaxGlobEntries} traversed-entry");
+                        return false;
+                    }
+
+                    if ((File.GetAttributes(childDirectory) & FileAttributes.ReparsePoint) != 0)
+                    {
+                        ReportSymlink(context, diagnosticLocation, entryIndex, methodName);
+                        return false;
+                    }
+
+                    directories.Push((childDirectory, depth + 1));
+                }
+            }
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException or NotSupportedException)
+        {
+            ReportReadFailure(context, diagnosticLocation, entryIndex, methodName, ex);
+            return false;
+        }
+
+        matchedFiles.Sort(GetPathComparer());
+        return true;
+    }
+
+    private static bool ContainsWildcard(string value)
+        => value.IndexOf('*') >= 0 || value.IndexOf('?') >= 0;
+
+    private static string GlobToRegex(string pattern)
+    {
+        var builder = new StringBuilder("^");
+
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            var current = pattern[i];
+            if (current == '*')
+            {
+                if (i + 1 < pattern.Length && pattern[i + 1] == '*')
+                {
+                    i++;
+                    if (i + 1 < pattern.Length && pattern[i + 1] == '/')
+                    {
+                        i++;
+                        builder.Append("(?:.*/)?");
+                    }
+                    else
+                    {
+                        builder.Append(".*");
+                    }
+                }
+                else
+                {
+                    builder.Append("[^/]*");
+                }
+            }
+            else if (current == '?')
+            {
+                builder.Append("[^/]");
+            }
+            else
+            {
+                builder.Append(Regex.Escape(current.ToString()));
+            }
+        }
+
+        return builder.Append('$').ToString();
+    }
+
+    [SuppressMessage("Build", "RS1035", Justification = "IncludeFiles path validation must reject symbolic-link traversal.")]
+    private static bool ContainsReparsePoint(string projectRoot, string fullPath)
+    {
+        var rootWithSeparator = EnsureEndingDirectorySeparator(projectRoot);
+        if (fullPath.Equals(projectRoot, GetPathComparison()))
+        {
+            return false;
+        }
+
+        if (!fullPath.StartsWith(rootWithSeparator, GetPathComparison()))
+        {
+            return true;
+        }
+
+        var current = projectRoot;
+        var relativePath = fullPath.Substring(rootWithSeparator.Length);
+        foreach (var segment in relativePath.Split(_pathSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            current = Path.Combine(current, segment);
+            if ((File.GetAttributes(current) & FileAttributes.ReparsePoint) != 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool IsWithinProjectRoot(string projectRoot, string fullPath)
+    {
+        var normalizedPath = TrimEndingDirectorySeparators(Path.GetFullPath(fullPath));
+        return normalizedPath.Equals(projectRoot, GetPathComparison())
+            || normalizedPath.StartsWith(EnsureEndingDirectorySeparator(projectRoot), GetPathComparison());
+    }
+
+    private static void ReportSymlink(SourceProductionContext context, Location? location, int index, string methodName)
+        => context.ReportDiagnostic(Diagnostic.Create(
+            ParserSourceGenerator.IncludeFileSymlinkDescriptor,
+            location,
+            index,
+            methodName));
+
+    private static void ReportLimit(SourceProductionContext context, Location? location, int index, string methodName, string limit)
+        => context.ReportDiagnostic(Diagnostic.Create(
+            ParserSourceGenerator.IncludeFileLimitDescriptor,
+            location,
+            index,
+            methodName,
+            limit));
+
+    private static void ReportReadFailure(SourceProductionContext context, Location? location, int index, string methodName, Exception exception)
+        => context.ReportDiagnostic(Diagnostic.Create(
+            ParserSourceGenerator.IncludeFileReadDescriptor,
+            location,
+            index,
+            methodName,
+            exception.GetType().Name));
+
+    private static RegexOptions GetRegexOptions()
+        => Path.DirectorySeparatorChar == '\\'
+            ? RegexOptions.CultureInvariant | RegexOptions.IgnoreCase
+            : RegexOptions.CultureInvariant;
+
+    private static string EnsureEndingDirectorySeparator(string path)
+        => path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            || path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            ? path
+            : path + Path.DirectorySeparatorChar;
+
+    private static string TrimEndingDirectorySeparators(string path)
+    {
+        var pathRoot = Path.GetPathRoot(path);
+        return string.Equals(path, pathRoot, GetPathComparison())
+            ? path
+            : path.TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+    }
+
+    private static StringComparison GetPathComparison()
+        => Path.DirectorySeparatorChar == '\\' ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static StringComparer GetPathComparer()
+        => Path.DirectorySeparatorChar == '\\' ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+}

--- a/src/Parlot.SourceGenerator/IncludeGeneratorsAttribute.cs
+++ b/src/Parlot.SourceGenerator/IncludeGeneratorsAttribute.cs
@@ -11,6 +11,11 @@ namespace Parlot.SourceGenerator;
 /// that your parser method may depend on. By specifying the generator assembly names, Parlot's
 /// source generator will load and run those generators before emitting the compilation.
 /// </para>
+///
+/// <para>
+/// Included generators execute inside the compiler host. Only include generator assemblies that you trust
+/// as executable build dependencies.
+/// </para>
 /// 
 /// <para>
 /// The assembly names should match the assembly name of the source generator (typically the

--- a/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
+++ b/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
 using System.IO;
 using System.Reflection;
@@ -31,6 +32,7 @@ namespace Parlot.SourceGenerator;
 [Generator]
 public sealed class ParserSourceGenerator : IIncrementalGenerator
 {
+    private static readonly char[] _invalidLineDirectivePathCharacters = ['\r', '\n', '\u2028', '\u2029'];
     private const int AggressiveInliningStatementLimit = 24;
 
     #region Diagnostic Descriptors
@@ -105,13 +107,56 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         DiagnosticSeverity.Error,
         isEnabledByDefault: true);
 
-    private static readonly DiagnosticDescriptor IncludeFileNotFoundDescriptor = new(
+    internal static readonly DiagnosticDescriptor IncludeFileNotFoundDescriptor = new(
         "PARLOT006",
         "Include file not found",
-        "Could not find included file '{0}' for method '{1}'",
+        "[IncludeFiles] entry {0} matched no files for method '{1}'",
         "Parlot.SourceGenerator",
-        DiagnosticSeverity.Warning,
+        DiagnosticSeverity.Error,
         isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor InvalidIncludeFileDescriptor = new(
+        "PARLOT016",
+        "Invalid include file path",
+        "[IncludeFiles] entry {0} for method '{1}' was rejected: {2}",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "IncludeFiles paths must be relative C# paths that remain within the project root.");
+
+    internal static readonly DiagnosticDescriptor IncludeFileSymlinkDescriptor = new(
+        "PARLOT017",
+        "Include file path uses a symbolic link",
+        "[IncludeFiles] entry {0} for method '{1}' was rejected because it traverses a symbolic link",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "IncludeFiles does not follow symbolic links because their targets can escape the project root.");
+
+    internal static readonly DiagnosticDescriptor IncludeFileLimitDescriptor = new(
+        "PARLOT018",
+        "Include file limit exceeded",
+        "[IncludeFiles] entry {0} for method '{1}' exceeded the {2} limit",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor IncludeFileReadDescriptor = new(
+        "PARLOT019",
+        "Include file could not be read",
+        "[IncludeFiles] entry {0} for method '{1}' could not be read ({2})",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
+
+    internal static readonly DiagnosticDescriptor ProjectRootUnavailableDescriptor = new(
+        "PARLOT020",
+        "Project root unavailable",
+        "[IncludeFiles] for method '{0}' requires the MSBuild project directory",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "The Parlot build-transitive props expose MSBuildProjectDirectory to enforce project-root containment.");
 
     private static readonly DiagnosticDescriptor MethodNotFoundDescriptor = new(
         "PARLOT011",
@@ -165,11 +210,13 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 options.GlobalOptions.TryGetValue("build_property.DesignTimeBuild", out var designTimeBuild);
                 options.GlobalOptions.TryGetValue("build_property.BuildingProject", out var buildingProject);
                 options.GlobalOptions.TryGetValue("build_property.BuildingInsideVisualStudio", out var buildingInsideVisualStudio);
+                options.GlobalOptions.TryGetValue("build_property.MSBuildProjectDirectory", out var projectDirectory);
 
                 return (
                     tfm: tfm ?? "",
                     identifier: identifier ?? "",
                     version: version ?? "",
+                    projectDirectory: projectDirectory ?? "",
                     isDesignTimeBuild: IsDesignTimeOrIdeContext(designTimeBuild, buildingProject, buildingInsideVisualStudio));
             });
 
@@ -252,7 +299,14 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
 
                     var targetFrameworkInfo = TargetFrameworkInfo.FromMsBuildProperties(tfmInfo.identifier, tfmInfo.version);
 
-                    GenerateForMethod(spc, compilation, targetFrameworkInfo, m.Value, methodInvocations ?? new List<InvocationInfo>(), tfmInfo.isDesignTimeBuild);
+                    GenerateForMethod(
+                        spc,
+                        compilation,
+                        targetFrameworkInfo,
+                        m.Value,
+                        methodInvocations ?? new List<InvocationInfo>(),
+                        tfmInfo.projectDirectory,
+                        tfmInfo.isDesignTimeBuild);
                 }
                 catch (Exception ex)
                 {
@@ -565,6 +619,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         TargetFrameworkInfo targetFramework,
         MethodToGenerate methodInfo,
         List<InvocationInfo> invocations,
+        string projectDirectory,
         bool isDesignTimeBuild)
     {
         var methodSymbol = methodInfo.Method;
@@ -624,6 +679,28 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         // This allows us to execute the parser with lambda stubs while keeping all other files intact
         var tempCompilation = hostCompilation
             .ReplaceSyntaxTree(originalSyntaxTree, rewrittenTree);
+
+        if (methodInfo.AdditionalFiles.Length > 0)
+        {
+            if (!IncludeFilesResolver.TryLoad(
+                context,
+                methodInfo.Method,
+                methodInfo.AttributeLocation,
+                methodInfo.AdditionalFiles,
+                originalSyntaxTree,
+                projectDirectory,
+                parseOptions,
+                tempCompilation.SyntaxTrees,
+                out var includedTrees))
+            {
+                return;
+            }
+
+            if (includedTrees.Count > 0)
+            {
+                tempCompilation = tempCompilation.AddSyntaxTrees(includedTrees);
+            }
+        }
 
         // Run additional source generators if specified via [IncludeGenerators] attribute
         if (methodInfo.AdditionalGenerators.Length > 0)
@@ -1011,7 +1088,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
 
             var sgContext = new SourceGenerationContext(
                 parseContextName: "context",
-                methodNamePrefix: methodSymbol.Name,
+                methodNamePrefix: GetGeneratedIdentifier(methodSymbol),
                 targetFramework: targetFramework,
                 csharpLanguageMajorVersion: GetCSharpLanguageMajorVersion(methodSymbol));
             
@@ -1128,8 +1205,8 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             ? null
             : methodSymbol.ContainingNamespace.ToDisplayString();
 
-        var typeName = methodSymbol.ContainingType.Name;
-        var methodName = methodSymbol.Name;
+        var typeName = EscapeIdentifier(methodSymbol.ContainingType.Name);
+        var methodName = GetGeneratedIdentifier(methodSymbol);
         var valueTypeName = TypeNameHelper.GetTypeName(valueType);
         var coreName = methodName + "_Core";
         var wrapperName = "GeneratedParser_" + methodName;
@@ -1583,6 +1660,49 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         return (sb.ToString(), failedLambdas);
     }
 
+    private static string GetGeneratedIdentifier(IMethodSymbol method)
+    {
+        var identifier = $"__Parlot_{method.Name.Length}_{method.Name}";
+        var candidate = identifier;
+        var suffix = 0;
+
+        while (HasGeneratedMemberCollision(method.ContainingType, candidate))
+        {
+            candidate = identifier + "_" + (++suffix).ToString(CultureInfo.InvariantCulture);
+        }
+
+        return candidate;
+    }
+
+    private static bool HasGeneratedMemberCollision(INamedTypeSymbol containingType, string identifier)
+    {
+        var generatedPrefix = identifier + "_";
+        var generatedFieldPrefix = "_" + generatedPrefix;
+        var wrapperName = "GeneratedParser_" + identifier;
+        var parserFieldName = "_generated_" + identifier;
+
+        foreach (var member in containingType.GetMembers())
+        {
+            var name = member.Name;
+            if (name == identifier
+                || name.StartsWith(generatedPrefix, StringComparison.Ordinal)
+                || name.StartsWith(generatedFieldPrefix, StringComparison.Ordinal)
+                || name == wrapperName
+                || name == parserFieldName)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static string EscapeIdentifier(string identifier)
+        => IsReservedKeyword(identifier) ? "@" + identifier : identifier;
+
+    private static bool IsReservedKeyword(string identifier)
+        => SyntaxFacts.GetKeywordKind(identifier) != SyntaxKind.None;
+
     private static void AppendAggressiveInliningIfSmall(StringBuilder builder, SourceResult result)
     {
         if (result.Locals.Count + result.Body.Count <= AggressiveInliningStatementLimit)
@@ -1612,7 +1732,9 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         var parameters = invokeMethod.GetParameters();
 
         // Emit #line directive for debugging if we have location info
-        var hasLineInfo = !string.IsNullOrEmpty(originalFilePath) && originalLine > 0;
+        var hasLineInfo = !string.IsNullOrEmpty(originalFilePath)
+            && originalLine > 0
+            && CanEmitLineDirective(originalFilePath!);
         
         if (isMethodGroup)
         {
@@ -1624,7 +1746,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             
             if (hasLineInfo)
             {
-                sb.Append($"#line {originalLine} \"{originalFilePath}\"\n");
+                AppendLineDirective(sb, originalLine, originalFilePath!);
             }
             
             sb.Append($"        private static {returnTypeName} {methodName}({paramList}) => ");
@@ -1719,7 +1841,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                     
                     if (hasLineInfo)
                     {
-                        sb.Append($"#line {originalLine} \"{originalFilePath}\"\n");
+                        AppendLineDirective(sb, originalLine, originalFilePath!);
                     }
                     
                     sb.Append($"        private static {returnTypeName} {methodName}({paramList}) => ");
@@ -1836,7 +1958,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         if (lines.Length <= 1)
         {
             // Single line - just add one directive
-            return $"#line {startLine} \"{filePath}\"\n{body}";
+            return $"#line {startLine} {LiteralHelper.StringToLiteral(filePath)}\n{body}";
         }
 
         var sb = new StringBuilder();
@@ -1855,7 +1977,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             
             if (isSignificantLine)
             {
-                sb.Append($"#line {currentLine} \"{filePath}\"\n");
+                AppendLineDirective(sb, currentLine, filePath);
             }
             
             sb.Append(line);
@@ -1871,6 +1993,17 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         
         return sb.ToString();
     }
+
+    private static void AppendLineDirective(StringBuilder builder, int line, string filePath)
+        => builder
+            .Append("#line ")
+            .Append(line)
+            .Append(' ')
+            .Append(LiteralHelper.StringToLiteral(filePath))
+            .Append('\n');
+
+    private static bool CanEmitLineDirective(string filePath)
+        => filePath.IndexOfAny(_invalidLineDirectivePathCharacters) < 0;
 
     /// <summary>
     /// Generates a diagnostics file containing compilation information for debugging.

--- a/src/Parlot.SourceGenerator/README.md
+++ b/src/Parlot.SourceGenerator/README.md
@@ -46,6 +46,10 @@ var foo = MyGrammar.FooParser();
 
 Include additional source files for types your parser depends on. Paths are relative to the source file containing the `[GenerateParser]` method.
 
+Paths must remain inside the MSBuild project root. Absolute paths, symbolic links, and patterns not ending
+in `.cs` are rejected. Use exact files or narrow globs; see the
+[security guidance](../../docs/security.md#includefiles-containment).
+
 ```csharp
 [GenerateParser]
 [IncludeFiles("Ast.cs", "Tokens.cs")]
@@ -80,6 +84,9 @@ Run other source generators (e.g., PolySharp) before parser generation:
 [IncludeGenerators("PolySharp")]
 public static Parser<Expression> CreateParser() => ...;
 ```
+
+`[GenerateParser]` factory methods and `[IncludeGenerators]` assemblies execute as trusted code inside the
+compiler host. Do not build untrusted factories or generators outside an isolated build environment.
 
 ### Class-level Attributes
 
@@ -120,4 +127,3 @@ public class MyCustomParser : Parser<string>, ISourceable
 ```
 
 For comprehensive documentation, see [Source Generation Guide](../../docs/source-generation.md).
-

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -34,23 +34,33 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
         context.EnterParser(this);
 
         var parsed = new ParseResult<T>();
-
-        if (!_parser.Parse(context, ref parsed))
+        var previousOffset = context.Scanner.Cursor.Offset;
+        if (!_parser.Parse(context, ref parsed)
+            || context.Scanner.Cursor.Offset == previousOffset)
         {
+            context.ExitParser(this);
             return false;
         }
 
         var start = parsed.Start;
-        var results = new HybridList<T>();
-
-        int end;
-
-        do
+        var end = parsed.End;
+        var results = new HybridList<T>
         {
+            parsed.Value
+        };
+
+        while (true)
+        {
+            previousOffset = context.Scanner.Cursor.Offset;
+            if (!_parser.Parse(context, ref parsed)
+                || context.Scanner.Cursor.Offset == previousOffset)
+            {
+                break;
+            }
+
             end = parsed.End;
             results.Add(parsed.Value);
-
-        } while (_parser.Parse(context, ref parsed));
+        }
 
         result.Set(start, end, results.AsReadOnlyList());
 
@@ -97,10 +107,13 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
         var helperName = context.Helpers
             .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_OneOrMany_Parser", valueTypeName, () => sourceable.GenerateSource(context))
             .MethodName;
+        var previousOffsetName = $"previousOffset{context.NextNumber()}";
+        var itemValueName = $"itemValue{context.NextNumber()}";
 
         result.Body.Add("while (true)");
         result.Body.Add("{");
-        result.Body.Add($"    if (!{helperName}({context.ParseContextName}, out var itemValue{context.NextNumber()}))");
+        result.Body.Add($"    var {previousOffsetName} = {context.CursorName}.Offset;");
+        result.Body.Add($"    if (!{helperName}({context.ParseContextName}, out var {itemValueName}) || {context.CursorName}.Offset == {previousOffsetName})");
         result.Body.Add("    {");
         result.Body.Add("        break;");
         result.Body.Add("    }");
@@ -110,7 +123,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
             result.Body.Add("    {");
             result.Body.Add($"        {listName} = new System.Collections.Generic.List<{elementTypeName}>();");
             result.Body.Add("    }");
-            result.Body.Add($"    {listName}!.Add(itemValue{context.NextNumber() - 1});");
+            result.Body.Add($"    {listName}!.Add({itemValueName});");
         }
         result.Body.Add($"    {result.SuccessVariable} = true;");
         result.Body.Add("}");

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -47,6 +47,8 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
 
         while (true)
         {
+            var previousOffset = context.Scanner.Cursor.Offset;
+
             if (!first)
             {
                 if (!_separator.Parse(context, ref separatorResult))
@@ -71,6 +73,17 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
             else
             {
                 end = context.Scanner.Cursor.Position;
+            }
+
+            if (context.Scanner.Cursor.Offset == previousOffset)
+            {
+                if (first)
+                {
+                    context.ExitParser(this);
+                    return false;
+                }
+
+                break;
             }
 
             if (first)
@@ -107,6 +120,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
         var firstName = $"first{context.NextNumber()}";
         var endName = $"end{context.NextNumber()}";
         var startName = $"start{context.NextNumber()}";
+        var previousOffsetName = $"previousOffset{context.NextNumber()}";
 
         if (!context.DiscardResult)
         {
@@ -133,6 +147,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
 
         result.Body.Add("while (true)");
         result.Body.Add("{");
+        result.Body.Add($"    var {previousOffsetName} = {cursorName}.Offset;");
         
         // If not first, try to parse separator
         result.Body.Add($"    if (!{firstName})");
@@ -157,6 +172,11 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
         result.Body.Add("    else");
         result.Body.Add("    {");
         result.Body.Add($"        {endName} = {cursorName}.Position;");
+        result.Body.Add("    }");
+
+        result.Body.Add($"    if ({cursorName}.Offset == {previousOffsetName})");
+        result.Body.Add("    {");
+        result.Body.Add("        break;");
         result.Body.Add("    }");
 
         result.Body.Add($"    if ({firstName})");

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -28,11 +28,15 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
         var first = true;
         var parsed = new ParseResult<T>();
 
-        // TODO: it's not restoring an intermediate failed text position
-        // is the inner parser supposed to be clean?
-
-        while (_parser.Parse(context, ref parsed))
+        while (true)
         {
+            var previousOffset = context.Scanner.Cursor.Offset;
+            if (!_parser.Parse(context, ref parsed)
+                || context.Scanner.Cursor.Offset == previousOffset)
+            {
+                break;
+            }
+
             if (first)
             {
                 results = [];
@@ -94,10 +98,13 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
         var helperName = context.Helpers
             .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_ZeroOrMany_Parser", valueTypeName, () => sourceable.GenerateSource(context))
             .MethodName;
+        var previousOffsetName = $"previousOffset{context.NextNumber()}";
+        var itemValueName = $"itemValue{context.NextNumber()}";
 
         result.Body.Add("while (true)");
         result.Body.Add("{");
-        result.Body.Add($"    if (!{helperName}({ctx}, out var itemValue{context.NextNumber()}))");
+        result.Body.Add($"    var {previousOffsetName} = {context.CursorName}.Offset;");
+        result.Body.Add($"    if (!{helperName}({ctx}, out var {itemValueName}) || {context.CursorName}.Offset == {previousOffsetName})");
         result.Body.Add("    {");
         result.Body.Add("        break;");
         result.Body.Add("    }");
@@ -109,7 +116,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
             result.Body.Add($"        {result.ValueVariable} = {listName};");
             result.Body.Add($"        {firstName} = false;");
             result.Body.Add("    }");
-            result.Body.Add($"    {listName}!.Add(itemValue{context.NextNumber() - 1});");
+            result.Body.Add($"    {listName}!.Add({itemValueName});");
         }
         result.Body.Add("}");
         if (!context.DiscardResult)

--- a/src/Parlot/buildTransitive/Parlot.props
+++ b/src/Parlot/buildTransitive/Parlot.props
@@ -10,4 +10,8 @@
   <ItemGroup Condition="'$(ImplicitUsings)' == 'true' or '$(ImplicitUsings)' == 'enable'">
     <Using Include="Parlot.Fluent.Parsers" Static="true" />
   </ItemGroup>
+
+  <ItemGroup>
+    <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
+  </ItemGroup>
 </Project>

--- a/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
@@ -229,10 +229,10 @@ public static partial class InlineGrammar
 
         const string attribute = "MethodImplOptions.AggressiveInlining";
         Assert.Contains($"{attribute})]{Environment.NewLine}            public override bool Parse", generated, StringComparison.Ordinal);
-        Assert.Contains($"{attribute})]{Environment.NewLine}        internal static bool Pair_Core", generated, StringComparison.Ordinal);
-        Assert.Contains($"{attribute})]{Environment.NewLine}        private static bool Pair_Sequence_P1", generated, StringComparison.Ordinal);
-        Assert.Contains($"{attribute})]{Environment.NewLine}        private static bool Pair_Sequence_P2", generated, StringComparison.Ordinal);
-        Assert.DoesNotContain($"{attribute})]{Environment.NewLine}        internal static bool LargeChoice_Core", generated, StringComparison.Ordinal);
+        Assert.Contains($"{attribute})]{Environment.NewLine}        internal static bool __Parlot_4_Pair_Core", generated, StringComparison.Ordinal);
+        Assert.Contains($"{attribute})]{Environment.NewLine}        private static bool __Parlot_4_Pair_Sequence_P1", generated, StringComparison.Ordinal);
+        Assert.Contains($"{attribute})]{Environment.NewLine}        private static bool __Parlot_4_Pair_Sequence_P2", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain($"{attribute})]{Environment.NewLine}        internal static bool __Parlot_11_LargeChoice_Core", generated, StringComparison.Ordinal);
         Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
     }
 
@@ -298,13 +298,267 @@ public static partial class VisualStudioGrammar
         Assert.Empty(result.Results.SelectMany(r => r.GeneratedSources));
     }
 
+    [Fact]
+    public void IncludeFiles_Allows_Contained_Parent_Path()
+    {
+        using var project = new TemporaryDirectory();
+        var grammarDirectory = Directory.CreateDirectory(Path.Combine(project.Path, "Grammar")).FullName;
+        var grammarPath = Path.Combine(grammarDirectory, "Grammar.cs");
+        File.WriteAllText(
+            Path.Combine(project.Path, "Included.cs"),
+            """
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            internal static class Included
+            {
+                public static Parser<string> Create() => Terms.Text("safe");
+            }
+            """);
+
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+
+            public static partial class IncludeGrammar
+            {
+                [GenerateParser]
+                [IncludeFiles("../*.cs")]
+                public static Parser<string> Parser() => Parsers.Terms.Text("safe");
+            }
+            """;
+
+        var (result, updatedCompilation) = RunGenerator(
+            source,
+            "ContainedInclude",
+            ProjectOptions(project.Path),
+            grammarPath);
+
+        Assert.DoesNotContain(result.Diagnostics, static d => d.Id is "PARLOT006" or "PARLOT016" or "PARLOT017" or "PARLOT018" or "PARLOT019" or "PARLOT020");
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void IncludeFiles_Rejects_Oversized_Source()
+    {
+        using var project = new TemporaryDirectory();
+        const string fileName = "Oversized.cs";
+        File.WriteAllText(Path.Combine(project.Path, fileName), new string(' ', (1024 * 1024) + 1));
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            public static partial class OversizedIncludeGrammar
+            {
+                [GenerateParser]
+                [IncludeFiles("Oversized.cs")]
+                public static Parser<string> Parser() => Terms.Text("safe");
+            }
+            """;
+
+        var (result, _) = RunGenerator(
+            source,
+            "OversizedInclude",
+            ProjectOptions(project.Path),
+            Path.Combine(project.Path, "Grammar.cs"));
+
+        var diagnostic = Assert.Single(result.Diagnostics, static d => d.Id == "PARLOT018");
+        Assert.Contains("1024 KiB per-file", diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain(fileName, diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain(project.Path, diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IncludeFiles_Rejects_Project_Root_Escape_Without_Disclosing_Path()
+    {
+        using var project = new TemporaryDirectory();
+        var sourcePath = Path.Combine(project.Path, "Grammar.cs");
+        const string secretName = "parlot-secret-do-not-disclose.cs";
+        var source = $$"""
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            public static partial class EscapingIncludeGrammar
+            {
+                [GenerateParser]
+                [IncludeFiles("../{{secretName}}")]
+                public static Parser<string> Parser() => Terms.Text("safe");
+            }
+            """;
+
+        var (result, _) = RunGenerator(
+            source,
+            "EscapingInclude",
+            ProjectOptions(project.Path),
+            sourcePath);
+
+        var diagnostic = Assert.Single(result.Diagnostics, static d => d.Id == "PARLOT016");
+        Assert.Contains("escapes the project root", diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain(secretName, diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain(project.Path, diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IncludeFiles_Rejects_Absolute_Path_Without_Disclosing_Path()
+    {
+        using var project = new TemporaryDirectory();
+        var sourcePath = Path.Combine(project.Path, "Grammar.cs");
+        var absolutePath = Path.Combine(project.Path, "secret.cs");
+        var literal = Parlot.SourceGeneration.LiteralHelper.StringToLiteral(absolutePath);
+        var source = $$"""
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            public static partial class AbsoluteIncludeGrammar
+            {
+                [GenerateParser]
+                [IncludeFiles({{literal}})]
+                public static Parser<string> Parser() => Terms.Text("safe");
+            }
+            """;
+
+        var (result, _) = RunGenerator(
+            source,
+            "AbsoluteInclude",
+            ProjectOptions(project.Path),
+            sourcePath);
+
+        var diagnostic = Assert.Single(result.Diagnostics, static d => d.Id == "PARLOT016");
+        Assert.Contains("absolute paths are not allowed", diagnostic.GetMessage(), StringComparison.Ordinal);
+        Assert.DoesNotContain(absolutePath, diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void IncludeFiles_Rejects_Symbolic_Links()
+    {
+        if (OperatingSystem.IsWindows())
+        {
+            return;
+        }
+
+        using var project = new TemporaryDirectory();
+        using var outside = new TemporaryDirectory();
+        File.WriteAllText(Path.Combine(outside.Path, "Secret.cs"), "internal static class Secret { }");
+        Directory.CreateSymbolicLink(Path.Combine(project.Path, "Linked"), outside.Path);
+
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            public static partial class SymlinkIncludeGrammar
+            {
+                [GenerateParser]
+                [IncludeFiles("Linked/Secret.cs")]
+                public static Parser<string> Parser() => Terms.Text("safe");
+            }
+            """;
+
+        var (result, _) = RunGenerator(
+            source,
+            "SymlinkInclude",
+            ProjectOptions(project.Path),
+            Path.Combine(project.Path, "Grammar.cs"));
+
+        Assert.Single(result.Diagnostics, static d => d.Id == "PARLOT017");
+    }
+
+    [Fact]
+    public void Generated_Literals_Escape_Adversarial_Text()
+    {
+        var values = new[]
+        {
+            "\"quoted\"",
+            "backslash\\",
+            "line\r\nbreak",
+            "#line 1 \"injected.cs\"",
+            "\u2028\u2029",
+            "\0",
+            "emoji \ud83d\ude80"
+        };
+
+        var declarations = string.Join(
+            Environment.NewLine,
+            values.Select((value, index) =>
+                $"internal const string Value{index} = {Parlot.SourceGeneration.LiteralHelper.StringToLiteral(value)};"));
+        var tree = CSharpSyntaxTree.ParseText(
+            $"internal static class EscapedValues {{{Environment.NewLine}{declarations}{Environment.NewLine}}}",
+            new CSharpParseOptions(LanguageVersion.Preview));
+
+        Assert.DoesNotContain(tree.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Generated_Identifiers_Handle_Keywords_And_Unicode()
+    {
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            namespace GeneratedIdentifierTests;
+
+            public static partial class IdentifierGrammar
+            {
+                private const int __Parlot_5_class_Core = 0;
+
+                [GenerateParser]
+                public static Parser<string> @class() => Terms.Text("keyword");
+
+                [GenerateParser]
+                public static Parser<string> _class() => Terms.Text("underscored");
+
+                [GenerateParser]
+                public static Parser<string> 解析() => Terms.Text("unicode");
+            }
+            """;
+
+        var (result, updatedCompilation) = RunGenerator(source, "GeneratedIdentifiers");
+        var generated = string.Join(
+            Environment.NewLine,
+            result.Results.SelectMany(static r => r.GeneratedSources).Select(static s => s.SourceText.ToString()));
+
+        Assert.DoesNotContain(result.Diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("__Parlot_5_class_1_Core", generated, StringComparison.Ordinal);
+        Assert.Contains("__Parlot_6__class_Core", generated, StringComparison.Ordinal);
+        Assert.Contains("__Parlot_2_解析_Core", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Generated_Line_Directives_Escape_Source_Path()
+    {
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+
+            namespace DirectiveTests;
+
+            public static partial class DirectiveGrammar
+            {
+                [GenerateParser]
+                public static Parser<string> Parser() =>
+                    Terms.Identifier().Then(static value => value.ToString());
+            }
+            """;
+
+        var sourcePath = Path.Combine(Path.GetTempPath(), "quote\"#line\nfile.cs");
+        var (_, updatedCompilation) = RunGenerator(source, "DirectiveEscaping", sourcePath: sourcePath);
+
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+    }
+
     private static (GeneratorDriverRunResult result, CSharpCompilation updatedCompilation) RunGenerator(
         string source,
         string assemblyName,
-        IReadOnlyDictionary<string, string> globalOptions = null)
+        IReadOnlyDictionary<string, string> globalOptions = null,
+        string sourcePath = "")
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
-        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
+        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, sourcePath);
 
         var references = new List<MetadataReference>();
         var trusted = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
@@ -356,6 +610,15 @@ public static partial class VisualStudioGrammar
 
         return (driver.GetRunResult(), (CSharpCompilation)updatedCompilation);
     }
+
+    private static IReadOnlyDictionary<string, string> ProjectOptions(string projectDirectory)
+        => new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["build_property.MSBuildProjectDirectory"] = projectDirectory,
+            ["build_property.TargetFramework"] = "net10.0",
+            ["build_property.TargetFrameworkIdentifier"] = ".NETCoreApp",
+            ["build_property.TargetFrameworkVersion"] = "v10.0"
+        };
 
     [Fact]
     public void Lambda_With_Closure_Reports_Error()
@@ -451,6 +714,24 @@ public static partial class StaticLambdaGrammar
 
             value = "";
             return false;
+        }
+    }
+
+    private sealed class TemporaryDirectory : IDisposable
+    {
+        public TemporaryDirectory()
+        {
+            Path = Directory.CreateDirectory(System.IO.Path.Combine(
+                System.IO.Path.GetTempPath(),
+                "Parlot.SourceGenerator.Tests",
+                Guid.NewGuid().ToString("N"))).FullName;
+        }
+
+        public string Path { get; }
+
+        public void Dispose()
+        {
+            Directory.Delete(Path, recursive: true);
         }
     }
 

--- a/test/Parlot.SourceGenerator.Tests/Grammars.cs
+++ b/test/Parlot.SourceGenerator.Tests/Grammars.cs
@@ -526,6 +526,18 @@ public static partial class Grammars
     public static Parser<IReadOnlyList<decimal>> SeparatedDecimalsParser() => Separated(Terms.Char(','), Terms.Decimal());
 
     [GenerateParser]
+    public static Parser<IReadOnlyList<char>> ZeroOrManyOptionalParser() =>
+        ZeroOrMany(ZeroOrOne(Literals.Char('a')));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<char>> OneOrManyOptionalParser() =>
+        OneOrMany(ZeroOrOne(Literals.Char('a')));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<char>> SeparatedOptionalParser() =>
+        Separated(ZeroOrOne(Literals.Char(',')), ZeroOrOne(Literals.Char('a')));
+
+    [GenerateParser]
     public static Parser<decimal> UnaryNegateDecimalParser() => Terms.Decimal().Unary((Terms.Char('-'), static d => -d));
 
     [GenerateParser]

--- a/test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj
+++ b/test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj
@@ -15,6 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
+
     <!-- Reference Parlot for the library types -->
     <ProjectReference Include="..\..\src\Parlot\Parlot.csproj" />
     

--- a/test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj
+++ b/test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj
@@ -15,6 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- Expose the project root to the generator so IncludeFiles tests can enforce project containment. -->
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
 
     <!-- Reference Parlot for the library types -->

--- a/test/Parlot.SourceGenerator.Tests/SourceableParsersTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/SourceableParsersTests.cs
@@ -225,6 +225,16 @@ namespace Parlot.SourceGenerator.Tests
         }
 
         [Fact]
+        public void RepetitionParsers_StopWhenInnerParserMakesNoProgress()
+        {
+            Assert.Equal(3, Grammars.ZeroOrManyOptionalParser().Parse("aaa")!.Count);
+            Assert.Equal(3, Grammars.OneOrManyOptionalParser().Parse("aaa")!.Count);
+            Assert.False(Grammars.OneOrManyOptionalParser().TryParse("", out _));
+            Assert.Equal(3, Grammars.SeparatedOptionalParser().Parse("aaa")!.Count);
+            Assert.False(Grammars.SeparatedOptionalParser().TryParse("", out _));
+        }
+
+        [Fact]
         public void SeparatedDecimals_Works()
         {
             var p = Grammars.SeparatedDecimalsParser();

--- a/test/Parlot.Tests/SecurityBoundaryTests.cs
+++ b/test/Parlot.Tests/SecurityBoundaryTests.cs
@@ -1,0 +1,114 @@
+using Parlot.Fluent;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using Xunit;
+
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Tests;
+
+public class SecurityBoundaryTests
+{
+    [Fact]
+    public void RepetitionParsersStopWhenTheInnerParserMakesNoProgress()
+    {
+        var optionalValue = ZeroOrOne(Literals.Char('a'));
+
+        Assert.Equal(3, ZeroOrMany(optionalValue).Parse("aaa")!.Count);
+        Assert.Equal(3, OneOrMany(optionalValue).Parse("aaa")!.Count);
+        Assert.False(OneOrMany(optionalValue).TryParse("", out _));
+
+        var optionalSeparator = ZeroOrOne(Literals.Char(','));
+        Assert.Equal(3, Separated(optionalSeparator, optionalValue).Parse("aaa")!.Count);
+        Assert.False(Separated(optionalSeparator, optionalValue).TryParse("", out _));
+    }
+
+    [Fact]
+    public void CancellationRequestedDuringParsingIsObserved()
+    {
+        var parser = ZeroOrMany(Terms.Integer());
+        var input = string.Join(" ", Enumerable.Range(0, 10_000));
+        using var cancellation = new CancellationTokenSource();
+        var context = new ParseContext(new Scanner(input), cancellation.Token);
+        var enteredParsers = 0;
+        context.OnEnterParser = (_, _) =>
+        {
+            if (++enteredParsers == 128)
+            {
+                cancellation.Cancel();
+            }
+        };
+        var result = new ParseResult<IReadOnlyList<long>>();
+
+        try
+        {
+            parser.Parse(context, ref result);
+            Assert.Fail("Parsing should observe cancellation requested during the operation.");
+        }
+        catch (OperationCanceledException)
+        {
+        }
+    }
+
+    [Fact]
+    public void TruncatedQuotedStringRestoresAtEveryBoundary()
+    {
+        const string text = "\"a\\u1234\\\\\\\"z\"";
+
+        for (var length = 0; length < text.Length; length++)
+        {
+            var scanner = new Scanner(text[..length]);
+
+            Assert.False(scanner.ReadQuotedString());
+            Assert.Equal(0, scanner.Cursor.Offset);
+        }
+
+        Assert.True(new Scanner(text).ReadQuotedString());
+    }
+
+    [Fact]
+    public void FailedCombinatorsRestoreTheCursorForShortAdversarialInputs()
+    {
+        Parser<string>[] parsers =
+        [
+            Literals.Text("abc"),
+            Terms.Text("abc"),
+            Between(Literals.Char('['), Literals.Text("abc"), Literals.Char(']')),
+            Literals.Text("ab").AndSkip(Literals.Char('!'))
+        ];
+        ReadOnlySpan<char> alphabet = [' ', 'a', 'b', 'c', '!', '[', ']'];
+
+        for (var length = 0; length <= 4; length++)
+        {
+            var combinations = (int)Math.Pow(alphabet.Length, length);
+            for (var value = 0; value < combinations; value++)
+            {
+                var input = CreateInput(alphabet, length, value);
+                foreach (var parser in parsers)
+                {
+                    var context = new ParseContext(new Scanner(input));
+                    var result = new ParseResult<string>();
+
+                    if (!parser.Parse(context, ref result))
+                    {
+                        Assert.Equal(0, context.Scanner.Cursor.Offset);
+                    }
+                }
+            }
+        }
+    }
+
+    private static string CreateInput(ReadOnlySpan<char> alphabet, int length, int value)
+    {
+        var buffer = new char[length];
+        for (var index = 0; index < buffer.Length; index++)
+        {
+            buffer[index] = alphabet[value % alphabet.Length];
+            value /= alphabet.Length;
+        }
+
+        return new string(buffer);
+    }
+}


### PR DESCRIPTION
## Summary
- document compiler-host execution trust, secure build isolation, and defensive runtime guidance
- contain and bound `IncludeFiles` resolution with redacted diagnostics for rejected paths
- terminate zero-progress repetition parsers in runtime and generated code
- harden CI/release permissions, immutable action pins, release-tag validation, main ancestry checks, and NuGet package attestations
- add adversarial coverage for path traversal, escaping, identifiers, cancellation, cursor restoration, scanner boundaries, and repetition termination

## Validation
- `dotnet build`
- `dotnet test test/Parlot.Tests/Parlot.Tests.csproj -f net10.0` (773 passed)
- `dotnet test test/Parlot.SourceGenerator.Tests/Parlot.SourceGenerator.Tests.csproj` (269 passed)
- `ZeroOrMany` short benchmark: fluent 134.05 ns, generated 98.00 ns
- release package version and workflow YAML validation

## External follow-up
Repository administrators should configure protected release tags, required release-environment reviewers, and NuGet Trusted Publishing. API-key publishing remains in place until that external configuration is available.