### PR TITLE
Refresh parser benchmark dependencies and results

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,8 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
     <PackageVersion Include="Pidgin" Version="3.5.1" />
     <PackageVersion Include="Sprache" Version="3.0.0-develop-00049" />
-    <PackageVersion Include="Superpower" Version="3.2.1" />
-    <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageVersion Include="Superpower" Version="3.2.2-dev-00214" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.5-beta1" />
     <!-- Global Package References -->
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.400" />
     <GlobalPackageReference Include="PolySharp" Version="1.16.0" />

--- a/README.md
+++ b/README.md
@@ -176,29 +176,29 @@ This benchmark creates an expression tree (AST) representing mathematical expres
 
 The benchmark compares Raw, Fluent, and source-generated Parlot parsers with Pidgin. It parses the expressions into the same AST without evaluating them.
 
-In these results, Parlot Fluent is about 13-14 times faster than Pidgin, Parlot Raw is faster still, and source generation improves on Fluent parsing while allocating less.
+In these results, Parlot Fluent is about 12-14 times faster than Pidgin and Parlot Raw is faster still. The source-generated parser allocates less than the Fluent parser; this short run measured it 17% slower for the small expression and 2% slower for the big expression.
 
 ```
-BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.8 (24G824) [Darwin 24.6.0]
+BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.9 (24G830) [Darwin 24.6.0]
 Apple M4 Pro, 1 CPU, 14 logical and 14 physical cores
-.NET SDK 10.0.301
-  [Host]   : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
-  ShortRun : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
+.NET SDK 10.0.302
+  [Host]   : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
+  ShortRun : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
 
 Job=ShortRun  IterationCount=3  LaunchCount=1
 WarmupCount=3
 
-| Method               | Mean        | Error     | StdDev   | Gen0   | Allocated |
-|--------------------- |------------:|----------:|---------:|-------:|----------:|
-| ParlotRawSmall       |    137.4 ns |  16.87 ns |  0.92 ns | 0.0362 |     304 B |
-| ParlotFluentSmall    |    212.6 ns |  15.12 ns |  0.83 ns | 0.0668 |     560 B |
-| ParlotGeneratedSmall |    173.4 ns |   9.90 ns |  0.54 ns | 0.0496 |     416 B |
-| PidginSmall          |  3,004.7 ns | 649.75 ns | 35.61 ns | 0.0992 |     832 B |
-|                      |             |           |          |        |           |
-| ParlotRawBig         |    694.6 ns |   9.31 ns |  0.51 ns | 0.1431 |    1200 B |
-| ParlotFluentBig      |  1,159.1 ns |  42.50 ns |  2.33 ns | 0.1736 |    1456 B |
-| ParlotGeneratedBig   |    981.0 ns | 124.41 ns |  6.82 ns | 0.1564 |    1312 B |
-| PidginBig            | 15,087.5 ns | 631.39 ns | 34.61 ns | 0.4883 |    4152 B |
+| Method               | Mean        | Error       | StdDev    | Gen0   | Allocated |
+|--------------------- |------------:|------------:|----------:|-------:|----------:|
+| ParlotRawSmall       |    123.4 ns |     7.04 ns |   0.39 ns | 0.0362 |     304 B |
+| ParlotFluentSmall    |    219.1 ns |     1.51 ns |   0.08 ns | 0.0668 |     560 B |
+| ParlotGeneratedSmall |    256.8 ns |    19.05 ns |   1.04 ns | 0.0496 |     416 B |
+| PidginSmall          |  3,105.8 ns |   686.70 ns |  37.64 ns | 0.0992 |     832 B |
+|                      |             |             |           |        |           |
+| ParlotRawBig         |    671.1 ns |    15.22 ns |   0.83 ns | 0.1431 |    1200 B |
+| ParlotFluentBig      |  1,300.6 ns |   260.54 ns |  14.28 ns | 0.1736 |    1456 B |
+| ParlotGeneratedBig   |  1,324.8 ns |    35.25 ns |   1.93 ns | 0.1564 |    1312 B |
+| PidginBig            | 15,521.2 ns | 1,261.73 ns |  69.16 ns | 0.4883 |    4152 B |
 ```
 
 ### JSON Benchmarks
@@ -208,46 +208,46 @@ For reference, Newtonsoft.Json is also added to show the differences with a dedi
 The benchmark compares Fluent and source-generated Parlot parsers with Pidgin, Sprache, Superpower, Newtonsoft.Json, and System.Text.Json. For most documents, the best JSON parser is System.Text.Json; don't build your own!
 
 ```
-BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.8 (24G824) [Darwin 24.6.0]
+BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.9 (24G830) [Darwin 24.6.0]
 Apple M4 Pro, 1 CPU, 14 logical and 14 physical cores
-.NET SDK 10.0.301
-  [Host]   : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
-  ShortRun : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
+.NET SDK 10.0.302
+  [Host]   : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
+  ShortRun : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
 
 Job=ShortRun  IterationCount=3  LaunchCount=1
 WarmupCount=3
 
-| Method                   | Mean       | Error      | StdDev    | Gen0     | Gen1     | Allocated  |
-|------------------------- |-----------:|-----------:|----------:|---------:|---------:|-----------:|
-| BigJson_Parlot           |  37.543 us |  0.8230 us | 0.0451 us |  11.6577 |   2.0142 |   95.66 KB |
-| BigJson_ParlotGenerated  |  31.460 us | 14.9022 us | 0.8168 us |  11.2305 |   1.8921 |    91.8 KB |
-| BigJson_Pidgin           |  76.461 us |  3.7114 us | 0.2034 us |  11.1084 |   1.7090 |    91.7 KB |
-| BigJson_Newtonsoft       |  51.177 us | 25.9966 us | 1.4250 us |  24.8413 |   8.2397 |   203.1 KB |
-| BigJson_SystemTextJson   |  18.408 us | 97.0510 us | 5.3197 us |   2.9297 |   0.3204 |   24.12 KB |
-| BigJson_Sprache          | 789.885 us | 61.7248 us | 3.3833 us | 609.3750 | 122.0703 | 4980.05 KB |
-| BigJson_Superpower       | 373.309 us | 26.2033 us | 1.4363 us | 103.5156 |  18.0664 |  845.93 KB |
-|                          |            |            |           |          |          |            |
-| DeepJson_Parlot          |  30.047 us |  2.7066 us | 0.1484 us |  14.2517 |   1.6785 |  116.57 KB |
-| DeepJson_ParlotGenerated |  22.902 us | 10.0453 us | 0.5506 us |  12.0239 |   1.2512 |   98.36 KB |
-| DeepJson_Pidgin          | 107.987 us | 78.4544 us | 4.3003 us |  14.1602 |   3.5400 |  116.29 KB |
-| DeepJson_Newtonsoft      |  37.605 us |  2.4738 us | 0.1356 us |  21.9116 |   8.7280 |  179.13 KB |
-| DeepJson_SystemTextJson  |  59.026 us |  3.1666 us | 0.1736 us |   2.4414 |   0.1831 |   20.24 KB |
-| DeepJson_Sprache         | 651.383 us | 10.3188 us | 0.5656 us | 338.8672 | 139.6484 |  2770.2 KB |
-|                          |            |            |           |          |          |            |
-| LongJson_Parlot          |  32.043 us |  1.6211 us | 0.0889 us |  15.1978 |   3.0518 |  124.52 KB |
-| LongJson_ParlotGenerated |  25.221 us |  0.4153 us | 0.0228 us |  14.4653 |   3.5706 |  118.38 KB |
-| LongJson_Pidgin          |  67.923 us |  1.6013 us | 0.0878 us |  14.6484 |   3.0518 |  120.25 KB |
-| LongJson_Newtonsoft      |  38.784 us | 12.1090 us | 0.6637 us |  24.7803 |   9.6436 |  202.68 KB |
-| LongJson_SystemTextJson  |   9.833 us |  3.0383 us | 0.1665 us |   2.9297 |   0.3204 |   24.12 KB |
-| LongJson_Sprache         | 683.235 us | 18.4119 us | 1.0092 us | 511.7188 | 130.8594 |  4181.2 KB |
-| LongJson_Superpower      | 302.714 us | 20.1201 us | 1.1029 us |  83.0078 |  20.0195 |  678.79 KB |
-|                          |            |            |           |          |          |            |
-| WideJson_Parlot          |  16.975 us |  0.7353 us | 0.0403 us |   4.9744 |   0.4883 |   40.72 KB |
-| WideJson_ParlotGenerated |  14.156 us |  1.1152 us | 0.0611 us |   4.9591 |   0.4883 |   40.59 KB |
-| WideJson_Pidgin          |  32.560 us |  3.7986 us | 0.2082 us |   4.9438 |   0.4883 |   40.48 KB |
-| WideJson_Newtonsoft      |  25.610 us |  1.7123 us | 0.0939 us |  13.0615 |   3.2349 |  106.72 KB |
-| WideJson_Sprache         | 365.637 us | 53.3936 us | 2.9267 us | 318.8477 |  45.4102 | 2606.25 KB |
-| WideJson_Superpower      | 174.801 us |  7.9470 us | 0.4356 us |  51.2695 |   5.1270 |  419.75 KB |
+| Method                   | Mean       | Error       | StdDev     | Gen0     | Gen1     | Allocated  |
+|------------------------- |-----------:|------------:|-----------:|---------:|---------:|-----------:|
+| BigJson_Parlot           |  36.797 us |   0.5195 us |  0.0285 us |  10.7422 |   1.8311 |   88.16 KB |
+| BigJson_ParlotGenerated  |  31.659 us |   0.3483 us |  0.0191 us |  11.2305 |   1.8921 |    91.8 KB |
+| BigJson_Pidgin           |  76.997 us |   0.8952 us |  0.0491 us |  11.1084 |   1.7090 |    91.7 KB |
+| BigJson_Newtonsoft       |  48.892 us |   2.3675 us |  0.1298 us |  24.8413 |   8.2397 |   203.1 KB |
+| BigJson_SystemTextJson   |  14.912 us |   0.7656 us |  0.0420 us |   2.9297 |   0.3204 |   24.12 KB |
+| BigJson_Sprache          | 807.783 us | 129.9628 us |  7.1237 us | 631.8359 | 130.8594 | 5161.74 KB |
+| BigJson_Superpower       | 356.457 us |  26.1486 us |  1.4333 us | 103.5156 |  18.0664 |  845.93 KB |
+|                          |            |             |            |          |          |            |
+| DeepJson_Parlot          |  28.795 us |   5.6271 us |  0.3084 us |  12.7869 |   1.4038 |  104.57 KB |
+| DeepJson_ParlotGenerated |  24.167 us |   0.5363 us |  0.0294 us |  12.0239 |   1.2512 |   98.36 KB |
+| DeepJson_Pidgin          | 100.953 us |  16.4148 us |  0.8998 us |  14.1602 |   3.5400 |  116.29 KB |
+| DeepJson_Newtonsoft      |  41.074 us |   6.1893 us |  0.3393 us |  21.9116 |   8.7280 |  179.13 KB |
+| DeepJson_SystemTextJson  |  58.011 us |   1.7527 us |  0.0961 us |   2.4414 |   0.1831 |   20.24 KB |
+| DeepJson_Sprache         | 628.468 us | 353.3203 us | 19.3667 us | 342.7734 | 141.6016 | 2802.33 KB |
+|                          |            |             |            |          |          |            |
+| LongJson_Parlot          |  29.772 us |   1.0465 us |  0.0574 us |  13.7634 |   2.8076 |  112.52 KB |
+| LongJson_ParlotGenerated |  26.750 us |   1.5866 us |  0.0870 us |  14.4653 |   3.5706 |  118.38 KB |
+| LongJson_Pidgin          |  70.988 us |   9.4521 us |  0.5181 us |  14.6484 |   3.0518 |  120.25 KB |
+| LongJson_Newtonsoft      |  37.257 us |   4.3815 us |  0.2402 us |  24.7803 |   9.6436 |  202.68 KB |
+| LongJson_SystemTextJson  |   9.422 us |   0.2364 us |  0.0130 us |   2.9297 |   0.3204 |   24.12 KB |
+| LongJson_Sprache         | 671.931 us | 127.6828 us |  6.9987 us | 509.7656 | 129.8828 |  4165.2 KB |
+| LongJson_Superpower      | 295.297 us |  12.4582 us |  0.6829 us |  83.0078 |  20.0195 |  678.79 KB |
+|                          |            |             |            |          |          |            |
+| WideJson_Parlot          |  17.604 us |   1.3398 us |  0.0734 us |   4.9744 |   0.4883 |   40.72 KB |
+| WideJson_ParlotGenerated |  14.807 us |   0.8907 us |  0.0488 us |   4.9591 |   0.4883 |   40.59 KB |
+| WideJson_Pidgin          |  32.984 us |   4.0433 us |  0.2216 us |   4.9438 |   0.4883 |   40.48 KB |
+| WideJson_Newtonsoft      |  24.726 us |   1.2357 us |  0.0677 us |  13.0615 |   3.2349 |  106.72 KB |
+| WideJson_Sprache         | 354.187 us |  10.4665 us |  0.5737 us | 320.8008 |  45.4102 | 2622.69 KB |
+| WideJson_Superpower      | 173.612 us |  10.3190 us |  0.5656 us |  51.2695 |   4.8828 |  419.81 KB |
 ```
 
 ### Regular Expressions
@@ -257,22 +257,22 @@ an email with the pattern `[\w\.+-]+@[\w-]+\.[\w\.-]+`. Note that in the case of
 The benchmark compares regular, compiled, and source-generated .NET regular expressions with Fluent and source-generated Parlot parsers.
 
 ```
-BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.8 (24G824) [Darwin 24.6.0]
+BenchmarkDotNet v0.15.8, macOS Sequoia 15.7.9 (24G830) [Darwin 24.6.0]
 Apple M4 Pro, 1 CPU, 14 logical and 14 physical cores
-.NET SDK 10.0.301
-  [Host]   : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
-  ShortRun : .NET 10.0.9 (10.0.9, 10.0.926.27113), Arm64 RyuJIT armv8.0-a
+.NET SDK 10.0.302
+  [Host]   : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
+  ShortRun : .NET 10.0.10 (10.0.10, 10.0.1026.32716), Arm64 RyuJIT armv8.0-a
 
 Job=ShortRun  IterationCount=3  LaunchCount=1
 WarmupCount=3
 
-| Method               | Mean      | Error    | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
-|--------------------- |----------:|---------:|---------:|------:|-------:|----------:|------------:|
-| RegexEmailCompiled   |  40.35 ns | 2.688 ns | 0.147 ns |  1.00 | 0.0249 |     208 B |        1.00 |
-| RegexEmail           |  92.52 ns | 2.671 ns | 0.146 ns |  2.29 | 0.0248 |     208 B |        1.00 |
-| RegexEmailGenerated  |  39.52 ns | 2.756 ns | 0.151 ns |  0.98 | 0.0249 |     208 B |        1.00 |
-| ParlotEmail          | 139.38 ns | 3.087 ns | 0.169 ns |  3.45 | 0.0372 |     312 B |        1.50 |
-| ParlotEmailGenerated |  97.09 ns | 2.432 ns | 0.133 ns |  2.41 | 0.0229 |     192 B |        0.92 |
+| Method               | Mean      | Error     | StdDev   | Ratio | Gen0   | Allocated | Alloc Ratio |
+|--------------------- |----------:|----------:|---------:|------:|-------:|----------:|------------:|
+| RegexEmailCompiled   |  39.98 ns |  8.539 ns | 0.468 ns |  1.00 | 0.0249 |     208 B |        1.00 |
+| RegexEmail           |  91.41 ns |  3.353 ns | 0.184 ns |  2.29 | 0.0248 |     208 B |        1.00 |
+| RegexEmailGenerated  |  40.36 ns |  4.797 ns | 0.263 ns |  1.01 | 0.0249 |     208 B |        1.00 |
+| ParlotEmail          | 147.08 ns | 27.495 ns | 1.507 ns |  3.68 | 0.0372 |     312 B |        1.50 |
+| ParlotEmailGenerated |  62.36 ns |  8.718 ns | 0.478 ns |  1.56 | 0.0229 |     192 B |        0.92 |
 ```
 
 ### Versions
@@ -282,8 +282,8 @@ The benchmarks were executed with the following versions:
 - Parlot (current source)
 - Pidgin 3.5.1
 - Sprache 3.0.0-develop-00049
-- Superpower 3.2.1
-- Newtonsoft.Json 13.0.4
+- Superpower 3.2.2-dev-00214
+- Newtonsoft.Json 13.0.5-beta1
 
 ### Operator Syntax
 


### PR DESCRIPTION
The published parser comparisons were using older benchmark library versions and stale measurements. Refresh them so readers see results from the current dependency set and runtime environment.

- Update Superpower to 3.2.2-dev-00214 and Newtonsoft.Json to 13.0.5-beta1, the latest available comparison-library releases.
- Rerun all Expression, JSON, and Regex benchmarks with the documented BenchmarkDotNet ShortRun configuration.
- Replace the README environment details, timing and allocation tables, version list, and expression summary with the generated results.

The final README tables were checked against all 39 generated BenchmarkDotNet report rows.