### PR TITLE
Publish Parlot 2.0 preview packages to Feedz on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,21 @@ jobs:
           10.0.x
         global-json-file: global.json
     - name: Build
-      run: dotnet build --configuration Release
+      run: dotnet build --configuration Release -p:VersionSuffix=preview-${{ github.run_number }} -p:ContinuousIntegrationBuild=True
     - name: Test
       run: dotnet test --configuration Release --no-build
+
+    - name: Pack preview packages
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+      run: dotnet pack --output artifacts --configuration Release --no-build -p:VersionSuffix=preview-${{ github.run_number }} -p:ContinuousIntegrationBuild=True
+
+    - name: Push preview packages to Feedz
+      if: github.event_name == 'push' && github.ref == 'refs/heads/main' && matrix.os == 'ubuntu-latest'
+      shell: bash
+      env:
+        FEEDZ_IO_API_KEY: ${{ secrets.FEEDZ_IO_API_KEY }}
+      run: |
+        set -euo pipefail
+        for package in artifacts/*.nupkg; do
+          dotnet nuget push "$package" --api-key "$FEEDZ_IO_API_KEY" --source https://f.feedz.io/sebastienros/parlot/nuget/index.json --skip-duplicate
+        done

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,8 @@
     <Authors>Sebastien Ros</Authors>
     <PackageProjectUrl>https://github.com/sebastienros/parlot</PackageProjectUrl>
     <PackageLicenseExpression>BSD-3-Clause</PackageLicenseExpression>
-    <Version>0.0.0-preview</Version>
+    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionSuffix>preview</VersionSuffix>
 
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,13 @@ Parlot is a __fast__, __lightweight__ and simple to use .NET parser combinator.
 
 Parlot provides a fluent API based on parser combinators that provide a more readable grammar definition.
 
+## Preview packages
+
+Successful Ubuntu builds for pushes to `main` publish preview packages to the
+[Parlot Feedz feed](https://f.feedz.io/sebastienros/parlot/nuget/index.json).
+Versions follow `2.0.0-preview-<run number>`, using the GitHub Actions build run number.
+Tagged releases continue to be published to NuGet.org.
+
 ## Fluent API
 
 The Fluent API provides simple parser combinators that are assembled to express more complex expressions.


### PR DESCRIPTION
Make current Parlot builds available without waiting for a tagged release, following Jint's main-branch Feedz publishing pattern.

Set the base version to `2.0.0` and use `preview-<GitHub Actions run number>` consistently for build and pack. After successful Ubuntu build and test steps, pushes to `main` publish both packages to `https://f.feedz.io/sebastienros/parlot/nuget/index.json` using `FEEDZ_IO_API_KEY`, with duplicate uploads skipped.

Publishing is excluded from pull requests and the Windows matrix job. Tag-based NuGet.org releases remain unchanged. The README documents the preview feed and version format.