### PR TITLE
Add metadata to source generator package

### DIFF
--- a/src/Parlot.SourceGenerator/Parlot.SourceGenerator.csproj
+++ b/src/Parlot.SourceGenerator/Parlot.SourceGenerator.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <!-- Source generators typically target netstandard2.0 to work with multiple compiler hosts -->
     <TargetFramework>netstandard2.0</TargetFramework>
+    <Title>Parlot Source Generator</Title>
+    <Description>Roslyn source generator for compiling Parlot parser combinators into optimized C# code.</Description>
+    <PackageTags>parlot;parser;parser-combinator;source-generator;roslyn</PackageTags>
     <IsPackable>true</IsPackable>
     <AssemblyOriginatorKeyFile>../Parlot/Parlot.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
The standalone source generator package was missing package-specific metadata, making it less discoverable on NuGet and leaving its purpose unclear.

This adds a title, description, and focused tags describing the Parlot Roslyn source generator. Shared repository metadata such as author, license, project URL, and version continues to come from the common build properties.

The package metadata was verified by packing the source generator and inspecting the generated nuspec.