### PR TITLE
Support parameterized source-generated parsers and conditional If

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,17 +104,20 @@ it — that is also the supported way to pass state into source-generated parser
 
 ### Source generation
 
-`src/Parlot.SourceGenerator` (netstandard2.0, Roslyn 4.11) makes `[GenerateParser]`-annotated static
-parameterless methods free at runtime: it loads `Parlot.dll`, executes the method at compile time to build
+`src/Parlot.SourceGenerator` (netstandard2.0, Roslyn 4.11) handles `[GenerateParser]`-annotated static
+methods: it loads `Parlot.dll`, executes the method at compile time to build
 the graph, walks it calling `ISourceable.GenerateSource`, and emits C# interceptors that replace the call
-sites. Consumers must set `<InterceptorsNamespaces>`.
+sites. Consumers must set `<InterceptorsNamespaces>`. Parameterless factories use a cached singleton;
+parameterized factories bind arguments to a small generated parser instance that callers should reuse.
 
-- `ParserSourceGenerator.cs` (~2.3k lines) drives it; `LambdaRewriter.cs` lifts lambdas into static methods
+- `ParserSourceGenerator.cs` drives it; `LambdaRewriter.cs` lifts lambdas into generated methods
   with `#line` mappings so breakpoints still land in the original source.
 - Registries in `src/Parlot/SourceGeneration` (`LambdaRegistry`, `DeferredRegistry`, `ParserHelperRegistry`,
   `TargetFrameworkInfo`, `SourceGenerationContext`, `SourceResult`) are the emission API.
-- Diagnostics are `PARLOT000`–`PARLOT015`; `PARLOT015` is the common one — **lambdas may not capture**
-  (no closures). Use `static` lambdas, static fields, method groups, or a custom `ParseContext`.
+- `PARLOT015` rejects captured locals or other methods' parameters. Inline parse-time callbacks in
+  `If`, `Select`, `Then`, `ThenElse`, `When`, `Switch`, and `Else` may capture their factory's by-value
+  parameters. `PARLOT021` rejects eager argument use or reassignment: keep the graph fixed and use
+  `If`/`Select` for runtime branches. Conditions may also accept a typed `ParseContext`.
 - Inspect output via `EmitCompilerGeneratedFiles` (both test/benchmark projects already set it; look under
   `obj/.../GeneratedFiles`).
 - The generator ships inside the Parlot NuGet package under `analyzers/dotnet/cs`, so `Parlot.csproj`

--- a/README.md
+++ b/README.md
@@ -104,10 +104,10 @@ Parlot can generate parsers at **compile time** using C# interceptors, avoiding 
 
 ### How it works
 
-- Annotate static, **parameterless** methods returning `Parlot.Fluent.Parser<T>` with `[GenerateParser]`.
+- Annotate static methods returning `Parlot.Fluent.Parser<T>` with `[GenerateParser]`.
 - The source generator executes the method at compile time to build the parser graph.
 - Uses C# interceptors to replace calls to the method with the generated, optimized code.
-- For parser variants (e.g., different keywords), create separate methods instead of using parameters.
+- For parser variants, capture factory parameters in `If`, `Select`, or other supported parse-time callbacks. Every branch is generated; runtime arguments configure the returned parser instance.
 
 ```csharp
 using Parlot.SourceGenerator;
@@ -136,8 +136,8 @@ var foo = MyGrammar.FooParser();      // Uses generated code
 ### Requirements
 
 - Add `<InterceptorsNamespaces>$(InterceptorsNamespaces);YourNamespace</InterceptorsNamespaces>` to your project file.
-- Methods must be static and parameterless.
-- The containing class should be `partial` (optional but recommended).
+- Methods must be static and non-generic. By-value parameters may only be read in supported parse-time callbacks, not during graph construction.
+- The containing class must be `partial`.
 
 ### Advanced Configuration
 

--- a/docs/parsers.md
+++ b/docs/parsers.md
@@ -103,6 +103,7 @@ Result:
 Selects the parser to execute at runtime. Use it when the next parser depends on mutable state or a custom `ParseContext` implementation.
 
 ```c#
+Parser<T> Select<T>(Func<int> selector, params Parser<T>[] parsers)
 Parser<T> Select<T>(Func<ParseContext, int> selector, params Parser<T>[] parsers)
 Parser<T> Select<C, T>(Func<C, int> selector, params Parser<T>[] parsers) where C : ParseContext
 ```
@@ -119,7 +120,7 @@ var result = parser.Parse(new CustomContext(new Scanner("yes")) { PreferYes = tr
 ```
 `CustomContext` is an application-defined type that derives from `ParseContext` and exposes additional configuration.
 
-If the selector returns an out-of-range index, the `Select` parser fails without consuming any input. Capture additional state through closures or custom `ParseContext` properties when needed.
+The selector is evaluated once per parse, before any branch skips whitespace. Only the selected parser runs; its failure does not try another branch. If the selector returns an out-of-range index, the `Select` parser fails without consuming any input. Capture additional state through closures or custom `ParseContext` properties when needed.
 
 ### Text
 
@@ -1119,17 +1120,37 @@ parser.Parse("42:"); // failure, lookahead matches
 
 The lookahead parser is checked at the current position but doesn't consume input. If the lookahead succeeds, the entire parser fails and the cursor is reset to the beginning.
 
-### If (Deprecated)
-
-NB: This parser can be rewritten using `Select` (and `Fail`) which is more flexible and simpler to understand.
+### If
 
 Executes a parser only if a condition is true.
 
 ```c#
-Parser<T> If<TContext, TState, T>(Func<ParseContext, TState, bool> predicate, TState state, Parser<T> parser)
+Parser<T> If<T>(Func<bool> condition, Parser<T> parser)
+Parser<T> If<T>(Func<ParseContext, bool> condition, Parser<T> parser)
+Parser<T> If<C, T>(Func<C, bool> condition, Parser<T> parser) where C : ParseContext
 ```
 
-To evaluate a condition before a parser is executed use the `If` parser instead.
+The condition is evaluated once per parse, at the current cursor position before any branch skips whitespace.
+When it is false, the two-argument form fails without consuming input or changing the result.
+When it is true, the parser succeeds only if the selected child succeeds.
+
+Provide an else parser to select between two fixed branches:
+
+```c#
+Parser<T> If<T>(Func<bool> condition, Parser<T> thenParser, Parser<T> elseParser)
+Parser<T> If<T>(Func<ParseContext, bool> condition, Parser<T> thenParser, Parser<T> elseParser)
+Parser<T> If<C, T>(Func<C, bool> condition, Parser<T> thenParser, Parser<T> elseParser) where C : ParseContext
+
+var allowWhiteSpace = true;
+var parser = If(() => allowWhiteSpace, Terms.Integer(), Literals.Integer());
+```
+
+Only the selected branch executes. If it fails, the cursor is restored and `If` fails;
+it never falls back to the other branch. Conditions and selectors should not consume input.
+To validate a parsed value instead, use `When`.
+
+The obsolete overloads taking a separate state argument and the `If<C, S, T>` type have been removed
+in this major version. Capture state in the condition or read it from a custom `ParseContext`.
 
 ### Switch
 

--- a/docs/source-generation.md
+++ b/docs/source-generation.md
@@ -50,9 +50,95 @@ var result = parser.Parse("hello world");
 ## Requirements
 
 - **Static methods**: The annotated method must be `static`.
-- **Parameterless**: Methods cannot have parameters (create separate methods for variants).
+- **Parameters**: Ordinary by-value arguments can be captured by inline parse-time callbacks. They cannot determine the parser graph during construction.
+- **Non-generic**: Generic factories and generic containing types are not supported. Neither are `ref`, `out`, `in`, ref-like, pointer, or function-pointer parameters.
 - **Return type**: Must return `Parlot.Fluent.Parser<T>`.
-- **Partial class**: Recommended but not required.
+- **Partial class**: The containing class must be `partial`.
+
+## Parameterized Parsers
+
+Factory arguments configure a generated parser instance. The generator emits every branch once; the
+actual arguments are bound when the factory is called at runtime.
+
+```csharp
+public static partial class MyGrammar
+{
+    [GenerateParser]
+    public static Parser<string> Greeting(bool formal, string prefix)
+    {
+        return If(
+            () => formal,
+            Literals.Text("Hello"),
+            Literals.Text("Hi"))
+            .Then(text => prefix + text);
+    }
+}
+
+var formal = MyGrammar.Greeting(true, "Greeting: ");
+var informal = MyGrammar.Greeting(false, "");
+
+formal.Parse("Hello"); // "Greeting: Hello"
+informal.Parse("Hi");  // "Hi"
+```
+
+Multiple parameters, overloads, named arguments, optional arguments, and `params` arrays are supported.
+Calls evaluate their arguments normally, once and in source order. Parameterless factories still return
+a cached singleton; parameterized factories create a small bound parser instance, not a parser graph.
+Build that instance once and reuse it.
+
+### Conditional branches and context
+
+`If(condition, thenParser, elseParser)` evaluates the predicate once each time it is parsed and runs only
+the selected branch. Failure does not try the other branch. `If(condition, parser)` fails without
+consuming input when the condition is false. Both forms also accept `Func<ParseContext, bool>` or
+`Func<C, bool>` where `C : ParseContext`:
+
+```csharp
+return If(
+    (LanguageParseContext context) => options.AllowExtensions && context.InsideFunction,
+    extensionExpression,
+    standardExpression);
+```
+
+Factory arguments belong to the parser instance; the context always comes from the current parse.
+Predicates must not consume input. Use `Select(() => index, a, b, c)` for multiple branches, or its
+context-aware overloads. All branch parsers are constructed at compile time, including inactive ones.
+
+### Capture restrictions
+
+Factory parameters may be read in inline callbacks passed to `If`, `Select`, `Then`, `ThenElse`, `When`,
+`Switch`, and `Else`. Generated callbacks access instance fields directly, without allocating closures
+or invoking delegates during parsing. An ordinary, non-intercepted factory call retains its normal
+runtime combinator behavior.
+
+Captured arguments retain normal value/reference semantics. A reference-type options object is not
+cloned or frozen, so later mutations are visible to predicates. Prefer immutable options for parsers
+shared across threads. Value-type arguments are copied when the factory is called.
+
+Parameters cannot be reassigned or passed by reference. Factory-parameter captures must be inline;
+storing such a callback in a local variable is not supported. Captured locals and captures of parameters
+belonging to a different helper method are also unsupported. Move calculations that depend on arguments
+into the callback, or compute them before calling the factory.
+
+The graph must not depend on placeholder argument values. These examples are rejected with `PARLOT021`:
+
+```csharp
+// Eager branch selection would omit one branch from the generated parser.
+return formal ? Literals.Text("Hello") : Literals.Text("Hi");
+
+// A runtime-configured literal is not a compile-time constant.
+return Literals.Text(keyword);
+
+// Even eager normalization reads an unavailable runtime argument.
+var normalized = prefix.Trim();
+return Literals.Text("Hello").Then(text => normalized + text);
+```
+
+Use `If` or `Select` for alternatives and callbacks such as `.Then(text => prefix.Trim() + text)` for
+deferred computation. Eager argument validation also belongs before the factory call. Deferred callbacks
+are identified without executing their user bodies for source extraction; a callback capturing factory
+state cannot be invoked while building the graph. Such execution is rejected even if the factory catches
+the resulting exception (`PARLOT022`).
 
 ## Attributes Reference
 
@@ -289,34 +375,35 @@ This ensures that:
 
 ## Troubleshooting
 
-### Parser method has parameters
+### Unsupported factory parameters
 
 ```
-error: [GenerateParser] methods must be parameterless
+error PARLOT009: Unsupported parser factory signature
 ```
 
-Create separate methods for each variant:
+Use ordinary by-value parameters, not generic factories, by-reference parameters, or ref-like types.
+If an ordinary parameter is used eagerly during graph construction, `PARLOT021` explains that it must
+instead be read in a supported parse-time callback:
 
 ```csharp
 // ❌ Wrong
 [GenerateParser]
-public static Parser<string> TextParser(string text) => Terms.Text(text);
+public static Parser<string> TextParser(bool formal) =>
+    formal ? Terms.Text("Hello") : Terms.Text("Hi");
 
 // ✅ Correct
 [GenerateParser]
-public static Parser<string> HelloParser() => Terms.Text("hello");
-
-[GenerateParser]
-public static Parser<string> WorldParser() => Terms.Text("world");
+public static Parser<string> TextParser(bool formal) =>
+    If(() => formal, Terms.Text("Hello"), Terms.Text("Hi"));
 ```
 
-### Closures are not supported
+### Unsupported captures
 
 ```
 error PARLOT015: Lambda captures variable 'prefix' from the enclosing scope
 ```
 
-Lambdas in source-generated parsers cannot capture variables from their enclosing scope (closures). The generated code creates static methods that don't have access to captured state.
+Lambdas may capture their factory's parameters, but not arbitrary locals or another method's parameters.
 
 ```csharp
 // ❌ Wrong - captures 'prefix' variable
@@ -330,7 +417,15 @@ public static Parser<string> MyParser()
 
 **Solutions:**
 
-1. **Use a custom `ParseContext` subclass** to pass state:
+1. **Pass the state as a factory parameter:**
+
+```csharp
+[GenerateParser]
+public static Parser<string> MyParser(string prefix) =>
+    Terms.Identifier().Then(x => prefix + x.ToString());
+```
+
+2. **Use a custom `ParseContext` subclass** for per-execution state:
 
 ```csharp
 public class MyParseContext : ParseContext
@@ -342,8 +437,8 @@ public class MyParseContext : ParseContext
 [GenerateParser]
 public static Parser<string> MyParser()
 {
-    return Terms.Identifier().Then<MyParseContext, TextSpan, string>(
-        static (context, x) => context.Prefix + x.ToString());
+    return Terms.Identifier().Then(
+        static (context, x) => ((MyParseContext)context).Prefix + x.ToString());
 }
 
 // Usage:
@@ -352,7 +447,7 @@ var context = new MyParseContext(new Scanner("world")) { Prefix = "hello" };
 parser.Parse(context, out var result);
 ```
 
-2. **Use static fields or properties:**
+3. **Use static fields or properties:**
 
 ```csharp
 private static string _prefix = "hello";
@@ -364,7 +459,7 @@ public static Parser<string> MyParser()
 }
 ```
 
-3. **Use method groups for static methods:**
+4. **Use method groups for static methods:**
 
 ```csharp
 private static string Transform(TextSpan x) => "hello" + x.ToString();

--- a/src/Parlot.SourceGenerator/FactoryParameterUsage.cs
+++ b/src/Parlot.SourceGenerator/FactoryParameterUsage.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Parlot.SourceGenerator;
+
+internal static class FactoryParameterUsage
+{
+    internal sealed record InvalidUse(string ParameterName, Location Location);
+
+    public static IEnumerable<InvalidUse> FindInvalidUses(
+        IMethodSymbol factory,
+        MethodDeclarationSyntax syntax,
+        SemanticModel semanticModel)
+    {
+        foreach (var identifier in syntax.DescendantNodes().OfType<IdentifierNameSyntax>())
+        {
+            if (semanticModel.GetSymbolInfo(identifier).Symbol is not IParameterSymbol parameter
+                || !SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, factory))
+            {
+                continue;
+            }
+
+            if (identifier.Ancestors().OfType<InvocationExpressionSyntax>()
+                .Any(invocation => semanticModel.GetOperation(invocation) is INameOfOperation))
+            {
+                continue;
+            }
+
+            var callback = identifier.Ancestors()
+                .OfType<LambdaExpressionSyntax>()
+                .FirstOrDefault(lambda => IsDeferredCallback(lambda, semanticModel));
+
+            if (callback is null
+                || IsWrittenOrPassedByReference(identifier, parameter, semanticModel))
+            {
+                yield return new InvalidUse(parameter.Name, identifier.GetLocation());
+            }
+        }
+    }
+
+    public static bool IsDeferredCallback(ExpressionSyntax expression, SemanticModel semanticModel)
+    {
+        SyntaxNode node = expression;
+        while (node.Parent is ParenthesizedExpressionSyntax or CastExpressionSyntax)
+        {
+            node = node.Parent;
+        }
+
+        if (node.Parent is not ArgumentSyntax argument
+            || semanticModel.GetOperation(argument) is not IArgumentOperation { Parameter: { } parameter }
+            || parameter.Type.TypeKind != TypeKind.Delegate
+            || parameter.ContainingSymbol is not IMethodSymbol method
+            || method.ContainingAssembly.Name != "Parlot"
+            || method.ContainingNamespace.ToDisplayString() != "Parlot.Fluent")
+        {
+            return false;
+        }
+
+        // Only callbacks known to run during Parse may depend on runtime factory arguments.
+        // In particular, Recursive's callback builds the graph and must still run at build time.
+        return method.ContainingType.MetadataName switch
+        {
+            "Parsers" => method.Name is "If" or "Select",
+            "Parser`1" => method.Name is "Then" or "ThenElse" or "When" or "Switch" or "Else",
+            _ => false
+        };
+    }
+
+    public static string GetFieldName(IParameterSymbol parameter) => $"_argument{parameter.Ordinal}";
+
+    private static bool IsWrittenOrPassedByReference(
+        IdentifierNameSyntax identifier,
+        IParameterSymbol parameter,
+        SemanticModel semanticModel)
+    {
+        var operation = semanticModel.GetOperation(identifier);
+        if (operation is null)
+        {
+            return false;
+        }
+
+        // Reference-type members belong to the supplied object; value-type members belong to
+        // the captured variable itself. Neither a captured variable nor its storage may escape.
+        while (operation.Parent is IParenthesizedOperation or ITupleOperation
+            || (parameter.Type.IsValueType && operation.Parent is IFieldReferenceOperation or IPropertyReferenceOperation))
+        {
+            operation = operation.Parent;
+        }
+
+        return operation.Parent switch
+        {
+            IAssignmentOperation assignment => ReferenceEquals(assignment.Target, operation),
+            IIncrementOrDecrementOperation => true,
+            IArgumentOperation argument => argument.Parameter?.RefKind is RefKind.Ref or RefKind.Out or RefKind.In,
+            _ => false
+        };
+    }
+}

--- a/src/Parlot.SourceGenerator/GenerateParserAttribute.cs
+++ b/src/Parlot.SourceGenerator/GenerateParserAttribute.cs
@@ -2,7 +2,9 @@ namespace Parlot.SourceGenerator;
 
 /// <summary>
 /// Marks a parser descriptor method for Parlot source generation using interceptors.
-/// The annotated method must be static, parameterless, and return Parlot.Fluent.Parser&lt;T&gt;.
+/// The annotated method must be static, non-generic, and return Parlot.Fluent.Parser&lt;T&gt;.
+/// By-value parameters may be captured by inline parse-time callbacks, but cannot be used
+/// to construct the parser graph eagerly.
 /// 
 /// When applied, the source generator will:
 /// 1. Execute the method at compile time to build the parser graph
@@ -22,14 +24,14 @@ namespace Parlot.SourceGenerator;
 /// var parser = HelloParser();
 /// </code>
 /// 
-/// If you need different parser variants with different configurations, create separate methods:
+/// Bind runtime arguments to a generated parser instance using conditional parsers:
 /// <code>
 /// [GenerateParser]
-/// public static Parser&lt;string&gt; FooLowerParser() =&gt; Terms.Text("foo");
-/// 
-/// [GenerateParser]
-/// public static Parser&lt;string&gt; FooUpperParser() =&gt; Terms.Text("FOO");
+/// public static Parser&lt;string&gt; FooParser(bool uppercase) =&gt;
+///     If(() =&gt; uppercase, Terms.Text("FOO"), Terms.Text("foo"));
 /// </code>
+/// Parameterless factories return a cached parser. Parameterized factories return a new bound
+/// instance that should be reused. Conditions may also accept the current ParseContext.
 /// </remarks>
 [System.AttributeUsage(System.AttributeTargets.Method)]
 #if SOURCE_GENERATOR

--- a/src/Parlot.SourceGenerator/LambdaRewriter.cs
+++ b/src/Parlot.SourceGenerator/LambdaRewriter.cs
@@ -13,41 +13,35 @@ namespace Parlot.SourceGenerator;
 /// that register their pointer ID when invoked. This allows the source generator to match
 /// runtime-registered lambdas back to their original source code.
 /// 
-/// The approach: Instead of replacing the lambda body entirely (which loses type information),
-/// we wrap the lambda to first register its pointer, then execute the original body.
+/// Deferred parser callbacks register their pointer without executing the user body.
+/// Other lambdas still execute normally, since they may participate in building the graph.
 /// 
 /// Example transformation:
 ///   Original: x => x.ToLower()
-///   Rewritten: x => { Parlot.SourceGeneration.LambdaPointer.CurrentPointer = 0; return x.ToLower(); }
+///   Rewritten: x => { Parlot.SourceGeneration.LambdaPointer.CurrentPointer = 0; return default(string); }
 /// 
 /// <para>
-/// <strong>Important:</strong> Only static (closure-free) lambdas are supported. Lambdas that
-/// capture variables from their enclosing scope cannot be source-generated because the generated
-/// code creates static methods that don't have access to the captured state.
+/// Factory parameter captures are bound to generated instance fields. Other captures are reported
+/// only when the callback is actually used by the generated graph.
 /// </para>
 /// </summary>
 internal sealed class LambdaRewriter : CSharpSyntaxRewriter
 {
     private readonly SemanticModel _semanticModel;
+    private readonly IMethodSymbol _factory;
     private readonly Dictionary<int, LambdaInfo> _lambdas = new();
-    private readonly List<CapturedVariableInfo> _capturedVariables = new();
     private int _nextPointer;
 
-    public LambdaRewriter(SemanticModel semanticModel)
+    public LambdaRewriter(SemanticModel semanticModel, IMethodSymbol factory)
     {
         _semanticModel = semanticModel;
+        _factory = factory;
     }
 
     /// <summary>
     /// Gets all recorded lambdas with their pointers and source code.
     /// </summary>
     public IReadOnlyDictionary<int, LambdaInfo> Lambdas => _lambdas;
-
-    /// <summary>
-    /// Gets information about any captured variables (closures) detected in lambdas.
-    /// If this list is non-empty, source generation will fail with appropriate diagnostics.
-    /// </summary>
-    public IReadOnlyList<CapturedVariableInfo> CapturedVariables => _capturedVariables;
 
     /// <summary>
     /// Information about a captured variable in a lambda (closure).
@@ -68,7 +62,8 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
         IReadOnlyList<string> ParameterTypes,
         string? FilePath,
         int StartLine,
-        int StartColumn);
+        int StartColumn,
+        IReadOnlyList<CapturedVariableInfo> CapturedVariables);
 
     public override SyntaxNode? VisitSimpleLambdaExpression(SimpleLambdaExpressionSyntax node)
     {
@@ -87,18 +82,19 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
         BlockSyntax? blockBody)
     {
         var pointer = _nextPointer++;
-        var originalSource = originalLambda.ToFullString().Trim();
-
-        // Check for captured variables (closures) - these are not supported in source generation
-        DetectCapturedVariables(originalLambda, parameters, originalSource);
+        var originalSource = new ParameterBindingRewriter(_semanticModel, _factory)
+            .Visit(originalLambda)!.ToFullString().Trim();
+        var capturedVariables = DetectCapturedVariables(originalLambda, originalSource);
 
         // Determine return type and parameter types from semantic model
         var paramTypes = new List<string>();
         string? returnType = null;
+        IMethodSymbol? delegateInvokeMethod = null;
 
         var typeInfo = _semanticModel.GetTypeInfo(originalLambda);
         if (typeInfo.ConvertedType is INamedTypeSymbol namedType && namedType.DelegateInvokeMethod is { } invokeMethod)
         {
+            delegateInvokeMethod = invokeMethod;
             returnType = invokeMethod.ReturnType.Name.ToLowerInvariant();
             foreach (var param in invokeMethod.Parameters)
             {
@@ -121,25 +117,45 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
             paramTypes,
             filePath,
             startLine,
-            startColumn);
+            startColumn,
+            capturedVariables);
 
         // Create the pointer registration statement
         // global::Parlot.SourceGeneration.LambdaPointer.CurrentPointer = {pointer};
         var registrationStatement = CreatePointerRegistrationStatement(pointer);
 
         BlockSyntax newBody;
-        if (blockBody != null)
+        if (delegateInvokeMethod is not null)
+        {
+            var hasCaptures = _semanticModel.AnalyzeDataFlow(originalLambda)?.CapturedInside.Any(symbol =>
+                !symbol.Locations.Any(location =>
+                    location.SourceTree == originalLambda.SyntaxTree && originalLambda.Span.Contains(location.SourceSpan))) == true;
+            var executionBody = blockBody is not null
+                ? (BlockSyntax)Visit(blockBody)!
+                : SyntaxFactory.Block(delegateInvokeMethod.ReturnsVoid
+                    ? SyntaxFactory.ExpressionStatement((ExpressionSyntax)Visit(expressionBody)!)
+                    : SyntaxFactory.ReturnStatement((ExpressionSyntax)Visit(expressionBody)!));
+            if (hasCaptures && FactoryParameterUsage.IsDeferredCallback(originalLambda, _semanticModel))
+            {
+                executionBody = SyntaxFactory.Block(
+                    SyntaxFactory.ThrowStatement(SyntaxFactory.ParseExpression(
+                        "global::Parlot.SourceGeneration.LambdaPointer.CreateEagerCaptureException()")));
+            }
+            newBody = CreateDeferredBody(registrationStatement, delegateInvokeMethod, executionBody);
+        }
+        else if (blockBody != null)
         {
             // Already a block body - prepend the registration
-            newBody = blockBody.WithStatements(
-                blockBody.Statements.Insert(0, registrationStatement));
+            var visitedBody = (BlockSyntax)Visit(blockBody)!;
+            newBody = visitedBody.WithStatements(
+                visitedBody.Statements.Insert(0, registrationStatement));
         }
         else if (expressionBody != null)
         {
             // Expression body - convert to block with registration + return
             newBody = SyntaxFactory.Block(
                 registrationStatement,
-                SyntaxFactory.ReturnStatement(expressionBody));
+                SyntaxFactory.ReturnStatement((ExpressionSyntax)Visit(expressionBody)!));
         }
         else
         {
@@ -172,7 +188,8 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
                 var method = (IMethodSymbol)(symbolInfo.Symbol ?? symbolInfo.CandidateSymbols[0]);
                 
                 var pointer = _nextPointer++;
-                var originalSource = node.Expression.ToFullString().Trim();
+                var originalSource = new ParameterBindingRewriter(_semanticModel, _factory)
+                    .Visit(node.Expression)!.ToFullString().Trim();
 
                 var paramTypes = method.Parameters.Select(p => p.Type.ToDisplayString()).ToList();
                 var returnType = method.ReturnType.Name.ToLowerInvariant();
@@ -192,7 +209,8 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
                     paramTypes,
                     filePath,
                     startLine,
-                    startColumn);
+                    startColumn,
+                    Array.Empty<CapturedVariableInfo>());
 
                 // Replace method group with a lambda that sets the pointer and calls the method
                 // e.g., char.IsLetter becomes (char arg0) => { LambdaPointer.CurrentPointer = N; return char.IsLetter(arg0); }
@@ -215,9 +233,8 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
                     node.Expression,
                     SyntaxFactory.ArgumentList(SyntaxFactory.SeparatedList(arguments)));
 
-                var body = SyntaxFactory.Block(
-                    registrationStatement,
-                    SyntaxFactory.ReturnStatement(methodCall));
+                var body = CreateDeferredBody(registrationStatement, method, SyntaxFactory.Block(
+                    method.ReturnsVoid ? SyntaxFactory.ExpressionStatement(methodCall) : SyntaxFactory.ReturnStatement(methodCall)));
 
                 var stubLambda = SyntaxFactory.ParenthesizedLambdaExpression(parameterList, body);
 
@@ -233,38 +250,20 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
     /// Captured variables are local variables or parameters from the enclosing scope
     /// that are referenced inside the lambda but are not lambda parameters themselves.
     /// </summary>
-    private void DetectCapturedVariables(
+    private List<CapturedVariableInfo> DetectCapturedVariables(
         LambdaExpressionSyntax lambda,
-        ParameterSyntax[] lambdaParameters,
         string lambdaSource)
     {
-        // Get all lambda parameter names
-        var parameterNames = new HashSet<string>(
-            lambdaParameters.Select(p => p.Identifier.Text),
-            StringComparer.Ordinal);
-
-        // Find all identifier references in the lambda body
-        var body = lambda.Body;
-        if (body is null)
-        {
-            return;
-        }
-
-        foreach (var identifier in body.DescendantNodes().OfType<IdentifierNameSyntax>())
+        var captures = new List<CapturedVariableInfo>();
+        var capturedSymbols = _semanticModel.AnalyzeDataFlow(lambda)?.CapturedInside;
+        foreach (var identifier in lambda.Body.DescendantNodesAndSelf().OfType<IdentifierNameSyntax>())
         {
             var name = identifier.Identifier.Text;
-
-            // Skip if it's a lambda parameter
-            if (parameterNames.Contains(name))
-            {
-                continue;
-            }
-
             // Get symbol info to determine what this identifier refers to
             var symbolInfo = _semanticModel.GetSymbolInfo(identifier);
             var symbol = symbolInfo.Symbol;
 
-            if (symbol is null)
+            if (symbol is null || capturedSymbols?.Contains(symbol, SymbolEqualityComparer.Default) != true)
             {
                 continue;
             }
@@ -275,7 +274,7 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
                 // This is a local variable - check if it's from outside the lambda
                 if (!IsDefinedWithinLambda(localSymbol, lambda))
                 {
-                    _capturedVariables.Add(new CapturedVariableInfo(
+                    captures.Add(new CapturedVariableInfo(
                         name,
                         lambdaSource,
                         identifier.GetLocation()));
@@ -283,17 +282,20 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
             }
             else if (symbol is IParameterSymbol paramSymbol)
             {
-                // This is a parameter - check if it's from the containing method (not the lambda)
-                if (paramSymbol.ContainingSymbol is IMethodSymbol containingMethod &&
-                    !IsLambdaMethod(containingMethod, lambda))
+                if (!SymbolEqualityComparer.Default.Equals(paramSymbol.ContainingSymbol, _factory)
+                    && !paramSymbol.Locations.Any(location =>
+                        location.SourceTree == lambda.SyntaxTree && lambda.Span.Contains(location.SourceSpan)))
                 {
-                    _capturedVariables.Add(new CapturedVariableInfo(
+                    captures.Add(new CapturedVariableInfo(
                         name,
                         lambdaSource,
                         identifier.GetLocation()));
                 }
             }
+
         }
+
+        return captures;
     }
 
     /// <summary>
@@ -315,24 +317,129 @@ internal sealed class LambdaRewriter : CSharpSyntaxRewriter
         return false;
     }
 
-    /// <summary>
-    /// Checks if a method symbol represents the lambda itself.
-    /// </summary>
-    private static bool IsLambdaMethod(IMethodSymbol method, LambdaExpressionSyntax lambda)
+    private static BlockSyntax CreateStubBody(StatementSyntax registration, IMethodSymbol method)
     {
-        // Lambda methods have MethodKind.LambdaMethod or AnonymousFunction
-        if (method.MethodKind is MethodKind.LambdaMethod or MethodKind.AnonymousFunction)
+        return method.ReturnsVoid
+            ? SyntaxFactory.Block(registration)
+            : SyntaxFactory.Block(
+                registration,
+                SyntaxFactory.ReturnStatement(SyntaxFactory.PostfixUnaryExpression(
+                    SyntaxKind.SuppressNullableWarningExpression,
+                    SyntaxFactory.DefaultExpression(SyntaxFactory.ParseTypeName(
+                        method.ReturnType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat))))));
+    }
+
+    private static BlockSyntax CreateDeferredBody(StatementSyntax registration, IMethodSymbol method, BlockSyntax executionBody)
+    {
+        var registrationBody = CreateStubBody(registration, method);
+        if (method.ReturnsVoid)
         {
-            // Check if the method's syntax reference matches our lambda
-            foreach (var syntaxRef in method.DeclaringSyntaxReferences)
+            registrationBody = registrationBody.AddStatements(SyntaxFactory.ReturnStatement());
+        }
+
+        return executionBody.WithStatements(executionBody.Statements.Insert(0, SyntaxFactory.IfStatement(
+            SyntaxFactory.ParseExpression("global::Parlot.SourceGeneration.LambdaPointer.IsRegistering"),
+            registrationBody)));
+    }
+
+    private sealed class ParameterBindingRewriter : CSharpSyntaxRewriter
+    {
+        private readonly SemanticModel _semanticModel;
+        private readonly IMethodSymbol _factory;
+
+        public ParameterBindingRewriter(SemanticModel semanticModel, IMethodSymbol factory)
+        {
+            _semanticModel = semanticModel;
+            _factory = factory;
+        }
+
+        public override SyntaxNode? VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            if (_semanticModel.GetSymbolInfo(node).Symbol is IParameterSymbol parameter
+                && SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, _factory))
             {
-                if (syntaxRef.GetSyntax() == lambda)
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.ThisExpression(),
+                    SyntaxFactory.IdentifierName(FactoryParameterUsage.GetFieldName(parameter)))
+                    .WithTriviaFrom(node);
+            }
+
+            return QualifyMember(node) ?? base.VisitIdentifierName(node);
+        }
+
+        public override SyntaxNode? VisitGenericName(GenericNameSyntax node)
+            => QualifyMember(node) ?? base.VisitGenericName(node);
+
+        private MemberAccessExpressionSyntax? QualifyMember(SimpleNameSyntax node)
+        {
+            if (node.Parent is MemberAccessExpressionSyntax member && member.Name == node
+                || node.Parent is MemberBindingExpressionSyntax or QualifiedNameSyntax or AliasQualifiedNameSyntax
+                || node.Parent is NameColonSyntax or NameEqualsSyntax)
+            {
+                return null;
+            }
+
+            var symbol = _semanticModel.GetSymbolInfo(node).Symbol;
+            if (symbol is IMethodSymbol { IsStatic: true, MethodKind: MethodKind.Ordinary }
+                or IFieldSymbol { IsStatic: true }
+                or IPropertySymbol { IsStatic: true }
+                or IEventSymbol { IsStatic: true })
+            {
+                return SyntaxFactory.MemberAccessExpression(
+                    SyntaxKind.SimpleMemberAccessExpression,
+                    SyntaxFactory.ParseName(symbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat)),
+                    node.WithoutTrivia()).WithTriviaFrom(node);
+            }
+
+            return null;
+        }
+
+        public override SyntaxNode? VisitAnonymousObjectMemberDeclarator(AnonymousObjectMemberDeclaratorSyntax node)
+        {
+            var rewritten = (AnonymousObjectMemberDeclaratorSyntax)base.VisitAnonymousObjectMemberDeclarator(node)!;
+            if (node.NameEquals is null && IsFactoryParameter(node.Expression))
+            {
+                rewritten = rewritten.WithNameEquals(SyntaxFactory.NameEquals(
+                    SyntaxFactory.IdentifierName(((IdentifierNameSyntax)node.Expression).Identifier)));
+            }
+
+            return rewritten;
+        }
+
+        public override SyntaxNode? VisitTupleExpression(TupleExpressionSyntax node)
+        {
+            var rewritten = (TupleExpressionSyntax)base.VisitTupleExpression(node)!;
+            for (var index = 0; index < node.Arguments.Count; index++)
+            {
+                var argument = node.Arguments[index];
+                if (argument.NameColon is null && IsFactoryParameter(argument.Expression))
                 {
-                    return true;
+                    rewritten = rewritten.WithArguments(rewritten.Arguments.Replace(rewritten.Arguments[index],
+                        rewritten.Arguments[index].WithNameColon(SyntaxFactory.NameColon(
+                            SyntaxFactory.IdentifierName(((IdentifierNameSyntax)argument.Expression).Identifier)))));
                 }
             }
+
+            return rewritten;
         }
-        return false;
+
+        private bool IsFactoryParameter(ExpressionSyntax expression)
+            => expression is IdentifierNameSyntax
+                && _semanticModel.GetSymbolInfo(expression).Symbol is IParameterSymbol parameter
+                && SymbolEqualityComparer.Default.Equals(parameter.ContainingSymbol, _factory);
+
+        public override SyntaxNode? VisitInvocationExpression(InvocationExpressionSyntax node)
+        {
+            if (node.Expression is IdentifierNameSyntax { Identifier.ValueText: "nameof" }
+                && _semanticModel.GetConstantValue(node) is { HasValue: true, Value: string name })
+            {
+                return SyntaxFactory.LiteralExpression(SyntaxKind.StringLiteralExpression, SyntaxFactory.Literal(name))
+                    .WithTriviaFrom(node);
+            }
+
+            return base.VisitInvocationExpression(node);
+        }
     }
 
     /// <summary>

--- a/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
+++ b/src/Parlot.SourceGenerator/ParserSourceGenerator.cs
@@ -55,14 +55,31 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         isEnabledByDefault: true,
         description: "Methods marked with [GenerateParser] must be static.");
 
-    private static readonly DiagnosticDescriptor MethodHasParametersDescriptor = new(
+    private static readonly DiagnosticDescriptor UnsupportedFactorySignatureDescriptor = new(
         "PARLOT009",
-        "Method must be parameterless",
-        "[GenerateParser] method '{0}' must not have parameters",
+        "Unsupported parser factory signature",
+        "[GenerateParser] method '{0}' must be non-generic and use only ordinary by-value parameters whose types can be stored in a parser instance",
         "Parlot.SourceGenerator",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Methods marked with [GenerateParser] must be parameterless.");
+        description: "Generic factories, generic containing types, by-reference parameters, ref-like types, pointers, and function pointers are not supported.");
+
+    private static readonly DiagnosticDescriptor InvalidFactoryParameterUseDescriptor = new(
+        "PARLOT021",
+        "Factory parameter must be deferred",
+        "Parameter '{1}' in [GenerateParser] method '{0}' may only be read inside supported parse-time callbacks and must not be reassigned or passed by reference",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true,
+        description: "Use If or Select to describe every branch at compile time. Factory arguments are bound at runtime, not used to build the parser graph.");
+
+    private static readonly DiagnosticDescriptor EagerCallbackDescriptor = new(
+        "PARLOT022",
+        "Captured callback executed during generation",
+        "Callbacks capturing factory state in method '{0}' cannot be executed while building the parser graph",
+        "Parlot.SourceGenerator",
+        DiagnosticSeverity.Error,
+        isEnabledByDefault: true);
 
     private static readonly DiagnosticDescriptor InvalidReturnTypeDescriptor = new(
         "PARLOT010",
@@ -168,15 +185,12 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
 
     private static readonly DiagnosticDescriptor ClosureNotSupportedDescriptor = new(
         "PARLOT015",
-        "Closures are not supported in source generation",
-        "Lambda in method '{0}' captures variable '{1}' from the enclosing scope. Source generation only supports static lambdas without captured variables. To pass state to lambdas, use a custom ParseContext subclass or store state in static fields.",
+        "Unsupported lambda capture",
+        "Lambda in method '{0}' captures variable '{1}' from the enclosing scope. Source generation only supports captures of that factory's parameters. Use a factory parameter or a custom ParseContext subclass instead.",
         "Parlot.SourceGenerator",
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
-        description: "Lambdas used in source-generated parsers cannot capture variables from their enclosing scope (closures). " +
-                     "The generated code creates static methods that don't have access to captured state. " +
-                     "To pass custom state to lambda functions, create a custom ParseContext subclass with properties for your state, " +
-                     "or use static fields/properties that can be accessed from static lambda expressions.");
+        description: "Factory parameters are bound to generated parser instances. Other captured locals or parameters are not supported.");
 
     #endregion
 
@@ -354,7 +368,12 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
 
     private static string GetMethodKey(IMethodSymbol method)
     {
-        return method.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + "." + method.Name;
+        return method.OriginalDefinition.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat
+            .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType
+                | SymbolDisplayMemberOptions.IncludeParameters
+                | SymbolDisplayMemberOptions.IncludeExplicitInterface)
+            .WithParameterOptions(SymbolDisplayParameterOptions.IncludeType | SymbolDisplayParameterOptions.IncludeParamsRefOut)
+            .WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters));
     }
 
 
@@ -385,12 +404,6 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             return null;
         }
 
-        // Only intercept parameterless method calls
-        if (invocation.ArgumentList.Arguments.Count > 0)
-        {
-            return null;
-        }
-
         // Get the interceptable location using Roslyn's API
         var interceptableLocation = semanticModel.GetInterceptableLocation(invocation, ct);
         if (interceptableLocation is null)
@@ -398,7 +411,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             return null;
         }
 
-        var methodKey = methodSymbol.ContainingType.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat) + "." + methodSymbol.Name;
+        var methodKey = GetMethodKey(methodSymbol);
         
         return new InvocationInfo(
             methodKey,
@@ -463,10 +476,14 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             validationArgs.Add(new object?[] { methodSymbol.Name });
         }
 
-        // Method must be parameterless
-        if (methodSymbol.Parameters.Length > 0)
+        if (methodSymbol.IsGenericMethod
+            || methodSymbol.ContainingType.IsGenericType
+            || methodSymbol.Parameters.Any(static parameter =>
+                parameter.RefKind != RefKind.None
+                || parameter.Type.IsRefLikeType
+                || parameter.Type.TypeKind is TypeKind.Pointer or TypeKind.FunctionPointer))
         {
-            validationErrors.Add(MethodHasParametersDescriptor);
+            validationErrors.Add(UnsupportedFactorySignatureDescriptor);
             validationArgs.Add(new object?[] { methodSymbol.Name });
         }
 
@@ -645,23 +662,22 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         // The rewriter replaces each lambda/method group with a stub that contains a unique pointer
         // When the rewritten code executes, LambdaRegistry can extract the pointer and map it
         // back to the original source code
-        var rewriter = new LambdaRewriter(semanticModel);
-        var rewrittenRoot = rewriter.Visit(originalSyntaxTree.GetRoot());
-
-        // Check for captured variables (closures) - these are not supported in source generation
-        if (rewriter.CapturedVariables.Count > 0)
+        var invalidParameterUses = FactoryParameterUsage.FindInvalidUses(methodSymbol, methodSyntax, semanticModel).ToList();
+        if (invalidParameterUses.Count > 0)
         {
-            // Report an error for each captured variable
-            foreach (var captured in rewriter.CapturedVariables)
+            foreach (var use in invalidParameterUses)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
-                    ClosureNotSupportedDescriptor,
-                    captured.Location,
+                    InvalidFactoryParameterUseDescriptor,
+                    use.Location,
                     methodSymbol.Name,
-                    captured.VariableName));
+                    use.ParameterName));
             }
             return;
         }
+
+        var rewriter = new LambdaRewriter(semanticModel, methodSymbol);
+        var rewrittenRoot = rewriter.Visit(originalSyntaxTree.GetRoot());
         
         // Create a new syntax tree with the rewritten code
         var parseOptions = (CSharpParseOptions)originalSyntaxTree.Options;
@@ -952,9 +968,8 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 return;
             }
 
-            var method = type.GetMethod(
-                methodSymbol.Name,
-                BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
+            var method = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static | BindingFlags.DeclaredOnly)
+                .SingleOrDefault(candidate => MatchesFactoryMethod(candidate, methodSymbol));
 
             if (method is null)
             {
@@ -964,11 +979,17 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 return;
             }
 
-            // Invoke the parameterless method to get the parser instance
+            // Parameters may only be read by deferred callbacks, so placeholders cannot affect the graph.
             object? parserInstance;
+            LambdaPointer.Reset();
             try
             {
-                parserInstance = method.Invoke(null, null);
+                var arguments = method.GetParameters()
+                    .Select(static parameter => parameter.ParameterType.IsValueType
+                        ? Array.CreateInstance(parameter.ParameterType, 1).GetValue(0)
+                        : null)
+                    .ToArray();
+                parserInstance = method.Invoke(null, arguments);
             }
             catch (TargetInvocationException ex)
             {
@@ -998,6 +1019,11 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                     methodInfo.AttributeLocation ?? methodSymbol.Locations.FirstOrDefault(),
                     methodSymbol.Name,
                     ex.Message));
+                return;
+            }
+
+            if (ReportEagerCapture(context, methodInfo))
+            {
                 return;
             }
 
@@ -1135,7 +1161,21 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             }
 
             // Generate C# code using the new pointer-based lambda system
-            var (sourceText, failedLambdas) = GenerateParserWrapperAndCore(methodSymbol, valueType, sourceResult, sgContext, lambdaSourceMap, rewriter.Lambdas, invocations, methodInfo.AdditionalUsings);
+            var (sourceText, failedLambdas, capturedVariables) = GenerateParserWrapperAndCore(methodSymbol, valueType, sourceResult, sgContext, lambdaSourceMap, rewriter.Lambdas, invocations, methodInfo.AdditionalUsings);
+
+            if (ReportEagerCapture(context, methodInfo))
+            {
+                return;
+            }
+
+            foreach (var captured in capturedVariables)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(
+                    ClosureNotSupportedDescriptor,
+                    captured.Location,
+                    methodSymbol.Name,
+                    captured.VariableName));
+            }
 
             // Report errors for lambdas that couldn't be extracted
             foreach (var failedLambda in failedLambdas)
@@ -1148,7 +1188,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             }
 
             // Only report success and add source if there were no failed lambdas
-            if (failedLambdas.Count > 0)
+            if (failedLambdas.Count > 0 || capturedVariables.Count > 0)
             {
                 return;
             }
@@ -1159,8 +1199,8 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 tempCompilation,
                 partialBypassedMethods);
 
-            var hintName = $"{methodSymbol.ContainingType.Name}_{methodSymbol.Name}.Parlot.g.cs";
-            var diagnosticsHintName = $"{methodSymbol.ContainingType.Name}_{methodSymbol.Name}.Diagnostics.g.cs";
+            var hintName = $"{methodSymbol.ContainingType.Name}_{GetGeneratedIdentifier(methodSymbol)}.Parlot.g.cs";
+            var diagnosticsHintName = $"{methodSymbol.ContainingType.Name}_{GetGeneratedIdentifier(methodSymbol)}.Diagnostics.g.cs";
             
             // Add generated source to compilation output
             context.AddSource(hintName, SourceText.From(sourceText, Encoding.UTF8));
@@ -1191,7 +1231,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         }
     }
 
-    private static (string SourceText, List<string> FailedLambdas) GenerateParserWrapperAndCore(
+    private static (string SourceText, List<string> FailedLambdas, List<LambdaRewriter.CapturedVariableInfo> CapturedVariables) GenerateParserWrapperAndCore(
         IMethodSymbol methodSymbol,
         Type valueType,
         SourceResult result,
@@ -1210,6 +1250,10 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         var valueTypeName = TypeNameHelper.GetTypeName(valueType);
         var coreName = methodName + "_Core";
         var wrapperName = "GeneratedParser_" + methodName;
+        var hasParameters = methodSymbol.Parameters.Length > 0;
+        var staticModifier = hasParameters ? "" : "static ";
+        var parameterList = GetFactoryParameterList(methodSymbol);
+        var argumentList = string.Join(", ", methodSymbol.Parameters.Select(static parameter => EscapeIdentifier(parameter.Name)));
 
         // First pass: process all deferred parsers to collect all lambdas
         // We need to do this before emitting lambda fields
@@ -1368,6 +1412,27 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         sb.AppendLine($"    partial class {typeName}");
         sb.AppendLine("    {");
 
+        if (hasParameters)
+        {
+            sb.AppendLine($"        private sealed class {wrapperName} : Parser<{valueTypeName}>");
+            sb.AppendLine("        {");
+            foreach (var parameter in methodSymbol.Parameters)
+            {
+                // Mutable structs must remain addressable, just like a variable captured by a closure.
+                var readOnly = parameter.Type is INamedTypeSymbol { IsValueType: true, IsReadOnly: false } ? "" : "readonly ";
+                sb.AppendLine($"            private {readOnly}{GetParameterTypeName(parameter)} {FactoryParameterUsage.GetFieldName(parameter)};");
+            }
+            sb.AppendLine();
+            sb.AppendLine($"            public {wrapperName}({parameterList})");
+            sb.AppendLine("            {");
+            foreach (var parameter in methodSymbol.Parameters)
+            {
+                sb.AppendLine($"                this.{FactoryParameterUsage.GetFieldName(parameter)} = {EscapeIdentifier(parameter.Name)};");
+            }
+            sb.AppendLine("            }");
+            sb.AppendLine();
+        }
+
         // ==== NEW POINTER-BASED LAMBDA EMISSION ====
         // Each lambda was rewritten to a stub that captures a unique pointer.
         // The LambdaRegistry extracted these pointers during execution and mapped them to IDs.
@@ -1375,6 +1440,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         
         var registeredLambdas = sgContext.Lambdas.Enumerate().OrderBy(x => x.Id).ToList();
         var failedLambdas = new List<string>();
+        var capturedVariables = new List<LambdaRewriter.CapturedVariableInfo>();
 
         foreach (var (id, del) in registeredLambdas)
         {
@@ -1397,6 +1463,12 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 // Also get the lambda info for additional metadata if available.
                 lambdaInfoMap.TryGetValue(pointer, out var lambdaInfo);
                 var isMethodGroup = lambdaInfo?.IsMethodGroup ?? !originalSource.Contains("=>");
+
+                if (lambdaInfo is not null && lambdaInfo.CapturedVariables.Count > 0)
+                {
+                    capturedVariables.AddRange(lambdaInfo.CapturedVariables);
+                    continue;
+                }
                 
                 // Generate a method from the original source with #line directive for debugging
                 var methodSource = GenerateLambdaMethod(
@@ -1405,7 +1477,8 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                     originalSource, 
                     isMethodGroup,
                     lambdaInfo?.FilePath,
-                    lambdaInfo?.StartLine ?? 0);
+                    lambdaInfo?.StartLine ?? 0,
+                    isStatic: !hasParameters);
                 sb.AppendLine(methodSource);
             }
             else
@@ -1439,17 +1512,23 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             }
         }
 
-        sb.AppendLine($"        private sealed class {wrapperName} : Parser<{valueTypeName}>");
-        sb.AppendLine("        {");
+        if (!hasParameters)
+        {
+            sb.AppendLine($"        private sealed class {wrapperName} : Parser<{valueTypeName}>");
+            sb.AppendLine("        {");
+        }
         sb.AppendLine("            [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
         sb.AppendLine($"            public override bool Parse(ParseContext context, ref ParseResult<{valueTypeName}> result)");
         sb.AppendLine("            {");
         sb.AppendLine($"                return {coreName}(context, ref result);");
         sb.AppendLine("            }");
-        sb.AppendLine("        }");
+        if (!hasParameters)
+        {
+            sb.AppendLine("        }");
+        }
         sb.AppendLine();
         AppendAggressiveInliningIfSmall(sb, result);
-        sb.AppendLine($"        internal static bool {coreName}(ParseContext context, ref ParseResult<{valueTypeName}> result)");
+        sb.AppendLine($"        internal {staticModifier}bool {coreName}(ParseContext context, ref ParseResult<{valueTypeName}> result)");
         sb.AppendLine("        {");
         sb.AppendLine("            context.CheckCancellation();");
         sb.AppendLine("            var scanner = context.Scanner;");
@@ -1534,7 +1613,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 sb.AppendLine($"        // {deferredParserName}");
             }
             sb.AppendLine("        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]");
-            sb.AppendLine($"        private static bool {deferredMethodName}(ParseContext context, out {deferredValueTypeName} value)");
+            sb.AppendLine($"        private {staticModifier}bool {deferredMethodName}(ParseContext context, out {deferredValueTypeName} value)");
             sb.AppendLine("        {");
             sb.AppendLine("            if (context.MaxRecursionDepth > 0)");
             sb.AppendLine("            {");
@@ -1554,7 +1633,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             sb.AppendLine("        }");
             sb.AppendLine();
             AppendAggressiveInliningIfSmall(sb, deferredResult);
-            sb.AppendLine($"        private static bool {deferredMethodName}_Core(ParseContext context, out {deferredValueTypeName} value)");
+            sb.AppendLine($"        private {staticModifier}bool {deferredMethodName}_Core(ParseContext context, out {deferredValueTypeName} value)");
             sb.AppendLine("        {");
             sb.AppendLine("            context.CheckCancellation();");
             sb.AppendLine("            var scanner = context.Scanner;");
@@ -1592,7 +1671,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 sb.AppendLine($"        // {helperParserName}");
             }
             AppendAggressiveInliningIfSmall(sb, helperResult);
-            sb.AppendLine($"        private static bool {helperMethodName}(ParseContext context, out {helperValueTypeName} value)");
+            sb.AppendLine($"        private {staticModifier}bool {helperMethodName}(ParseContext context, out {helperValueTypeName} value)");
             sb.AppendLine("        {");
             sb.AppendLine("            context.CheckCancellation();");
             sb.AppendLine("            var scanner = context.Scanner;");
@@ -1621,10 +1700,19 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         }
         sb.AppendLine();
 
-        // Generate a static field to hold the cached parser instance
+        if (hasParameters)
+        {
+            sb.AppendLine("        }");
+            sb.AppendLine();
+        }
+
         var parserFieldName = $"_generated_{methodName}";
-        sb.AppendLine($"        private static readonly Parlot.Fluent.Parser<{valueTypeName}> {parserFieldName} = new {wrapperName}();");
-        sb.AppendLine();
+        if (!hasParameters)
+        {
+            sb.AppendLine($"        private static readonly Parlot.Fluent.Parser<{valueTypeName}> {parserFieldName} = new {wrapperName}();");
+            sb.AppendLine();
+        }
+        var parserExpression = hasParameters ? $"new {wrapperName}({argumentList})" : parserFieldName;
         
         // Generate interceptor methods for each invocation site
         if (invocations.Count > 0)
@@ -1635,15 +1723,16 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 var inv = invocations[i];
                 // Note: InterceptsLocationAttribute already includes brackets from GetInterceptsLocationAttributeSyntax()
                 sb.AppendLine($"        {inv.InterceptsLocationAttribute}");
-                sb.AppendLine($"        internal static Parlot.Fluent.Parser<{valueTypeName}> {methodName}_Interceptor_{i}() => {parserFieldName};");
+                sb.AppendLine($"        internal static Parlot.Fluent.Parser<{valueTypeName}> {methodName}_Interceptor_{i}({parameterList}) => {parserExpression};");
                 sb.AppendLine();
             }
         }
         else
         {
             // No invocations found - emit a comment and keep a public accessor for manual use
-            sb.AppendLine("        // No invocations found to intercept. You can access the generated parser via this property.");
-            sb.AppendLine($"        public static Parlot.Fluent.Parser<{valueTypeName}> {methodName}_Generated => {parserFieldName};");
+            sb.AppendLine("        // No invocations found to intercept. You can access the generated parser directly.");
+            var accessor = hasParameters ? $"{methodName}_Generated({parameterList})" : $"{methodName}_Generated";
+            sb.AppendLine($"        public static Parlot.Fluent.Parser<{valueTypeName}> {accessor} => {parserExpression};");
         }
 
         // Generate helper methods if needed (e.g., CreateCharMap for ListOfChars on netstandard)
@@ -1657,12 +1746,19 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             sb.AppendLine("}");
         }
 
-        return (sb.ToString(), failedLambdas);
+        return (sb.ToString(), failedLambdas, capturedVariables);
     }
 
     private static string GetGeneratedIdentifier(IMethodSymbol method)
     {
         var identifier = $"__Parlot_{method.Name.Length}_{method.Name}";
+        var overloads = method.ContainingType.GetMembers(method.Name).OfType<IMethodSymbol>()
+            .OrderBy(GetMethodKey, StringComparer.Ordinal).ToArray();
+        if (overloads.Length > 1)
+        {
+            identifier += "_Overload" + Array.FindIndex(overloads, candidate =>
+                SymbolEqualityComparer.Default.Equals(candidate, method)).ToString(CultureInfo.InvariantCulture);
+        }
         var candidate = identifier;
         var suffix = 0;
 
@@ -1672,6 +1768,78 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         }
 
         return candidate;
+    }
+
+    private static string GetFactoryParameterList(IMethodSymbol method)
+        => string.Join(", ", method.Parameters.Select(static parameter =>
+            $"{GetParameterTypeName(parameter)} {EscapeIdentifier(parameter.Name)}"));
+
+    private static bool ReportEagerCapture(SourceProductionContext context, MethodToGenerate method)
+    {
+        if (!LambdaPointer.HasEagerCapture)
+        {
+            return false;
+        }
+
+        context.ReportDiagnostic(Diagnostic.Create(
+            EagerCallbackDescriptor,
+            method.AttributeLocation ?? method.Method.Locations.FirstOrDefault(),
+            method.Method.Name));
+        return true;
+    }
+
+    private static string GetParameterTypeName(IParameterSymbol parameter)
+        => parameter.Type.ToDisplayString(SymbolDisplayFormat.FullyQualifiedFormat.WithMiscellaneousOptions(
+            SymbolDisplayFormat.FullyQualifiedFormat.MiscellaneousOptions | SymbolDisplayMiscellaneousOptions.IncludeNullableReferenceTypeModifier));
+
+    private static bool MatchesFactoryMethod(MethodInfo candidate, IMethodSymbol method)
+    {
+        if (candidate.Name != method.MetadataName || candidate.IsGenericMethod)
+        {
+            return false;
+        }
+
+        var parameters = candidate.GetParameters();
+        return parameters.Length == method.Parameters.Length
+            && parameters.Select((parameter, index) => MatchesParameterType(parameter.ParameterType, method.Parameters[index].Type)).All(static match => match);
+    }
+
+    private static bool MatchesParameterType(Type type, ITypeSymbol symbol)
+    {
+        if (symbol is IArrayTypeSymbol array)
+        {
+            return type.IsArray && type.GetArrayRank() == array.Rank && MatchesParameterType(type.GetElementType()!, array.ElementType);
+        }
+
+        if (symbol is IDynamicTypeSymbol)
+        {
+            return type == typeof(object);
+        }
+
+        if (symbol is not INamedTypeSymbol named)
+        {
+            return false;
+        }
+
+        if (named.IsTupleType)
+        {
+            named = named.TupleUnderlyingType!;
+        }
+
+        var typeNames = new Stack<string>();
+        var typeArguments = new List<ITypeSymbol>();
+        for (var current = named; current is not null; current = current.ContainingType)
+        {
+            typeNames.Push(current.MetadataName);
+            typeArguments.InsertRange(0, current.TypeArguments);
+        }
+
+        var namespaceName = named.ContainingNamespace.IsGlobalNamespace ? "" : named.ContainingNamespace.ToDisplayString() + ".";
+        var metadataName = namespaceName + string.Join("+", typeNames);
+        var definition = type.IsGenericType ? type.GetGenericTypeDefinition() : type;
+        return definition.FullName == metadataName
+            && (!type.IsGenericType || type.GetGenericArguments()
+                .Select((argument, index) => MatchesParameterType(argument, typeArguments[index])).All(static match => match));
     }
 
     private static bool HasGeneratedMemberCollision(INamedTypeSymbol containingType, string identifier)
@@ -1725,9 +1893,11 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
         string lambdaSource, 
         bool isMethodGroup,
         string? originalFilePath,
-        int originalLine)
+        int originalLine,
+        bool isStatic)
     {
         var sb = new StringBuilder();
+        var staticModifier = isStatic ? "static " : "";
         var returnTypeName = TypeNameHelper.GetTypeName(invokeMethod.ReturnType);
         var parameters = invokeMethod.GetParameters();
 
@@ -1749,7 +1919,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 AppendLineDirective(sb, originalLine, originalFilePath!);
             }
             
-            sb.Append($"        private static {returnTypeName} {methodName}({paramList}) => ");
+            sb.Append($"        private {staticModifier}{returnTypeName} {methodName}({paramList}) => ");
             sb.Append(lambdaSource);
             sb.Append('(');
             for (int i = 0; i < parameters.Length; i++)
@@ -1818,7 +1988,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                 {
                     // Block lambda - generate a method with body
                     // Add #line directive for each line to enable debugging on any line
-                    sb.Append($"        private static {returnTypeName} {methodName}({paramList})\n");
+                    sb.Append($"        private {staticModifier}{returnTypeName} {methodName}({paramList})\n");
                     
                     if (hasLineInfo)
                     {
@@ -1844,7 +2014,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
                         AppendLineDirective(sb, originalLine, originalFilePath!);
                     }
                     
-                    sb.Append($"        private static {returnTypeName} {methodName}({paramList}) => ");
+                    sb.Append($"        private {staticModifier}{returnTypeName} {methodName}({paramList}) => ");
                     sb.Append(body);
                     if (!body.EndsWith(";", StringComparison.Ordinal))
                     {
@@ -1861,7 +2031,7 @@ public sealed class ParserSourceGenerator : IIncrementalGenerator
             {
                 var paramList = GenerateParameterListWithStandardNames(invokeMethod);
                 sb.Append("        [global::System.Runtime.CompilerServices.MethodImpl(global::System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]\n");
-                sb.Append($"        private static {returnTypeName} {methodName}({paramList}) => default!;");
+                sb.Append($"        private {staticModifier}{returnTypeName} {methodName}({paramList}) => default!;");
             }
         }
         

--- a/src/Parlot.SourceGenerator/README.md
+++ b/src/Parlot.SourceGenerator/README.md
@@ -9,10 +9,10 @@ To debug the generated code, add this to a project:
 
 ## GenerateParser attribute
 
-- Apply `[GenerateParser]` to static, **parameterless** methods returning `Parlot.Fluent.Parser<T>`.
+- Apply `[GenerateParser]` to static, non-generic methods returning `Parlot.Fluent.Parser<T>`.
 - Uses C# interceptors to replace calls to the annotated method with generated, optimized code at compile time.
 - Each method can only have one `[GenerateParser]` attribute.
-- If you need multiple parser variants (e.g., different keywords), create separate methods.
+- Bind by-value factory arguments through inline parse-time callbacks, for example `If(() => enabled, a, b)`. Arguments must not be used eagerly to construct the graph.
 
 Example:
 
@@ -27,17 +27,15 @@ public static partial class MyGrammar
     [GenerateParser]
     public static Parser<string> HelloParser() => Terms.Text("hello");
 
-    // For variants, create separate methods instead of parameterized ones
+    // Both branches are generated; the argument is bound at runtime.
     [GenerateParser]
-    public static Parser<string> FooParser() => Terms.Text("foo");
-
-    [GenerateParser]
-    public static Parser<string> BarParser() => Terms.Text("bar");
+    public static Parser<string> FooParser(bool uppercase) =>
+        If(() => uppercase, Terms.Text("FOO"), Terms.Text("foo"));
 }
 
 // Usage - calls are intercepted and replaced with generated code
 var hello = MyGrammar.HelloParser();
-var foo = MyGrammar.FooParser();
+var foo = MyGrammar.FooParser(uppercase: false);
 ```
 
 ## Helper Attributes

--- a/src/Parlot/Fluent/If.cs
+++ b/src/Parlot/Fluent/If.cs
@@ -4,42 +4,82 @@ using System;
 namespace Parlot.Fluent;
 
 /// <summary>
-/// Ensure the given parser is valid based on a condition, and backtracks if not.
+/// Evaluates a condition once and executes only the selected parser.
 /// </summary>
 /// <typeparam name="C">The concrete <see cref="ParseContext" /> type to use.</typeparam>
-/// <typeparam name="S">The type of the state to pass.</typeparam>
 /// <typeparam name="T">The output parser type.</typeparam>
-public sealed class If<C, S, T> : Parser<T>, ISourceable where C : ParseContext
+public sealed class If<C, T> : Parser<T>, ISourceable where C : ParseContext
 {
-    private readonly Func<C, S?, bool> _predicate;
-    private readonly S? _state;
-    private readonly Parser<T> _parser;
+    private readonly Func<C, bool>? _contextCondition;
+    private readonly Func<bool>? _condition;
+    private readonly Parser<T> _thenParser;
+    private readonly Parser<T>? _elseParser;
 
-    public If(Parser<T> parser, Func<C, S?, bool> predicate, S? state)
+    /// <summary>
+    /// Creates a parser that fails without consuming input when <paramref name="condition"/> is false.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="parser">The parser to execute when the condition is true.</param>
+    public If(Func<C, bool> condition, Parser<T> parser)
     {
-        _predicate = predicate ?? throw new ArgumentNullException(nameof(predicate));
-        _state = state;
-        _parser = parser ?? throw new ArgumentNullException(nameof(parser));
+        _contextCondition = condition ?? throw new ArgumentNullException(nameof(condition));
+        _thenParser = parser ?? throw new ArgumentNullException(nameof(parser));
+    }
+
+    /// <summary>
+    /// Creates a parser that fails without consuming input when <paramref name="condition"/> is false.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="parser">The parser to execute when the condition is true.</param>
+    public If(Func<bool> condition, Parser<T> parser)
+    {
+        _condition = condition ?? throw new ArgumentNullException(nameof(condition));
+        _thenParser = parser ?? throw new ArgumentNullException(nameof(parser));
+    }
+
+    /// <summary>
+    /// Creates a parser that executes only the selected branch, without falling back if it fails.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="thenParser">The parser to execute when the condition is true.</param>
+    /// <param name="elseParser">The parser to execute when the condition is false.</param>
+    public If(Func<C, bool> condition, Parser<T> thenParser, Parser<T> elseParser)
+    {
+        _contextCondition = condition ?? throw new ArgumentNullException(nameof(condition));
+        _thenParser = thenParser ?? throw new ArgumentNullException(nameof(thenParser));
+        _elseParser = elseParser ?? throw new ArgumentNullException(nameof(elseParser));
+    }
+
+    /// <summary>
+    /// Creates a parser that executes only the selected branch, without falling back if it fails.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="thenParser">The parser to execute when the condition is true.</param>
+    /// <param name="elseParser">The parser to execute when the condition is false.</param>
+    public If(Func<bool> condition, Parser<T> thenParser, Parser<T> elseParser)
+    {
+        _condition = condition ?? throw new ArgumentNullException(nameof(condition));
+        _thenParser = thenParser ?? throw new ArgumentNullException(nameof(thenParser));
+        _elseParser = elseParser ?? throw new ArgumentNullException(nameof(elseParser));
     }
 
     public override bool Parse(ParseContext context, ref ParseResult<T> result)
     {
         context.EnterParser(this);
 
-        var valid = _predicate((C)context, _state);
+        var condition = _condition is not null ? _condition() : _contextCondition!((C)context);
+        var parser = condition ? _thenParser : _elseParser;
+        var parsed = new ParseResult<T>();
 
-        if (valid)
+        if (parser is not null && parser.Parse(context, ref parsed))
         {
-            var start = context.Scanner.Cursor.Position;
-
-            if (!_parser.Parse(context, ref result))
-            {
-                context.Scanner.Cursor.ResetPosition(start);
-            }
+            result.Set(parsed.Start, parsed.End, parsed.Value);
+            context.ExitParser(this);
+            return true;
         }
 
         context.ExitParser(this);
-        return valid;
+        return false;
     }
 
 
@@ -47,61 +87,43 @@ public sealed class If<C, S, T> : Parser<T>, ISourceable where C : ParseContext
     {
         ThrowHelper.ThrowIfNull(context, nameof(context));
 
-        if (_parser is not ISourceable sourceable)
+        if (_thenParser is not ISourceable thenSourceable || (_elseParser is not null && _elseParser is not ISourceable))
         {
-            throw new NotSupportedException("If requires a source-generatable parser.");
+            throw new NotSupportedException("If requires all branch parsers to be source-generatable.");
         }
 
         var result = context.CreateResult(typeof(T));
-        var cursorName = context.CursorName;
         var ctx = context.ParseContextName;
-
-        var startName = $"start{context.NextNumber()}";
-        result.Body.Add($"var {startName} = {cursorName}.Position;");
-
-        // Register the predicate lambda
-        var predicateLambda = context.RegisterLambda(_predicate);
-        var stateLambda = context.RegisterLambda(new Func<S?>(() => _state));
         var valueTypeName = SourceGenerationContext.GetTypeName(typeof(T));
+        var outTarget = context.DiscardResult ? "_" : result.ValueVariable;
 
-        // Use helper instead of inlining
-        var helperName = context.Helpers
-            .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_If", valueTypeName, () => sourceable.GenerateSource(context))
+        var conditionCall = _condition is not null
+            ? $"{context.RegisterLambda(_condition)}()"
+            : $"{context.RegisterLambda(_contextCondition!)}(({SourceGenerationContext.GetTypeName(typeof(C))}){ctx})";
+
+        var thenHelper = context.Helpers
+            .GetOrCreate(_thenParser, $"{context.MethodNamePrefix}_If_Then", valueTypeName, () => thenSourceable.GenerateSource(context))
             .MethodName;
 
-        // if (_predicate((C)context, _state))
-        // {
-        //     if (Helper(context, out value))
-        //     {
-        //         success = true;
-        //     }
-        // }
-        // if (!success)
-        // {
-        //     cursor.ResetPosition(start);
-        // }
+        result.Body.Add($"if ({conditionCall})");
+        result.Body.Add("{");
+        result.Body.Add($"    {result.SuccessVariable} = {thenHelper}({ctx}, out {outTarget});");
+        result.Body.Add("}");
 
-        result.Body.Add($"if ({predicateLambda}(({SourceGenerationContext.GetTypeName(typeof(C))}){ctx}, {stateLambda}()))");
-        result.Body.Add("{");
-        if (context.DiscardResult)
+        if (_elseParser is ISourceable elseSourceable)
         {
-            result.Body.Add($"    if ({helperName}({ctx}, out _))");
+            var elseHelper = context.Helpers
+                .GetOrCreate(_elseParser, $"{context.MethodNamePrefix}_If_Else", valueTypeName, () => elseSourceable.GenerateSource(context))
+                .MethodName;
+
+            result.Body.Add("else");
+            result.Body.Add("{");
+            result.Body.Add($"    {result.SuccessVariable} = {elseHelper}({ctx}, out {outTarget});");
+            result.Body.Add("}");
         }
-        else
-        {
-            result.Body.Add($"    if ({helperName}({ctx}, out {result.ValueVariable}))");
-        }
-        result.Body.Add("    {");
-        result.Body.Add($"        {result.SuccessVariable} = true;");
-        result.Body.Add("    }");
-        result.Body.Add("}");
-        result.Body.Add($"if (!{result.SuccessVariable})");
-        result.Body.Add("{");
-        result.Body.Add($"    {cursorName}.ResetPosition({startName});");
-        result.Body.Add("}");
 
         return result;
     }
 
-    public override string ToString() => $"{_parser} (If)";
+    public override string ToString() => _elseParser is null ? $"{_thenParser} (If)" : $"{_thenParser} (If) {_elseParser} (Else)";
 }

--- a/src/Parlot/Fluent/Parsers.cs
+++ b/src/Parlot/Fluent/Parsers.cs
@@ -58,28 +58,60 @@ public static partial class Parsers
     public static Parser<T> Not<T>(Parser<T> parser) => new Not<T>(parser);
 
     /// <summary>
-    /// Builds a parser that invoked the next one if a condition is true.
+    /// Evaluates a condition once and executes <paramref name="parser"/> if it is true.
+    /// Otherwise, fails without consuming input or changing the result.
     /// </summary>
-    [Obsolete("Use the Select parser instead.")]
-    public static Parser<T> If<C, S, T>(Func<C, S?, bool> predicate, S? state, Parser<T> parser) where C : ParseContext => new If<C, S, T>(parser, predicate, state);
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="parser">The parser to execute when the condition is true.</param>
+    public static Parser<T> If<T>(Func<bool> condition, Parser<T> parser) => new If<ParseContext, T>(condition, parser);
 
     /// <summary>
-    /// Builds a parser that invoked the next one if a condition is true.
+    /// Evaluates a condition once using the current context and executes <paramref name="parser"/> if it is true.
+    /// Otherwise, fails without consuming input or changing the result.
     /// </summary>
-    [Obsolete("Use the Select parser instead.")]
-    public static Parser<T> If<S, T>(Func<ParseContext, S?, bool> predicate, S? state, Parser<T> parser) => new If<ParseContext, S, T>(parser, predicate, state);
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="parser">The parser to execute when the condition is true.</param>
+    public static Parser<T> If<T>(Func<ParseContext, bool> condition, Parser<T> parser) => new If<ParseContext, T>(condition, parser);
 
     /// <summary>
-    /// Builds a parser that invoked the next one if a condition is true.
+    /// Evaluates a condition once using the concrete context and executes <paramref name="parser"/> if it is true.
+    /// Otherwise, fails without consuming input or changing the result.
     /// </summary>
-    [Obsolete("Use the Select parser instead.")]
-    public static Parser<T> If<C, T>(Func<C, bool> predicate, Parser<T> parser) where C : ParseContext => new If<C, object?, T>(parser, (c, s) => predicate(c), null);
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="parser">The parser to execute when the condition is true.</param>
+    public static Parser<T> If<C, T>(Func<C, bool> condition, Parser<T> parser) where C : ParseContext => new If<C, T>(condition, parser);
 
     /// <summary>
-    /// Builds a parser that invoked the next one if a condition is true.
+    /// Evaluates a condition once and executes only the selected branch, without falling back if it fails.
     /// </summary>
-    [Obsolete("Use the Select parser instead.")]
-    public static Parser<T> If<T>(Func<ParseContext, bool> predicate, Parser<T> parser) => new If<ParseContext, object?, T>(parser, (c, s) => predicate(c), null);
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="thenParser">The parser to execute when the condition is true.</param>
+    /// <param name="elseParser">The parser to execute when the condition is false.</param>
+    public static Parser<T> If<T>(Func<bool> condition, Parser<T> thenParser, Parser<T> elseParser) => new If<ParseContext, T>(condition, thenParser, elseParser);
+
+    /// <summary>
+    /// Evaluates a condition once using the current context and executes only the selected branch, without falling back if it fails.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="thenParser">The parser to execute when the condition is true.</param>
+    /// <param name="elseParser">The parser to execute when the condition is false.</param>
+    public static Parser<T> If<T>(Func<ParseContext, bool> condition, Parser<T> thenParser, Parser<T> elseParser) => new If<ParseContext, T>(condition, thenParser, elseParser);
+
+    /// <summary>
+    /// Evaluates a condition once using the concrete context and executes only the selected branch, without falling back if it fails.
+    /// </summary>
+    /// <param name="condition">The condition to evaluate before parsing.</param>
+    /// <param name="thenParser">The parser to execute when the condition is true.</param>
+    /// <param name="elseParser">The parser to execute when the condition is false.</param>
+    public static Parser<T> If<C, T>(Func<C, bool> condition, Parser<T> thenParser, Parser<T> elseParser) where C : ParseContext => new If<C, T>(condition, thenParser, elseParser);
+
+    /// <summary>
+    /// Evaluates a selector once and executes the parser at its index.
+    /// An out-of-range index fails without consuming input.
+    /// </summary>
+    /// <param name="selector">The selector to evaluate before parsing.</param>
+    /// <param name="parsers">The fixed set of parsers to select from.</param>
+    public static Parser<T> Select<T>(Func<int> selector, params Parser<T>[] parsers) => new Select<ParseContext, T>(selector, parsers);
 
     /// <summary>
     /// Builds a parser that selects another parser using custom logic.

--- a/src/Parlot/Fluent/Select.cs
+++ b/src/Parlot/Fluent/Select.cs
@@ -1,6 +1,5 @@
 using Parlot.SourceGeneration;
 using System;
-using System.Linq;
 
 namespace Parlot.Fluent;
 
@@ -12,12 +11,33 @@ namespace Parlot.Fluent;
 public sealed class Select<C, T> : Parser<T>, ISourceable where C : ParseContext
 {
     private readonly Parser<T>[] _parsers;
-    private readonly Func<C, int> _selector;
+    private readonly Func<C, int>? _contextSelector;
+    private readonly Func<int>? _selector;
 
+    /// <summary>
+    /// Creates a parser that executes the branch selected using the current context.
+    /// </summary>
+    /// <param name="selector">The selector to evaluate once before parsing.</param>
+    /// <param name="parsers">The fixed set of parsers to select from.</param>
     public Select(Func<C, int> selector, params Parser<T>[] parsers)
+        : this(parsers)
+    {
+        _contextSelector = selector ?? throw new ArgumentNullException(nameof(selector));
+    }
+
+    /// <summary>
+    /// Creates a parser that executes the branch selected by a context-free callback.
+    /// </summary>
+    /// <param name="selector">The selector to evaluate once before parsing.</param>
+    /// <param name="parsers">The fixed set of parsers to select from.</param>
+    public Select(Func<int> selector, params Parser<T>[] parsers)
+        : this(parsers)
     {
         _selector = selector ?? throw new ArgumentNullException(nameof(selector));
+    }
 
+    private Select(Parser<T>[] parsers)
+    {
         ThrowHelper.ThrowIfNull(parsers, nameof(parsers));
 
         _parsers = parsers;
@@ -32,7 +52,7 @@ public sealed class Select<C, T> : Parser<T>, ISourceable where C : ParseContext
     {
         context.EnterParser(this);
 
-        var index = _selector((C)context);
+        var index = _selector is not null ? _selector() : _contextSelector!((C)context);
 
         if ((uint)index >= (uint)_parsers.Length)
         {
@@ -73,11 +93,12 @@ public sealed class Select<C, T> : Parser<T>, ISourceable where C : ParseContext
         var ctx = context.ParseContextName;
         var valueTypeName = SourceGenerationContext.GetTypeName(typeof(T));
 
-        // Register the selector lambda
-        var selectorLambda = context.RegisterLambda(_selector);
+        var selectorCall = _selector is not null
+            ? $"{context.RegisterLambda(_selector)}()"
+            : $"{context.RegisterLambda(_contextSelector!)}(({SourceGenerationContext.GetTypeName(typeof(C))}){ctx})";
 
         var indexName = $"index{context.NextNumber()}";
-        result.Body.Add($"var {indexName} = {selectorLambda}(({SourceGenerationContext.GetTypeName(typeof(C))}){ctx});");
+        result.Body.Add($"var {indexName} = {selectorCall};");
         result.Body.Add($"switch ({indexName})");
         result.Body.Add("{");
 

--- a/src/Parlot/SourceGeneration/LambdaRegistry.cs
+++ b/src/Parlot/SourceGeneration/LambdaRegistry.cs
@@ -28,6 +28,36 @@ public static class LambdaPointer
     [ThreadStatic]
     private static int _currentPointer;
 
+    [ThreadStatic]
+    private static bool _isRegistering;
+
+    [ThreadStatic]
+    private static bool _hasEagerCapture;
+
+    /// <summary>
+    /// Whether a callback attempted to use captured state while constructing the current parser graph.
+    /// </summary>
+    public static bool HasEagerCapture => _hasEagerCapture;
+
+    /// <summary>
+    /// Records prohibited callback execution and creates its exception. The generator also checks
+    /// the recorded state in case factory code catches the exception.
+    /// </summary>
+    public static InvalidOperationException CreateEagerCaptureException()
+    {
+        _hasEagerCapture = true;
+        return new InvalidOperationException("Callbacks capturing factory state cannot be executed while building the parser graph.");
+    }
+
+    /// <summary>
+    /// Whether a deferred callback is being inspected for source generation rather than executed.
+    /// </summary>
+    public static bool IsRegistering
+    {
+        get => _isRegistering;
+        internal set => _isRegistering = value;
+    }
+
     /// <summary>
     /// Gets or sets the current lambda pointer.
     /// This is set by rewritten lambdas at the start of their execution.
@@ -44,6 +74,7 @@ public static class LambdaPointer
     public static void Reset()
     {
         _currentPointer = -1;
+        _hasEagerCapture = false;
     }
 
     /// <summary>
@@ -133,8 +164,8 @@ public sealed class LambdaRegistry
                 args[i] = GetDefaultValue(paramType);
             }
             
-            // Invoke the delegate - this will set LambdaPointer.CurrentPointer
-            // We ignore the return value and any exceptions from the original body
+            var wasRegistering = LambdaPointer.IsRegistering;
+            LambdaPointer.IsRegistering = true;
             try
             {
                 @delegate.DynamicInvoke(args);
@@ -143,6 +174,10 @@ public sealed class LambdaRegistry
             {
                 // Ignore exceptions from the original lambda body
                 // The pointer should still be set even if the body fails
+            }
+            finally
+            {
+                LambdaPointer.IsRegistering = wasRegistering;
             }
             
             // Read the pointer that was set by the rewritten lambda
@@ -161,7 +196,7 @@ public sealed class LambdaRegistry
     {
         if (type.IsValueType)
         {
-            return Activator.CreateInstance(type);
+            return Array.CreateInstance(type, 1).GetValue(0);
         }
         
         // For reference types, try some common cases

--- a/test/Parlot.Benchmarks/IfSelectBenchmarks.cs
+++ b/test/Parlot.Benchmarks/IfSelectBenchmarks.cs
@@ -1,0 +1,115 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using Parlot.Fluent;
+using Parlot.SourceGenerator;
+using System;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public partial class IfSelectBenchmarks
+{
+    private Parser<string> _if;
+    private Parser<string> _select;
+    private Parser<string> _ifElse;
+    private Parser<string> _selectElse;
+    private Parser<string> _ifGenerated;
+    private Parser<string> _selectGenerated;
+    private Parser<string> _ifElseGenerated;
+    private Parser<string> _selectElseGenerated;
+    private ParseContext _context;
+
+    [Params(true, false)]
+    public bool Condition { get; set; }
+
+    [Params(true, false)]
+    public bool Match { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _if = CreateIf(Condition);
+        _select = CreateSelect(Condition);
+        _ifElse = CreateIfElse(Condition);
+        _selectElse = CreateSelectElse(Condition);
+        _ifGenerated = CreateIfGenerated(Condition);
+        _selectGenerated = CreateSelectGenerated(Condition);
+        _ifElseGenerated = CreateIfElseGenerated(Condition);
+        _selectElseGenerated = CreateSelectElseGenerated(Condition);
+        _context = new ParseContext(new Scanner(Match ? (Condition ? "42" : "17") : "x"));
+
+        if (_ifGenerated.GetType() == _if.GetType() || _selectGenerated.GetType() == _select.GetType()
+            || _ifElseGenerated.GetType() == _ifElse.GetType() || _selectElseGenerated.GetType() == _selectElse.GetType())
+        {
+            throw new InvalidOperationException("Conditional parser benchmark requires source-generated factory interception.");
+        }
+
+        if (IfRuntime() != (Condition && Match) || SelectRuntime() != (Condition && Match)
+            || IfElseRuntime() != Match || SelectElseRuntime() != Match
+            || IfGenerated() != (Condition && Match) || SelectGenerated() != (Condition && Match)
+            || IfElseGenerated() != Match || SelectElseGenerated() != Match)
+        {
+            throw new InvalidOperationException("Conditional parser benchmark returned an unexpected result.");
+        }
+    }
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Guard")]
+    public bool IfRuntime() => Parse(_if);
+
+    [Benchmark, BenchmarkCategory("Guard")]
+    public bool SelectRuntime() => Parse(_select);
+
+    [Benchmark, BenchmarkCategory("Guard")]
+    public bool IfGenerated() => Parse(_ifGenerated);
+
+    [Benchmark, BenchmarkCategory("Guard")]
+    public bool SelectGenerated() => Parse(_selectGenerated);
+
+    [Benchmark(Baseline = true), BenchmarkCategory("Branches")]
+    public bool IfElseRuntime() => Parse(_ifElse);
+
+    [Benchmark, BenchmarkCategory("Branches")]
+    public bool SelectElseRuntime() => Parse(_selectElse);
+
+    [Benchmark, BenchmarkCategory("Branches")]
+    public bool IfElseGenerated() => Parse(_ifElseGenerated);
+
+    [Benchmark, BenchmarkCategory("Branches")]
+    public bool SelectElseGenerated() => Parse(_selectElseGenerated);
+
+    private bool Parse(Parser<string> parser)
+    {
+        _context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<string>();
+        return parser.Parse(_context, ref result);
+    }
+
+    private static Parser<string> CreateIf(bool condition) =>
+        If(() => condition, Literals.Text("42"));
+
+    private static Parser<string> CreateSelect(bool condition) =>
+        Select(() => condition ? 0 : -1, Literals.Text("42"));
+
+    private static Parser<string> CreateIfElse(bool condition) =>
+        If(() => condition, Literals.Text("42"), Literals.Text("17"));
+
+    private static Parser<string> CreateSelectElse(bool condition) =>
+        Select(() => condition ? 0 : 1, Literals.Text("42"), Literals.Text("17"));
+
+    [GenerateParser]
+    private static Parser<string> CreateIfGenerated(bool condition) =>
+        If(() => condition, Literals.Text("42"));
+
+    [GenerateParser]
+    private static Parser<string> CreateSelectGenerated(bool condition) =>
+        Select(() => condition ? 0 : -1, Literals.Text("42"));
+
+    [GenerateParser]
+    private static Parser<string> CreateIfElseGenerated(bool condition) =>
+        If(() => condition, Literals.Text("42"), Literals.Text("17"));
+
+    [GenerateParser]
+    private static Parser<string> CreateSelectElseGenerated(bool condition) =>
+        Select(() => condition ? 0 : 1, Literals.Text("42"), Literals.Text("17"));
+}

--- a/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
@@ -13,9 +13,8 @@ namespace Parlot.SourceGenerator.Tests;
 public class GeneratorDiagnosticsTests
 {
     [Fact]
-    public void Method_With_Parameters_Is_Not_Generated()
+    public void Parameter_Used_To_Build_The_Graph_Is_Rejected()
     {
-        // [GenerateParser] should only work on parameterless methods
         const string source = @"
 using Parlot.SourceGenerator;
 using Parlot.Fluent;
@@ -28,60 +27,166 @@ public static partial class ParameterizedGrammar
 }
 ";
 
-        var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
-        var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions);
-
-        var references = new List<MetadataReference>();
-        var trusted = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string;
-        if (!string.IsNullOrEmpty(trusted))
-        {
-            foreach (var path in trusted!.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
-            {
-                references.Add(MetadataReference.CreateFromFile(path));
-            }
-        }
-
-        void AddReference(string path)
-        {
-            if (!references.OfType<PortableExecutableReference>().Any(r => string.Equals(r.FilePath, path, StringComparison.OrdinalIgnoreCase)))
-            {
-                references.Add(MetadataReference.CreateFromFile(path));
-            }
-        }
-
-        AddReference(typeof(global::Parlot.Fluent.ParseContext).Assembly.Location);
-        AddReference(typeof(global::Parlot.SourceGenerator.GenerateParserAttribute).Assembly.Location);
-
-        var compilation = CSharpCompilation.Create(
-            assemblyName: "Parlot.SourceGenerator.Tests.ParameterizedMethod",
-            syntaxTrees: new[] { syntaxTree },
-            references: references,
-            options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
-
-        var config = 
-#if DEBUG
-            "Debug";
-#else
-            "Release";
-#endif
-        var generatorPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/Parlot.SourceGenerator/bin", config, "netstandard2.0/Parlot.SourceGenerator.dll"));
-        Assert.True(File.Exists(generatorPath), $"Generator assembly not found at {generatorPath}");
-
-        var generatorAssembly = Assembly.LoadFrom(generatorPath);
-        var generatorType = generatorAssembly.GetType("Parlot.SourceGenerator.ParserSourceGenerator", throwOnError: true)!;
-        var generator = (IIncrementalGenerator)Activator.CreateInstance(generatorType)!;
-
-        var sourceGenerator = generator.AsSourceGenerator();
-        var driver = CSharpGeneratorDriver.Create(new[] { sourceGenerator }, parseOptions: parseOptions)
-            .RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out var generatorDiagnostics);
-        
-        // The method should generate a PARLOT009 error since it has parameters
-        var result = driver.GetRunResult();
+        var (result, _) = RunGenerator(source, "ParameterizedMethod");
         var parserDiagnostics = result.Diagnostics.Where(d => d.Id.StartsWith("PARLOT", StringComparison.Ordinal)).ToList();
         Assert.Single(parserDiagnostics);
-        Assert.Equal("PARLOT009", parserDiagnostics[0].Id);
+        Assert.Equal("PARLOT021", parserDiagnostics[0].Id);
         Assert.Equal(DiagnosticSeverity.Error, parserDiagnostics[0].Severity);
         Assert.Contains("Foo", parserDiagnostics[0].GetMessage());
+    }
+
+    [Theory]
+    [InlineData("return enabled ? Terms.Text(\"yes\") : Terms.Text(\"no\");")]
+    [InlineData("var selected = enabled; return If(() => selected, Terms.Text(\"yes\"));")]
+    [InlineData("enabled = true; return If(() => enabled, Terms.Text(\"yes\"));")]
+    [InlineData("return If(() => enabled = true, Terms.Text(\"yes\"));")]
+    [InlineData("return If(() => Change(ref enabled), Terms.Text(\"yes\"));")]
+    [InlineData("return If(() => { (enabled, enabled) = (true, false); return true; }, Terms.Text(\"yes\"));")]
+    [InlineData("System.Func<bool> predicate = () => enabled; return If(predicate, Terms.Text(\"yes\"));")]
+    [InlineData("return Build(() => enabled);")]
+    public void Factory_Parameters_Must_Be_Read_Only_And_Deferred(string body)
+    {
+        var source = $$"""
+            using System;
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class InvalidParameterGrammar
+            {
+                [GenerateParser]
+                public static Parser<string> Create(bool enabled) { {{body}} }
+                private static bool Change(ref bool value) => value = true;
+                private static Parser<string> Build(Func<bool> predicate) => If(predicate, Terms.Text("yes"));
+            }
+            """;
+
+        var (result, _) = RunGenerator(source, "InvalidParameter" + Guid.NewGuid().ToString("N"));
+        Assert.Contains(result.Diagnostics, static diagnostic => diagnostic.Id == "PARLOT021");
+        Assert.DoesNotContain(result.Results.SelectMany(static result => result.GeneratedSources),
+            static source => source.HintName.EndsWith(".Parlot.g.cs", StringComparison.Ordinal));
+    }
+
+    [Theory]
+    [InlineData("ref int value")]
+    [InlineData("in int value")]
+    [InlineData("out int value")]
+    [InlineData("System.ReadOnlySpan<char> value")]
+    public void Unsupported_Factory_Parameters_Report_A_Diagnostic(string parameter)
+    {
+        var source = $$"""
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class UnsupportedParameterGrammar
+            {
+                [GenerateParser]
+                public static Parser<char> Create({{parameter}}) => Literals.Char('x');
+            }
+            """;
+
+        var (result, _) = RunGenerator(source, "UnsupportedParameter" + Guid.NewGuid().ToString("N"));
+        Assert.Single(result.Diagnostics, static diagnostic => diagnostic.Id == "PARLOT009");
+    }
+
+    [Fact]
+    public void Deferred_Callbacks_Are_Not_Executed_For_Source_Extraction()
+    {
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class DeferredCallbackGrammar
+            {
+                public static int Evaluations;
+                private static bool Condition() { Evaluations++; return true; }
+                [GenerateParser]
+                public static Parser<char> Create()
+                {
+                    System.Func<char, char> convert = value => { Evaluations++; return value; };
+                    return If(Condition, Literals.Char('x')).Then(convert);
+                }
+            }
+            """;
+        var assemblyName = "DeferredCallbacks" + Guid.NewGuid().ToString("N");
+        var (result, updatedCompilation) = RunGenerator(source, assemblyName);
+        Assert.DoesNotContain(result.Diagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+
+        var assembly = Assert.Single(AppDomain.CurrentDomain.GetAssemblies(),
+            assembly => assembly.GetName().Name == "Parlot.SourceGenerator.Tests." + assemblyName);
+        Assert.Equal(0, assembly.GetType("DeferredCallbackGrammar").GetField("Evaluations").GetValue(null));
+    }
+
+    [Fact]
+    public void Captures_In_Unrelated_Code_Do_Not_Reject_The_Factory()
+    {
+        const string source = """
+            using System;
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class ScopedCaptureGrammar
+            {
+                [GenerateParser]
+                public static Parser<char> Create() => Literals.Char('x');
+                public static Func<int> Unrelated(int value) => () => value;
+            }
+            """;
+
+        var (result, updatedCompilation) = RunGenerator(source, "ScopedCapture");
+        Assert.DoesNotContain(result.Diagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+    }
+
+    [Fact]
+    public void Captured_Callback_Cannot_Be_Executed_While_Building_The_Graph()
+    {
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class EagerCallbackGrammar
+            {
+                [GenerateParser]
+                public static Parser<string> Create(bool enabled)
+                {
+                    var probe = If(() => enabled, Literals.Text("yes"));
+                    return probe.Parse("yes") != null ? Literals.Text("enabled") : Literals.Text("disabled");
+                }
+            }
+            """;
+
+        var (result, _) = RunGenerator(source, "EagerCallback");
+        var diagnostic = Assert.Single(result.Diagnostics, static diagnostic => diagnostic.Severity == DiagnosticSeverity.Error);
+        Assert.Contains("cannot be executed while building", diagnostic.GetMessage(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Catching_Eager_Callback_Exception_Still_Rejects_Generation()
+    {
+        const string source = """
+            using System;
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+            using static Parlot.Fluent.Parsers;
+            public static partial class CaughtCallbackGrammar
+            {
+                [GenerateParser]
+                public static Parser<string> Create(bool enabled)
+                {
+                    var probe = Literals.Char('x').Then(_ => enabled ? "yes" : "no");
+                    string text;
+                    try { text = probe.Parse("x"); }
+                    catch (InvalidOperationException) { text = "fallback"; }
+                    return Literals.Text(text);
+                }
+            }
+            """;
+
+        var (result, _) = RunGenerator(source, "CaughtCallback");
+        Assert.Single(result.Diagnostics, static diagnostic => diagnostic.Id == "PARLOT022");
+        Assert.DoesNotContain(result.Results.SelectMany(static result => result.GeneratedSources),
+            static source => source.HintName.EndsWith(".Parlot.g.cs", StringComparison.Ordinal));
     }
 
     [Fact]

--- a/test/Parlot.SourceGenerator.Tests/ParameterizedParserTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/ParameterizedParserTests.cs
@@ -1,0 +1,399 @@
+using System;
+using Parlot.Fluent;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.SourceGenerator.Tests;
+
+public class ParameterizedParserTests
+{
+    [Fact]
+    public void ParameterlessIf_UsesCurrentContextAndRetainsSingleton()
+    {
+        var parser = ParameterizedGrammars.ContextOnly();
+        AssertGenerated(parser);
+        Assert.Same(parser, ParameterizedGrammars.ContextOnly());
+        var result = new ParseResult<string>();
+        Assert.True(parser.Parse(new ConditionalContext("yes") { Enabled = true }, ref result));
+        Assert.Equal("yes", result.Value);
+        Assert.True(parser.Parse(new ConditionalContext("no") { Enabled = false }, ref result));
+        Assert.Equal("no", result.Value);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(3)]
+    [InlineData(4)]
+    [InlineData(5)]
+    public void If_UsesBoundArgumentsAndCurrentContext(int kind)
+    {
+        var options = new ConditionalOptions { Enabled = true };
+        var parser = kind switch
+        {
+            0 => ParameterizedGrammars.Gate(options),
+            1 => ParameterizedGrammars.Choice(options),
+            2 => ParameterizedGrammars.ContextGate(options),
+            3 => ParameterizedGrammars.ContextChoice(options),
+            4 => ParameterizedGrammars.TypedGate(options),
+            _ => ParameterizedGrammars.TypedChoice(options)
+        };
+        AssertGenerated(parser);
+        Assert.Equal(0, options.Evaluations);
+
+        var context = new ConditionalContext("  yes") { Enabled = true };
+        var result = new ParseResult<string>();
+        Assert.True(parser.Parse(context, ref result));
+        Assert.Equal("yes", result.Value);
+        Assert.Equal(1, options.Evaluations);
+
+        options.Enabled = false;
+        context = new ConditionalContext("  no") { Enabled = true };
+        var succeeds = kind % 2 == 1;
+        Assert.Equal(succeeds, parser.Parse(context, ref result));
+        Assert.Equal(succeeds ? 4 : 0, context.Scanner.Cursor.Offset);
+        Assert.Equal(2, options.Evaluations);
+
+        if (kind >= 2)
+        {
+            options.Enabled = true;
+            context = new ConditionalContext("  no") { Enabled = false };
+            Assert.Equal(succeeds, parser.Parse(context, ref result));
+            Assert.Equal(3, options.Evaluations);
+        }
+    }
+
+    [Theory]
+    [InlineData(true, " no!")]
+    [InlineData(false, " yes!")]
+    [InlineData(true, " yes?")]
+    [InlineData(false, " no?")]
+    public void SelectedBranchFailure_RestoresCursorWithoutFallback(bool enabled, string input)
+    {
+        var generated = ParameterizedGrammars.Backtracking(enabled);
+        Func<bool, Parser<string>> factory = ParameterizedGrammars.Backtracking;
+        var runtime = factory(enabled);
+        AssertGenerated(generated);
+
+        foreach (var parser in new[] { generated, runtime })
+        {
+            var context = new ParseContext(new Scanner(input));
+            var start = context.Scanner.Cursor.Position;
+            var result = new ParseResult<string>();
+            Assert.False(parser.Parse(context, ref result));
+            Assert.Equal(start, context.Scanner.Cursor.Position);
+        }
+    }
+
+    [Fact]
+    public void FactoryCalls_HaveIndependentState()
+    {
+        var first = ParameterizedGrammars.Multiple(3, 4, "first:");
+        var second = ParameterizedGrammars.Multiple(10, 20, "second:");
+        AssertGenerated(first);
+        AssertGenerated(second);
+        Assert.NotSame(first, second);
+        Assert.Equal("first:7", first.Parse("x"));
+        Assert.Equal("second:30", second.Parse("x"));
+        Assert.Equal("first:7", first.Parse("x"));
+    }
+
+    [Fact]
+    public void SelectAndWhen_SupportCaptures()
+    {
+        var parser = ParameterizedGrammars.Selected(1, "no");
+        AssertGenerated(parser);
+        Assert.Equal("no", parser.Parse("no"));
+        Assert.Null(parser.Parse("yes"));
+        Assert.Null(ParameterizedGrammars.Selected(1, "yes").Parse("no"));
+        Assert.Null(ParameterizedGrammars.Selected(-1, "yes").Parse("yes"));
+    }
+
+    [Fact]
+    public void SwitchAndFallbacks_SupportCaptures()
+    {
+        var switched = ParameterizedGrammars.Switched(1);
+        AssertGenerated(switched);
+        Assert.Equal("no", switched.Parse("xno"));
+        Assert.Null(switched.Parse("xyes"));
+        Assert.Equal("prefix:0", ParameterizedGrammars.Fallback("prefix:").Parse(""));
+        Assert.Equal("prefix:x", ParameterizedGrammars.Fallback("prefix:").Parse("x"));
+        Assert.Equal("prefix:x", ParameterizedGrammars.TransformedOrElse("prefix:").Parse("x"));
+        Assert.Equal("fallback", ParameterizedGrammars.TransformedOrElse("prefix:").Parse(""));
+    }
+
+    [Fact]
+    public void RecursiveHelpers_RetainBoundArguments()
+    {
+        var enabled = ParameterizedGrammars.RecursiveChoice(true);
+        var disabled = ParameterizedGrammars.RecursiveChoice(false);
+        AssertGenerated(enabled);
+        Assert.Equal("x", enabled.Parse("((x))"));
+        Assert.Null(disabled.Parse("(x)"));
+        Assert.Equal("x", disabled.Parse("x"));
+    }
+
+    [Fact]
+    public void Overloads_InterceptIndependently()
+    {
+        var parameterless = ParameterizedGrammars.Overloaded();
+        var boolean = ParameterizedGrammars.Overloaded(true);
+        var integer = ParameterizedGrammars.Overloaded(42);
+        AssertGenerated(parameterless);
+        AssertGenerated(boolean);
+        AssertGenerated(integer);
+        Assert.Same(parameterless, ParameterizedGrammars.Overloaded());
+        Assert.Equal("default", parameterless.Parse("default"));
+        Assert.Equal("yes", boolean.Parse("yes"));
+        Assert.Equal("42", integer.Parse("x"));
+    }
+
+    [Fact]
+    public void NamedAndOptionalArguments_AreForwarded()
+    {
+        Assert.Equal("default:2", ParameterizedGrammars.Optional().Parse("x"));
+        Assert.Equal("named:5", ParameterizedGrammars.Optional(count: 5, prefix: "named:").Parse("x"));
+        Assert.Equal("last", ParameterizedGrammars.Variadic("first", "last").Parse("x"));
+    }
+
+    [Fact]
+    public void Arguments_AreEvaluatedOnceInSourceOrder()
+    {
+        var next = 0;
+        var parser = ParameterizedGrammars.ArgumentOrder(second: ++next, first: ++next);
+        AssertGenerated(parser);
+        Assert.Equal(2, next);
+        Assert.Equal(21, parser.Parse("x"));
+        Assert.Equal(2, next);
+    }
+
+    [Fact]
+    public void Captures_PreserveSymbolIdentityAndNameof()
+    {
+        var parser = ParameterizedGrammars.Symbols("bound", 7);
+        AssertGenerated(parser);
+        Assert.Equal("bound:7:context", parser.Parse("x"));
+    }
+
+    [Fact]
+    public void ReferenceAndValueTypeArguments_AreNotBakedIntoGeneratedSource()
+    {
+        var parser = ParameterizedGrammars.Values((2, 3), new[,] { { 4 } }, null);
+        AssertGenerated(parser);
+        Assert.Equal(9, parser.Parse("x"));
+        Assert.Equal(14, ParameterizedGrammars.Values((2, 3), new[,] { { 4 } }, 5).Parse("x"));
+    }
+
+    [Fact]
+    public void NullableResults_UseRuntimeArguments()
+    {
+        var parser = ParameterizedGrammars.NullableValue(null);
+        AssertGenerated(parser);
+        var result = new ParseResult<string>();
+        Assert.True(parser.Parse(new ParseContext(new Scanner("x")), ref result));
+        Assert.Null(result.Value);
+        Assert.Equal("value", ParameterizedGrammars.NullableValue("value").Parse("x"));
+    }
+
+    [Fact]
+    public void MutableStructCaptures_PreserveClosureSemantics()
+    {
+        var parser = ParameterizedGrammars.Counted(default);
+        AssertGenerated(parser);
+        Assert.Equal(1, parser.Parse("x"));
+        Assert.Equal(2, parser.Parse("x"));
+    }
+
+    [Fact]
+    public void RelocatedCallbacks_PreserveEnclosingMemberBindings()
+    {
+        var parser = ParameterizedGrammars.EnclosingMembers("prefix:");
+        AssertGenerated(parser);
+        Assert.Equal("prefix:grammar:x", parser.Parse("x"));
+        Assert.Equal("grammar:x", ParameterizedGrammars.EnclosingMethodGroup(0).Parse("x"));
+    }
+
+    [Fact]
+    public void Captures_PreserveInferredTupleAndAnonymousPropertyNames()
+    {
+        var parser = ParameterizedGrammars.InferredNames("value");
+        AssertGenerated(parser);
+        Assert.Equal("valuevalue", parser.Parse("x"));
+    }
+
+    [Fact]
+    public void Nameof_DoesNotCaptureRuntimeState()
+    {
+        var parser = ParameterizedGrammars.NameOnly(42);
+        AssertGenerated(parser);
+        Assert.Equal("value", parser.Parse("value"));
+    }
+
+    private static void AssertGenerated<T>(Parser<T> parser)
+        => Assert.StartsWith("GeneratedParser_", parser.GetType().Name, StringComparison.Ordinal);
+}
+
+public sealed class ConditionalOptions
+{
+    private bool _enabled;
+
+    public int Evaluations { get; private set; }
+
+    public bool Enabled
+    {
+        get
+        {
+            Evaluations++;
+            return _enabled;
+        }
+        set => _enabled = value;
+    }
+}
+
+public sealed class ConditionalContext : ParseContext
+{
+    public ConditionalContext(string input) : base(new Scanner(input))
+    {
+    }
+
+    public bool Enabled { get; set; }
+}
+
+public struct ConditionalCounter
+{
+    private int _value;
+
+    public int Next() => ++_value;
+}
+
+public static partial class ParameterizedGrammars
+{
+    private const string Name = "grammar";
+
+    private static string Parse(char value) => Name + ":" + value;
+
+    [GenerateParser]
+    public static Parser<string> ContextOnly()
+        => If(static (ConditionalContext context) => context.Enabled, Literals.Text("yes"), Literals.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> Gate(ConditionalOptions options)
+        => If(() => options.Enabled, Terms.Text("yes"));
+
+    [GenerateParser]
+    public static Parser<string> Choice(ConditionalOptions options)
+        => If(() => options.Enabled, Terms.Text("yes"), Terms.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> ContextGate(ConditionalOptions options)
+        => If(context => options.Enabled && ((ConditionalContext)context).Enabled, Terms.Text("yes"));
+
+    [GenerateParser]
+    public static Parser<string> ContextChoice(ConditionalOptions options)
+        => If(context => options.Enabled && ((ConditionalContext)context).Enabled, Terms.Text("yes"), Terms.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> TypedGate(ConditionalOptions options)
+        => If((ConditionalContext context) => options.Enabled && context.Enabled, Terms.Text("yes"));
+
+    [GenerateParser]
+    public static Parser<string> TypedChoice(ConditionalOptions options)
+        => If((ConditionalContext context) => options.Enabled && context.Enabled, Terms.Text("yes"), Terms.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> Backtracking(bool enabled)
+        => If(() => enabled, Terms.Text("yes").AndSkip(Literals.Char('!')), Terms.Text("no").AndSkip(Literals.Char('!')));
+
+    [GenerateParser]
+    public static Parser<string> Multiple(int first, int second, string prefix)
+        => Literals.Char('x').Then(_ => prefix + (first + second).ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+    [GenerateParser]
+    public static Parser<int> ArgumentOrder(int first, int second)
+        => Literals.Char('x').Then(_ => first * 10 + second);
+
+    [GenerateParser]
+    public static Parser<string> Selected(int index, string expected)
+        => Select(() => index, Literals.Text("yes"), Literals.Text("no"))
+            .When((_, value) => value == expected);
+
+    [GenerateParser]
+    public static Parser<string> Switched(int index)
+        => Literals.Char('x').Switch((_, value) => index, Literals.Text("yes"), Literals.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> Fallback(string prefix)
+        => Literals.Text("x").Then(value => prefix + value)
+            .Else(context => prefix + context.Scanner.Cursor.Offset.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+    [GenerateParser]
+    public static Parser<string> TransformedOrElse(string prefix)
+        => Literals.Text("x").ThenElse(value => prefix + value, "fallback");
+
+    [GenerateParser]
+    public static Parser<string> RecursiveChoice(bool enabled)
+        => Recursive<string>(self => OneOf(
+            If(() => enabled, Between(Literals.Char('('), self, Literals.Char(')'))),
+            Literals.Text("x")));
+
+    [GenerateParser]
+    public static Parser<string> Overloaded() => Literals.Text("default");
+
+    [GenerateParser]
+    public static Parser<string> Overloaded(bool enabled)
+        => If(() => enabled, Literals.Text("yes"), Literals.Text("no"));
+
+    [GenerateParser]
+    public static Parser<string> Overloaded(int value)
+        => Literals.Char('x').Then(_ => value.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+    [GenerateParser]
+    public static Parser<string> Optional(string prefix = "default:", int count = 2)
+        => Literals.Char('x').Then(_ => prefix + count.ToString(System.Globalization.CultureInfo.InvariantCulture));
+
+    [GenerateParser]
+    public static Parser<string> Variadic(params string[] values)
+        => Literals.Char('x').Then(_ => values[values.Length - 1]);
+
+    [GenerateParser]
+    public static Parser<string> Symbols(string context, int @class)
+        => Literals.Char('x').Then((_, value) =>
+            context + ":" + @class.ToString(System.Globalization.CultureInfo.InvariantCulture) + ":" + nameof(context));
+
+    [GenerateParser]
+    public static Parser<int> Values((int First, int Second) pair, int[,] values, int? optional)
+        => Literals.Char('x').Then(_ => pair.First + pair.Second + values[0, 0] + (optional ?? 0));
+
+    [GenerateParser]
+    public static Parser<string> NullableValue(string value)
+        => Literals.Char('x').Then(_ => value);
+
+    [GenerateParser]
+    public static Parser<int> Counted(ConditionalCounter counter)
+        => Literals.Char('x').Then(_ => counter.Next());
+
+    [GenerateParser]
+    public static Parser<string> EnclosingMembers(string prefix)
+        => Literals.Char('x').Then(value => prefix + Name + ":" + value);
+
+    [GenerateParser]
+    public static Parser<string> EnclosingMethodGroup(int unused)
+        => Literals.Char('x').Then(Parse);
+
+    [GenerateParser]
+    public static Parser<string> InferredNames(string value)
+        => Literals.Char('x').Then(_ =>
+        {
+            var item = new { value };
+            var tuple = (value, 1);
+            return item.value + tuple.value;
+        });
+
+    [GenerateParser]
+    public static Parser<string> NameOnly(int value)
+    {
+        var probe = Literals.Char('x').Then(_ => nameof(value));
+        return Literals.Text(probe.Parse("x"));
+    }
+}

--- a/test/Parlot.Tests/FluentTests.cs
+++ b/test/Parlot.Tests/FluentTests.cs
@@ -27,12 +27,9 @@ public class FluentTests
     [Fact]
     public void IfShouldNotInvokeParserWhenFalse()
     {
-        bool invoked = false;
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        var evenState = If(predicate: (context, x) => x % 2 == 0, state: 0, parser: Literals.Integer().Then(x => invoked = true));
-        var oddState = If(predicate: (context, x) => x % 2 == 0, state: 1, parser: Literals.Integer().Then(x => invoked = true));
-#pragma warning restore CS0618 // Type or member is obsolete
+        var invoked = false;
+        var evenState = If(condition: static () => true, parser: Literals.Integer().Then(x => invoked = true));
+        var oddState = If(condition: static () => false, parser: Literals.Integer().Then(x => invoked = true));
 
         Assert.False(oddState.TryParse("1234", out var result1));
         Assert.False(invoked);

--- a/test/Parlot.Tests/IfTests.cs
+++ b/test/Parlot.Tests/IfTests.cs
@@ -1,0 +1,329 @@
+#nullable enable
+
+using Parlot.Fluent;
+using Parlot.Rewriting;
+using Parlot.SourceGeneration;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Tests;
+
+public class IfTests
+{
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void GuardShouldEvaluateOnceAndLeaveRejectedResultUnchanged(bool enabled)
+    {
+        var evaluations = 0;
+        var childCalls = 0;
+        var child = Terms.Text("42");
+        var parser = If(() => { evaluations++; return enabled; }, child);
+        var context = new ParseContext(new Scanner("!\n 42"))
+        {
+            OnEnterParser = (p, _) => { if (ReferenceEquals(p, child)) childCalls++; }
+        };
+        context.Scanner.Cursor.Advance(1);
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>(7, 11, "unchanged");
+
+        Assert.Equal(enabled, parser.Parse(context, ref result));
+        Assert.Equal(1, evaluations);
+        Assert.Equal(enabled ? 1 : 0, childCalls);
+        Assert.Equal(enabled ? "42" : "unchanged", result.Value);
+        Assert.Equal(enabled ? 3 : 7, result.Start);
+        Assert.Equal(enabled ? 5 : 11, result.End);
+        if (enabled)
+        {
+            Assert.Equal(5, context.Scanner.Cursor.Offset);
+        }
+        else
+        {
+            Assert.Equal(start, context.Scanner.Cursor.Position);
+        }
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void IfElseShouldExecuteOnlySelectedBranch(bool enabled)
+    {
+        var evaluations = 0;
+        var thenCalls = 0;
+        var elseCalls = 0;
+        var parser = If(
+            () => { evaluations++; return enabled; },
+            Literals.Text("42").Then(_ => { thenCalls++; return "then"; }),
+            Literals.Text("42").Then(_ => { elseCalls++; return "else"; }));
+
+        Assert.True(parser.TryParse("42", out var result));
+        Assert.Equal(enabled ? "then" : "else", result);
+        Assert.Equal(enabled ? 1 : 0, thenCalls);
+        Assert.Equal(enabled ? 0 : 1, elseCalls);
+        Assert.Equal(1, evaluations);
+
+        enabled = !enabled;
+        Assert.True(parser.TryParse("42", out result));
+        Assert.Equal(enabled ? "then" : "else", result);
+        Assert.Equal(1, thenCalls);
+        Assert.Equal(1, elseCalls);
+        Assert.Equal(2, evaluations);
+    }
+
+    [Theory]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    public void ChildFailureShouldBacktrackWithoutFallingBack(bool enabled, bool withElse)
+    {
+        var evaluations = 0;
+        var otherCalls = 0;
+        var failing = Terms.Text("42").AndSkip(Literals.Char('!'));
+        var other = Terms.Text("42").Then(value => { otherCalls++; return value; });
+        Func<bool> condition = () => { evaluations++; return enabled; };
+        var parser = withElse
+            ? If(condition, enabled ? failing : other, enabled ? other : failing)
+            : If(condition, failing);
+        var context = new ParseContext(new Scanner("!\n 42?"));
+        context.Scanner.Cursor.Advance(1);
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>(7, 11, "unchanged");
+
+        Assert.False(parser.Parse(context, ref result));
+        Assert.Equal(start, context.Scanner.Cursor.Position);
+        Assert.Equal("unchanged", result.Value);
+        Assert.Equal(7, result.Start);
+        Assert.Equal(11, result.End);
+        Assert.Equal(1, evaluations);
+        Assert.Equal(0, otherCalls);
+
+        Assert.True(parser.Or(Terms.Text("42")).Parse(context, ref result));
+        Assert.Equal("42", result.Value);
+        Assert.Equal(2, evaluations);
+        Assert.Equal(0, otherCalls);
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(true, true)]
+    public void ConditionShouldReceiveCurrentContext(bool typed, bool withElse)
+    {
+        var evaluations = 0;
+        var current = new ConditionalContext("42", true);
+        Func<ParseContext, bool> condition = context =>
+        {
+            Assert.Same(current, context);
+            evaluations++;
+            return current.Enabled;
+        };
+        Func<ConditionalContext, bool> typedCondition = context =>
+        {
+            Assert.Same(current, context);
+            evaluations++;
+            return context.Enabled;
+        };
+        var thenParser = Literals.Text("42");
+        var elseParser = Literals.Text("17");
+        var parser = (typed, withElse) switch
+        {
+            (true, true) => If(typedCondition, thenParser, elseParser),
+            (true, false) => If(typedCondition, thenParser),
+            (false, true) => If(condition, thenParser, elseParser),
+            (false, false) => If(condition, thenParser)
+        };
+
+        Assert.True(parser.TryParse(current, out var value, out _));
+        Assert.Equal("42", value);
+        Assert.Equal(1, evaluations);
+
+        current = new ConditionalContext("17", false);
+        Assert.Equal(withElse, parser.TryParse(current, out value, out _));
+        Assert.Equal(withElse ? "17" : null, value);
+        Assert.Equal(withElse ? 2 : 0, current.Scanner.Cursor.Offset);
+        Assert.Equal(2, evaluations);
+    }
+
+    [Theory]
+    [InlineData(false, " 42", true)]
+    [InlineData(true, " 42", true)]
+    [InlineData(false, " x", false)]
+    [InlineData(true, " x", false)]
+    public void OneOfShouldNotSkipConditionOrHoistWhitespace(bool withElse, string input, bool success)
+    {
+        var evaluations = 0;
+        Func<ParseContext, bool> condition = context =>
+        {
+            evaluations++;
+            Assert.Equal(0, context.Scanner.Cursor.Offset);
+            Assert.Equal(' ', context.Scanner.Cursor.Current);
+            return true;
+        };
+        var conditional = withElse
+            ? If(condition, Terms.Text("42"), Terms.Text("17"))
+            : If(condition, Terms.Text("42"));
+        Assert.False(conditional is ISeekable { CanSeek: true });
+        Assert.False(conditional is ISeekable { SkipWhitespace: true });
+        var parser = OneOf(conditional, Terms.Text("z")).Or(Terms.Text("y"));
+        var context = new ParseContext(new Scanner(input));
+        var result = new ParseResult<string>();
+
+        Assert.Equal(success, parser.Parse(context, ref result));
+        Assert.Equal(1, evaluations);
+        Assert.Equal(success ? input.Length : 0, context.Scanner.Cursor.Offset);
+    }
+
+    [Theory]
+    [InlineData(true, false, "42")]
+    [InlineData(false, false, "42")]
+    [InlineData(true, false, "x")]
+    [InlineData(true, true, "42")]
+    [InlineData(false, true, "17")]
+    [InlineData(true, true, "17")]
+    [InlineData(false, true, "42")]
+    public void ParserEntryAndExitShouldMatch(bool enabled, bool withElse, string input)
+    {
+        var parser = withElse
+            ? If(() => enabled, Literals.Text("42"), Literals.Text("17"))
+            : If(() => enabled, Literals.Text("42"));
+        var stack = new Stack<object>();
+        var entries = 0;
+        var exits = 0;
+        var context = new ParseContext(new Scanner(input))
+        {
+            OnEnterParser = (p, c) =>
+            {
+                Assert.NotNull(c);
+                stack.Push(p);
+                entries++;
+            },
+            OnExitParser = (p, _) =>
+            {
+                Assert.Same(p, stack.Pop());
+                exits++;
+            }
+        };
+        var result = new ParseResult<string>();
+
+        parser.Parse(context, ref result);
+
+        Assert.Empty(stack);
+        Assert.Equal(entries, exits);
+        Assert.Equal(enabled || withElse ? 2 : 1, entries);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public void ShouldSupportNullableResults(bool enabled)
+    {
+        var reference = If(() => enabled, Always<string?>(null), Always<string?>("else"));
+        var value = If(() => enabled, Always<int?>(null), Always<int?>(42));
+
+        Assert.True(reference.TryParse("", out var referenceResult));
+        Assert.Equal(enabled ? null : "else", referenceResult);
+        Assert.True(value.TryParse("", out var valueResult));
+        Assert.Equal(enabled ? null : (int?)42, valueResult);
+        Assert.True(If(static () => true, Always<string?>(null)).TryParse("", out referenceResult));
+        Assert.Null(referenceResult);
+        Assert.True(If(static () => true, Always<int?>(null)).TryParse("", out valueResult));
+        Assert.Null(valueResult);
+    }
+
+    [Fact]
+    public void ShouldValidateArguments()
+    {
+        var child = Literals.Text("42");
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<bool>)null!, child));
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<ParseContext, bool>)null!, child));
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<ConditionalContext, bool>)null!, child));
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<bool>)null!, child, child));
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<ParseContext, bool>)null!, child, child));
+        Assert.Throws<ArgumentNullException>("condition", () => If((Func<ConditionalContext, bool>)null!, child, child));
+        Assert.Throws<ArgumentNullException>("parser", () => If<string>(static () => true, null!));
+        Assert.Throws<ArgumentNullException>("parser", () => If<string>(static _ => true, null!));
+        Assert.Throws<ArgumentNullException>("parser", () => If<ConditionalContext, string>(static _ => true, null!));
+        Assert.Throws<ArgumentNullException>("thenParser", () => If(static () => true, null!, child));
+        Assert.Throws<ArgumentNullException>("thenParser", () => If(static _ => true, null!, child));
+        Assert.Throws<ArgumentNullException>("thenParser", () => If<ConditionalContext, string>(static _ => true, null!, child));
+        Assert.Throws<ArgumentNullException>("elseParser", () => If(static () => true, child, null!));
+        Assert.Throws<ArgumentNullException>("elseParser", () => If(static _ => true, child, null!));
+        Assert.Throws<ArgumentNullException>("elseParser", () => If<ConditionalContext, string>(static _ => true, child, null!));
+    }
+
+    [Theory]
+    [InlineData(0, false, false)]
+    [InlineData(1, false, false)]
+    [InlineData(2, false, false)]
+    [InlineData(0, false, true)]
+    [InlineData(1, false, true)]
+    [InlineData(2, false, true)]
+    [InlineData(0, true, false)]
+    [InlineData(1, true, false)]
+    [InlineData(2, true, false)]
+    [InlineData(0, true, true)]
+    [InlineData(1, true, true)]
+    [InlineData(2, true, true)]
+    public void SourceShouldRegisterOriginalConditionAndBranchHelpers(int shape, bool withElse, bool discard)
+    {
+        Delegate condition = shape switch
+        {
+            0 => (Func<bool>)(static () => true),
+            1 => (Func<ParseContext, bool>)(static context => context.Scanner.Cursor.Offset == 0),
+            _ => (Func<ConditionalContext, bool>)(static context => context.Enabled)
+        };
+        var thenParser = Literals.Char('a');
+        var elseParser = Literals.Char('b');
+        var parser = (shape, withElse) switch
+        {
+            (0, false) => If((Func<bool>)condition, thenParser),
+            (0, true) => If((Func<bool>)condition, thenParser, elseParser),
+            (1, false) => If((Func<ParseContext, bool>)condition, thenParser),
+            (1, true) => If((Func<ParseContext, bool>)condition, thenParser, elseParser),
+            (_, false) => If((Func<ConditionalContext, bool>)condition, thenParser),
+            (_, true) => If((Func<ConditionalContext, bool>)condition, thenParser, elseParser)
+        };
+        var context = new SourceGenerationContext("context", "Test") { DiscardResult = discard };
+
+        var source = Assert.IsAssignableFrom<ISourceable>(parser).GenerateSource(context);
+
+        Assert.Same(condition, Assert.Single(context.Lambdas.Enumerate()).Delegate);
+        Assert.Equal(withElse ? 2 : 1, context.Helpers.Enumerate().Count());
+        var call = shape == 0
+            ? "_Test_lambda0()"
+            : $"_Test_lambda0(({SourceGenerationContext.GetTypeName(shape == 1 ? typeof(ParseContext) : typeof(ConditionalContext))})context)";
+        Assert.Equal($"if ({call})", source.Body[0]);
+        Assert.Equal(withElse, source.Body.Contains("else"));
+        Assert.Contains(source.Body, line => line.IndexOf($"out {(discard ? "_" : source.ValueVariable)}", StringComparison.Ordinal) >= 0);
+    }
+
+    [Fact]
+    public void SourceShouldValidateContextAndBothBranches()
+    {
+        var supported = Literals.Text("42");
+        var unsupported = new RuntimeOnlyParser();
+        Assert.Throws<ArgumentNullException>("context", () => ((ISourceable)If(static () => true, supported)).GenerateSource(null!));
+        Assert.Throws<NotSupportedException>(() => ((ISourceable)If(static () => true, unsupported)).GenerateSource(new()));
+        Assert.Throws<NotSupportedException>(() => ((ISourceable)If(static () => false, unsupported, supported)).GenerateSource(new()));
+        Assert.Throws<NotSupportedException>(() => ((ISourceable)If(static () => true, supported, unsupported)).GenerateSource(new()));
+    }
+
+    private sealed class ConditionalContext : ParseContext
+    {
+        public ConditionalContext(string input, bool enabled) : base(new Scanner(input))
+        {
+            Enabled = enabled;
+        }
+
+        public bool Enabled { get; }
+    }
+
+    private sealed class RuntimeOnlyParser : Parser<string>
+    {
+        public override bool Parse(ParseContext context, ref ParseResult<string> result) => throw new NotSupportedException();
+    }
+}

--- a/test/Parlot.Tests/SelectTests.cs
+++ b/test/Parlot.Tests/SelectTests.cs
@@ -1,0 +1,220 @@
+#nullable enable
+
+using Parlot.Fluent;
+using Parlot.Rewriting;
+using Parlot.SourceGeneration;
+using System;
+using System.Linq;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Tests;
+
+public class SelectTests
+{
+    [Theory]
+    [InlineData(int.MinValue)]
+    [InlineData(-1)]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(2)]
+    [InlineData(int.MaxValue)]
+    public void ContextFreeSelectorShouldRunOnceAndOnlyExecuteSelectedBranch(int index)
+    {
+        var evaluations = 0;
+        var firstCalls = 0;
+        var secondCalls = 0;
+        var entries = 0;
+        var exits = 0;
+        var parser = Select(
+            () => { evaluations++; return index; },
+            Literals.Text("42").Then(_ => { firstCalls++; return "first"; }),
+            Literals.Text("42").Then(_ => { secondCalls++; return "second"; }));
+        var context = new ParseContext(new Scanner("!42"))
+        {
+            OnEnterParser = (p, _) => { if (ReferenceEquals(p, parser)) entries++; },
+            OnExitParser = (p, _) => { if (ReferenceEquals(p, parser)) exits++; }
+        };
+        context.Scanner.Cursor.Advance(1);
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>(7, 11, "unchanged");
+        var success = index is 0 or 1;
+
+        Assert.Equal(success, parser.Parse(context, ref result));
+        Assert.Equal(1, evaluations);
+        Assert.Equal(1, entries);
+        Assert.Equal(1, exits);
+        Assert.Equal(index == 0 ? 1 : 0, firstCalls);
+        Assert.Equal(index == 1 ? 1 : 0, secondCalls);
+        Assert.Equal(success ? (index == 0 ? "first" : "second") : "unchanged", result.Value);
+        Assert.Equal(success ? 1 : 7, result.Start);
+        Assert.Equal(success ? 3 : 11, result.End);
+        if (!success)
+        {
+            Assert.Equal(start, context.Scanner.Cursor.Position);
+        }
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    public void SelectedChildFailureShouldBacktrackWithoutFallback(int index)
+    {
+        var evaluations = 0;
+        var otherCalls = 0;
+        var failing = Terms.Text("42").AndSkip(Literals.Char('!'));
+        var other = Terms.Text("42").Then(value => { otherCalls++; return value; });
+        var parser = Select(() => { evaluations++; return index; }, index == 0 ? failing : other, index == 0 ? other : failing);
+        var context = new ParseContext(new Scanner("!\n 42?"));
+        context.Scanner.Cursor.Advance(1);
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>(7, 11, "unchanged");
+
+        Assert.False(parser.Parse(context, ref result));
+        Assert.Equal(start, context.Scanner.Cursor.Position);
+        Assert.Equal("unchanged", result.Value);
+        Assert.Equal(1, evaluations);
+        Assert.Equal(0, otherCalls);
+        Assert.True(parser.Or(Terms.Text("42")).Parse(context, ref result));
+        Assert.Equal("42", result.Value);
+        Assert.Equal(0, otherCalls);
+    }
+
+    [Fact]
+    public void ContextFreeSelectorShouldObserveUpdatedState()
+    {
+        var index = 0;
+        var parser = Select(() => index, Literals.Text("42"), Literals.Text("17"));
+
+        Assert.Equal("42", parser.Parse("42"));
+        index = 1;
+        Assert.Equal("17", parser.Parse("17"));
+        Assert.False(parser.TryParse("42", out _));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void SelectorShouldReceiveCurrentContextOnce(bool typed)
+    {
+        var evaluations = 0;
+        var current = new CustomContext("42", 0);
+        Func<ParseContext, int> selector = context =>
+        {
+            Assert.Same(current, context);
+            evaluations++;
+            return current.Index;
+        };
+        Func<CustomContext, int> typedSelector = context =>
+        {
+            Assert.Same(current, context);
+            evaluations++;
+            return context.Index;
+        };
+        var parser = typed
+            ? Select(typedSelector, Literals.Text("42"), Literals.Text("17"))
+            : Select(selector, Literals.Text("42"), Literals.Text("17"));
+
+        Assert.True(parser.TryParse(current, out var value, out _));
+        Assert.Equal("42", value);
+        Assert.Equal(1, evaluations);
+        current = new CustomContext("17", 1);
+        Assert.True(parser.TryParse(current, out value, out _));
+        Assert.Equal("17", value);
+        Assert.Equal(2, evaluations);
+    }
+
+    [Theory]
+    [InlineData(" 42", true)]
+    [InlineData(" x", false)]
+    public void OneOfShouldNotSkipSelectorOrHoistWhitespace(string input, bool success)
+    {
+        var context = new ParseContext(new Scanner(input));
+        var evaluations = 0;
+        var select = Select(() =>
+        {
+            evaluations++;
+            Assert.Equal(0, context.Scanner.Cursor.Offset);
+            return 0;
+        }, Terms.Text("42"), Terms.Text("17"));
+        Assert.False(select is ISeekable { CanSeek: true });
+        Assert.False(select is ISeekable { SkipWhitespace: true });
+        var parser = OneOf(select, Terms.Text("z")).Or(Terms.Text("y"));
+        var result = new ParseResult<string>();
+
+        Assert.Equal(success, parser.Parse(context, ref result));
+        Assert.Equal(1, evaluations);
+        Assert.Equal(success ? input.Length : 0, context.Scanner.Cursor.Offset);
+    }
+
+    [Fact]
+    public void ContextFreeSelectorShouldSupportNullableResults()
+    {
+        Assert.True(Select(static () => 0, Always<string?>(null)).TryParse("", out var reference));
+        Assert.Null(reference);
+        Assert.True(Select(static () => 0, Always<int?>(null)).TryParse("", out var value));
+        Assert.Null(value);
+    }
+
+    [Fact]
+    public void ShouldValidateArguments()
+    {
+        var child = Literals.Text("42");
+        Assert.Throws<ArgumentNullException>("selector", () => Select((Func<int>)null!, child));
+        Assert.Throws<ArgumentNullException>("selector", () => Select((Func<ParseContext, int>)null!, child));
+        Assert.Throws<ArgumentNullException>("selector", () => Select((Func<CustomContext, int>)null!, child));
+        Assert.Throws<ArgumentNullException>("parsers", () => Select(static () => 0, (Parser<string>[])null!));
+        Assert.Throws<ArgumentNullException>("parsers", () => Select(static _ => 0, (Parser<string>[])null!));
+        Assert.Throws<ArgumentNullException>("parsers", () => Select<CustomContext, string>(static _ => 0, (Parser<string>[])null!));
+        Assert.Throws<ArgumentException>("parsers", () => Select(static () => 0, child, null!));
+        Assert.Throws<ArgumentException>("parsers", () => Select(static _ => 0, child, null!));
+        Assert.Throws<ArgumentException>("parsers", () => Select<CustomContext, string>(static _ => 0, child, null!));
+        Assert.False(Select<string>(static () => 0).TryParse("42", out _));
+    }
+
+    [Theory]
+    [InlineData(0, false)]
+    [InlineData(1, false)]
+    [InlineData(2, false)]
+    [InlineData(0, true)]
+    [InlineData(1, true)]
+    [InlineData(2, true)]
+    public void SourceShouldRegisterOriginalSelector(int shape, bool discard)
+    {
+        Delegate selector = shape switch
+        {
+            0 => (Func<int>)(static () => 0),
+            1 => (Func<ParseContext, int>)(static context => context.Scanner.Cursor.Offset),
+            _ => (Func<CustomContext, int>)(static context => context.Index)
+        };
+        var first = Literals.Char('a');
+        var second = Literals.Char('b');
+        var parser = shape switch
+        {
+            0 => Select((Func<int>)selector, first, second),
+            1 => Select((Func<ParseContext, int>)selector, first, second),
+            _ => Select((Func<CustomContext, int>)selector, first, second)
+        };
+        var context = new SourceGenerationContext("context", "Test") { DiscardResult = discard };
+
+        var source = Assert.IsAssignableFrom<ISourceable>(parser).GenerateSource(context);
+
+        Assert.Same(selector, Assert.Single(context.Lambdas.Enumerate()).Delegate);
+        Assert.Equal(2, context.Helpers.Enumerate().Count());
+        var call = shape == 0
+            ? "_Test_lambda0()"
+            : $"_Test_lambda0(({SourceGenerationContext.GetTypeName(shape == 1 ? typeof(ParseContext) : typeof(CustomContext))})context)";
+        Assert.EndsWith($"= {call};", source.Body[0]);
+        Assert.Contains(source.Body, line => line.IndexOf($"out {(discard ? "_" : source.ValueVariable)}", StringComparison.Ordinal) >= 0);
+    }
+
+    private sealed class CustomContext : ParseContext
+    {
+        public CustomContext(string input, int index) : base(new Scanner(input))
+        {
+            Index = index;
+        }
+
+        public int Index { get; }
+    }
+}


### PR DESCRIPTION
Source-generated factories currently require parameterless methods, so callers cannot configure a reusable generated parser through factory arguments. This adds instance-bound arguments while keeping the grammar fixed at compile time: all candidate branches are generated once, and runtime predicates select which branch to execute.

```csharp
[GenerateParser]
public static Parser<string> Greeting(bool formal, string prefix) =>
    If(() => formal, Literals.Text("Hello"), Literals.Text("Hi"))
        .Then(text => prefix + text);
```

## Approach

- Bind multiple by-value factory arguments to generated parser instances. Preserve cached singletons for parameterless factories, and distinguish overloaded factories when resolving and intercepting calls. Named arguments, optional arguments, and `params` arrays retain normal call semantics.
- Replace the obsolete `If` APIs with guard-only and two-branch forms accepting `Func<bool>`, `Func<ParseContext, bool>`, or a typed-context predicate. A false guard fails without consuming input; a selected branch's failure never falls back to the other branch. Also add context-free `Select(Func<int>, ...)`.
- Allow factory-parameter captures in supported inline parse-time callbacks, including `Then`, `When`, `Switch`, and fallbacks. Preserve member binding, inferred tuple/property names, `nameof`, recursive helpers, and mutable-struct closure semantics when relocating callbacks.
- Reject eager argument-dependent graph construction, unsupported signatures, reassignment/by-reference use, and other captures. Callback registration does not execute user bodies, and attempted eager execution of captured callbacks remains an error even when the factory catches the exception.
- Add runtime and generator regression coverage, conditional-parser benchmarks, and API/source-generation documentation.

**Migration:** This intentionally removes the obsolete stateful `If<C, S, T>` implementation and overloads at the major-version boundary. Use captured factory arguments or context-aware predicates instead. Options objects retain reference semantics; they are not cloned or frozen.

## Validation

- Debug and Release builds cover all target frameworks with `-p:WarningsNotAsErrors=CA1860`.
- All 310 source-generator tests pass. All 59 dedicated `If`/`Select` tests pass on both net8.0 and net10.0.
- The complete net10.0 runtime suite has 830 passing tests and two failures: `NumberParsesCustomDecimalSeparator` and `SwitchShouldProvidePreviousResult`. Both decimal expected-value failures reproduce on an isolated, unchanged HEAD with the same SDK.
- A plain build is also blocked on unchanged HEAD by CA1860 in `src/Samples/Sql/SqlParser.cs:306`. These unrelated baseline issues are left unchanged.

## Performance

Representative results from 32 conditional-parser cases. Every case measured zero managed allocation per parse; parser construction is excluded.

| Scenario | Runtime | Generated | Parse-time change |
|---|---:|---:|---:|
| Guard enabled, match | 11.44 ns | 6.72 ns | -41% |
| Two branches, true branch matches | 10.44 ns | 6.78 ns | -35% |
| Two branches, false branch matches | 10.00 ns | 6.54 ns | -35% |
| Guard disabled, immediate failure | 1.48 ns | 1.73 ns | +17% |

Generated `If` and equivalent generated `Select` were close: successful two-branch parses took 6.54-6.78 ns and 6.76-7.00 ns respectively.

These are preliminary runtime-versus-generated comparisons of the new implementation, not before/after revision measurements. Environment: Apple M4 Pro, .NET 10.0.11, SDK 11.0.100-rc.1, BenchmarkDotNet 0.15.8 in-process, three warmups and five 100 ms measurement iterations. Reproduce with `IfSelectBenchmarks`.