### PR TITLE
Match runtime collection allocations in source-generated parsers

### DIFF
--- a/docs/source-generation.md
+++ b/docs/source-generation.md
@@ -40,6 +40,13 @@ var result = parser.Parse("hello world");
 3. C# interceptors replace calls to your method with the generated implementation.
 4. At runtime, no parser graph construction occurs—just the generated code runs.
 
+Generated `ZeroOrMany`, `OneOrMany`, and `Separated` parsers use the same collection storage as
+runtime parsers: up to four elements are stored inline, with no separate backing array. Larger
+results use a growing `List<T>`, and an empty `ZeroOrMany` result uses `Array.Empty<T>()`.
+Results remain exposed as `IReadOnlyList<T>`; their concrete type is an implementation detail.
+`Parlot.Fluent.HybridList<T>` is public, but hidden from IntelliSense, to support generated code
+in consumer assemblies. It is a result builder, not a general-purpose collection API.
+
 > [!WARNING]
 > `[GenerateParser]` factory methods are executable build code, not declarative metadata. They run with the
 > compiler host's process permissions and can access the build environment. `[IncludeGenerators]` additionally

--- a/src/Parlot/Fluent/HybridList.cs
+++ b/src/Parlot/Fluent/HybridList.cs
@@ -1,17 +1,26 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Parlot.Fluent;
 
 /// <summary>
-/// An internal implementation of IReadOnlyList&lt;T&gt; that stores up to 4 items inline
+/// A parser result builder that stores up to 4 items inline
 /// before switching to a List&lt;T&gt; for growth.
 /// This provides efficient memory usage for small result sets while maintaining
 /// flexibility for larger lists.
 /// </summary>
+/// <remarks>
+/// This type is public to support source-generated parsers in consumer assemblies.
+/// Parser consumers should use <see cref="IReadOnlyList{T}"/> rather than depending on this implementation.
+/// </remarks>
+/// <typeparam name="T">The element type.</typeparam>
 #nullable enable
-internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
+[EditorBrowsable(EditorBrowsableState.Never)]
+[SuppressMessage("Naming", "CA1710:Identifiers should have correct suffix", Justification = "The type implements IReadOnlyList<T>; ICollection<T> supports pre-sized copies.")]
+public sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
 {
     private T? _item1;
     private T? _item2;
@@ -20,8 +29,10 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
     private List<T>? _list;
     private int _count;
 
+    /// <summary>Gets the number of items.</summary>
     public int Count => _count;
 
+    /// <summary>Gets the item at the specified index.</summary>
     public T this[int index]
     {
         get
@@ -47,6 +58,7 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
         }
     }
 
+    /// <summary>Adds an item while building a parser result.</summary>
     public void Add(T item)
     {
         if (_list is not null)
@@ -103,6 +115,7 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
 
     bool ICollection<T>.Remove(T item) => throw new NotSupportedException();
 
+    /// <summary>Determines whether the collection contains an item.</summary>
     public bool Contains(T item)
     {
         if (_list is not null)
@@ -123,6 +136,7 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
         return false;
     }
 
+    /// <summary>Copies the items to an array starting at the specified index.</summary>
     public void CopyTo(T[] array, int arrayIndex)
     {
         _ = array ?? throw new ArgumentNullException(nameof(array));
@@ -159,6 +173,7 @@ internal sealed class HybridList<T> : IReadOnlyList<T>, ICollection<T>
     /// </remarks>
     public IReadOnlyList<T> AsReadOnlyList() => _list ?? (IReadOnlyList<T>)this;
 
+    /// <summary>Returns an enumerator over the items.</summary>
     public IEnumerator<T> GetEnumerator()
     {
         if (_list is not null)

--- a/src/Parlot/Fluent/OneOrMany.cs
+++ b/src/Parlot/Fluent/OneOrMany.cs
@@ -2,14 +2,12 @@ using Parlot.Rewriting;
 using Parlot.SourceGeneration;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Parlot.Fluent;
 
 public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourceable
 {
     private readonly Parser<T> _parser;
-    private static readonly MethodInfo _listAddMethodInfo = typeof(List<T>).GetMethod("Add")!;
 
     public OneOrMany(Parser<T> parser)
     {
@@ -85,7 +83,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
 
         if (!context.DiscardResult)
         {
-            result.Body.Add($"System.Collections.Generic.List<{elementTypeName}>? {listName} = null;");
+            result.Body.Add($"global::Parlot.Fluent.HybridList<{elementTypeName}>? {listName} = null;");
         }
         result.Body.Add($"{result.SuccessVariable} = false;");
 
@@ -121,7 +119,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
         {
             result.Body.Add($"    if ({listName} == null)");
             result.Body.Add("    {");
-            result.Body.Add($"        {listName} = new System.Collections.Generic.List<{elementTypeName}>();");
+            result.Body.Add($"        {listName} = new global::Parlot.Fluent.HybridList<{elementTypeName}>();");
             result.Body.Add("    }");
             result.Body.Add($"    {listName}!.Add({itemValueName});");
         }
@@ -131,7 +129,7 @@ public sealed class OneOrMany<T> : Parser<IReadOnlyList<T>>, ISeekable, ISourcea
         {
             result.Body.Add($"if ({listName} != null)");
             result.Body.Add("{");
-            result.Body.Add($"    {result.ValueVariable} = {listName};");
+            result.Body.Add($"    {result.ValueVariable} = {listName}.AsReadOnlyList();");
             result.Body.Add("}");
         }
 

--- a/src/Parlot/Fluent/Separated.cs
+++ b/src/Parlot/Fluent/Separated.cs
@@ -2,14 +2,11 @@ using Parlot.Rewriting;
 using Parlot.SourceGeneration;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Parlot.Fluent;
 
 public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISourceable
 {
-    private static readonly MethodInfo _listAddMethodInfo = typeof(List<T>).GetMethod("Add")!;
-
     private readonly Parser<U> _separator;
     private readonly Parser<T> _parser;
 
@@ -124,7 +121,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
 
         if (!context.DiscardResult)
         {
-            result.Body.Add($"System.Collections.Generic.List<{elementTypeName}>? {listName} = null;");
+            result.Body.Add($"global::Parlot.Fluent.HybridList<{elementTypeName}>? {listName} = null;");
         }
         result.Body.Add($"bool {firstName} = true;");
         result.Body.Add($"var {endName} = {cursorName}.Position;");
@@ -183,7 +180,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
         result.Body.Add("    {");
         if (!context.DiscardResult)
         {
-            result.Body.Add($"        {listName} = new System.Collections.Generic.List<{elementTypeName}>();");
+            result.Body.Add($"        {listName} = new global::Parlot.Fluent.HybridList<{elementTypeName}>();");
             result.Body.Add($"        {startName} = {endName}.Offset;");
         }
         result.Body.Add($"        {firstName} = false;");
@@ -199,7 +196,7 @@ public sealed class Separated<U, T> : Parser<IReadOnlyList<T>>, ISeekable, ISour
         {
             result.Body.Add($"if ({listName} != null)");
             result.Body.Add("{");
-            result.Body.Add($"    {result.ValueVariable} = {listName};");
+            result.Body.Add($"    {result.ValueVariable} = {listName}.AsReadOnlyList();");
             result.Body.Add($"    {result.SuccessVariable} = true;");
             result.Body.Add("}");
             result.Body.Add("else");

--- a/src/Parlot/Fluent/ZeroOrMany.cs
+++ b/src/Parlot/Fluent/ZeroOrMany.cs
@@ -1,14 +1,11 @@
 using Parlot.SourceGeneration;
 using System;
 using System.Collections.Generic;
-using System.Reflection;
 
 namespace Parlot.Fluent;
 
 public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
 {
-    private static readonly MethodInfo _listAdd = typeof(List<T>).GetMethod("Add")!;
-
     private readonly Parser<T> _parser;
 
     public ZeroOrMany(Parser<T> parser)
@@ -76,7 +73,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
 
         if (!context.DiscardResult)
         {
-            result.Body.Add($"System.Collections.Generic.List<{elementTypeName}>? {listName} = null;");
+            result.Body.Add($"global::Parlot.Fluent.HybridList<{elementTypeName}>? {listName} = null;");
             result.Body.Add($"bool {firstName} = true;");
         }
 
@@ -112,8 +109,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
         {
             result.Body.Add($"    if ({firstName})");
             result.Body.Add("    {");
-            result.Body.Add($"        {listName} = new System.Collections.Generic.List<{elementTypeName}>();");
-            result.Body.Add($"        {result.ValueVariable} = {listName};");
+            result.Body.Add($"        {listName} = new global::Parlot.Fluent.HybridList<{elementTypeName}>();");
             result.Body.Add($"        {firstName} = false;");
             result.Body.Add("    }");
             result.Body.Add($"    {listName}!.Add({itemValueName});");
@@ -121,10 +117,7 @@ public sealed class ZeroOrMany<T> : Parser<IReadOnlyList<T>>, ISourceable
         result.Body.Add("}");
         if (!context.DiscardResult)
         {
-            result.Body.Add($"if ({listName} is null)");
-            result.Body.Add("{");
-            result.Body.Add($"    {result.ValueVariable} = global::System.Array.Empty<{elementTypeName}>();");
-            result.Body.Add("}");
+            result.Body.Add($"{result.ValueVariable} = {listName}?.AsReadOnlyList() ?? global::System.Array.Empty<{elementTypeName}>();");
         }
 
         return result;

--- a/test/Parlot.Benchmarks/CollectionBenchmarks.cs
+++ b/test/Parlot.Benchmarks/CollectionBenchmarks.cs
@@ -1,0 +1,82 @@
+using BenchmarkDotNet.Attributes;
+using Parlot.Fluent;
+using Parlot.SourceGenerator;
+using System;
+using System.Collections.Generic;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser]
+public partial class CollectionBenchmarks
+{
+    private Parser<IReadOnlyList<(int, string)>> _runtime;
+    private Parser<IReadOnlyList<(int, string)>> _generated;
+    private ParseContext _context;
+
+    [Params(0, 1, 4, 5, 32)]
+    public int Count { get; set; }
+
+    [Params("ZeroOrMany", "OneOrMany", "Separated")]
+    public string Combinator { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        Func<Parser<IReadOnlyList<(int, string)>>> factory = Combinator switch
+        {
+            "ZeroOrMany" => CreateZero,
+            "OneOrMany" => CreateOne,
+            _ => CreateSeparated
+        };
+        _runtime = factory();
+        _generated = Combinator switch
+        {
+            "ZeroOrMany" => CreateZero(),
+            "OneOrMany" => CreateOne(),
+            _ => CreateSeparated()
+        };
+        var input = new string('x', Count);
+        if (Combinator == "Separated")
+        {
+            input = string.Join(",", input.ToCharArray());
+        }
+        _context = new ParseContext(new Scanner(input));
+
+        if (_runtime.GetType() == _generated.GetType())
+        {
+            throw new InvalidOperationException("Collection benchmarks require factory interception.");
+        }
+
+        var expectedSuccess = Count > 0 || Combinator == "ZeroOrMany";
+        if (Runtime() != expectedSuccess || Generated() != expectedSuccess)
+        {
+            throw new InvalidOperationException("Unexpected collection parser result.");
+        }
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool Runtime() => Parse(_runtime);
+
+    [Benchmark]
+    public bool Generated() => Parse(_generated);
+
+    private bool Parse(Parser<IReadOnlyList<(int, string)>> parser)
+    {
+        _context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<IReadOnlyList<(int, string)>>();
+        return parser.Parse(_context, ref result);
+    }
+
+    [GenerateParser]
+    private static Parser<IReadOnlyList<(int, string)>> CreateZero() =>
+        ZeroOrMany(Literals.Text("x").Then(static text => (1, text)));
+
+    [GenerateParser]
+    private static Parser<IReadOnlyList<(int, string)>> CreateOne() =>
+        OneOrMany(Literals.Text("x").Then(static text => (1, text)));
+
+    [GenerateParser]
+    private static Parser<IReadOnlyList<(int, string)>> CreateSeparated() =>
+        Separated(Literals.Char(','), Literals.Text("x").Then(static text => (1, text)));
+}

--- a/test/Parlot.SourceGenerator.Tests/CollectionParserTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/CollectionParserTests.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using Parlot.Fluent;
+using Parlot.SourceGenerator;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.SourceGenerator.Tests;
+
+public partial class CollectionParserTests
+{
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(32)]
+    public void Collections_MatchRuntimeStorageAndAllocations(int count)
+    {
+        Check(ZeroStrings(), ZeroStrings, count, separated: false, allowsEmpty: true);
+        Check(OneStrings(), OneStrings, count, separated: false, allowsEmpty: false);
+        Check(SeparatedStrings(), SeparatedStrings, count, separated: true, allowsEmpty: false);
+        Check(ZeroTuples(), ZeroTuples, count, separated: false, allowsEmpty: true);
+        Check(OneTuples(), OneTuples, count, separated: false, allowsEmpty: false);
+        Check(SeparatedTuples(), SeparatedTuples, count, separated: true, allowsEmpty: false);
+    }
+
+    private static void Check<T>(Parser<IReadOnlyList<T>> generated,
+        Func<Parser<IReadOnlyList<T>>> factory, int count, bool separated, bool allowsEmpty)
+    {
+        // Method-group invocation bypasses factory interception.
+        var runtime = factory();
+        Assert.NotEqual(runtime.GetType(), generated.GetType());
+        var input = CreateInput(count, separated);
+        var generatedContext = new ParseContext(new Scanner(input));
+        var runtimeContext = new ParseContext(new Scanner(input));
+        var generatedResult = new ParseResult<IReadOnlyList<T>>();
+        var runtimeResult = new ParseResult<IReadOnlyList<T>>();
+        var expectedSuccess = count > 0 || allowsEmpty;
+
+        Assert.Equal(expectedSuccess, runtime.Parse(runtimeContext, ref runtimeResult));
+        Assert.Equal(expectedSuccess, generated.Parse(generatedContext, ref generatedResult));
+        Assert.Equal(runtimeContext.Scanner.Cursor.Position, generatedContext.Scanner.Cursor.Position);
+        Assert.Equal(input.Length, generatedContext.Scanner.Cursor.Offset);
+
+        if (expectedSuccess)
+        {
+            Assert.Equal(runtimeResult.Value, generatedResult.Value);
+            Assert.Equal(runtimeResult.Value.GetType(), generatedResult.Value.GetType());
+            Assert.Equal(count, generatedResult.Value.Count);
+
+            if (count == 0)
+            {
+                Assert.Same(Array.Empty<T>(), generatedResult.Value);
+            }
+            else if (count <= 4)
+            {
+                Assert.IsType<HybridList<T>>(generatedResult.Value);
+            }
+            else
+            {
+                Assert.IsType<List<T>>(generatedResult.Value);
+            }
+
+            var collection = Assert.IsAssignableFrom<ICollection<T>>(generatedResult.Value);
+            var runtimeCollection = Assert.IsAssignableFrom<ICollection<T>>(runtimeResult.Value);
+            Assert.Equal(runtimeCollection.IsReadOnly, collection.IsReadOnly);
+            var copy = new T[count + 2];
+            collection.CopyTo(copy, 1);
+            Assert.Equal(count, new List<T>(generatedResult.Value).Count);
+            for (var i = 0; i < count; i++)
+            {
+                Assert.Equal(runtimeResult.Value[i], copy[i + 1]);
+                Assert.True(collection.Contains(copy[i + 1]));
+            }
+
+            if (count > 0 && count <= 4)
+            {
+                var item = generatedResult.Value[0];
+                Assert.Throws<NotSupportedException>(() => collection.Add(item));
+                Assert.Throws<NotSupportedException>(() => collection.Clear());
+                Assert.Throws<NotSupportedException>(() => collection.Remove(item));
+            }
+        }
+
+        var runtimeBytes = AllocatedBytes(runtime, runtimeContext);
+        var generatedBytes = AllocatedBytes(generated, generatedContext);
+        Assert.Equal(runtimeBytes, generatedBytes);
+        if (count == 0)
+        {
+            Assert.Equal(0, generatedBytes);
+        }
+    }
+
+    private static long AllocatedBytes<T>(Parser<T> parser, ParseContext context)
+    {
+        var result = new ParseResult<T>();
+        for (var i = 0; i < 100; i++)
+        {
+            context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+            parser.Parse(context, ref result);
+        }
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        for (var i = 0; i < 1000; i++)
+        {
+            context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+            parser.Parse(context, ref result);
+        }
+        var bytes = GC.GetAllocatedBytesForCurrentThread() - before;
+        GC.KeepAlive(result.Value);
+        return bytes;
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("x")]
+    [InlineData("x,x,x,x")]
+    [InlineData("x,x,x,x,x")]
+    [InlineData("x,?")]
+    [InlineData("  ?")]
+    public void Separated_PreservesBacktracking(string input)
+    {
+        var generated = SeparatedStrings();
+        Func<Parser<IReadOnlyList<string>>> factory = SeparatedStrings;
+        var runtime = factory();
+        var generatedContext = new ParseContext(new Scanner(input));
+        var runtimeContext = new ParseContext(new Scanner(input));
+        var generatedResult = new ParseResult<IReadOnlyList<string>>();
+        var runtimeResult = new ParseResult<IReadOnlyList<string>>();
+        Assert.Equal(runtime.Parse(runtimeContext, ref runtimeResult),
+            generated.Parse(generatedContext, ref generatedResult));
+        Assert.Equal(runtimeContext.Scanner.Cursor.Position, generatedContext.Scanner.Cursor.Position);
+        Assert.Equal(input == "x,?" ? 1 : input == "  ?" ? 0 : input.Length,
+            generatedContext.Scanner.Cursor.Offset);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(1)]
+    [InlineData(4)]
+    [InlineData(5)]
+    [InlineData(32)]
+    public void DiscardedCollections_DoNotAllocate(int count)
+    {
+        CheckDiscarded(CaptureZero(), CaptureZero, CreateInput(count, false), expectedSuccess: true);
+        CheckDiscarded(CaptureOne(), CaptureOne, CreateInput(count, false), count > 0);
+        CheckDiscarded(CaptureSeparated(), CaptureSeparated, CreateInput(count, true), count > 0);
+    }
+
+    private static void CheckDiscarded(Parser<TextSpan> generated, Func<Parser<TextSpan>> factory,
+        string input, bool expectedSuccess)
+    {
+        Assert.NotEqual(factory().GetType(), generated.GetType());
+        var context = new ParseContext(new Scanner(input));
+        var result = new ParseResult<TextSpan>();
+        Assert.Equal(expectedSuccess, generated.Parse(context, ref result));
+        Assert.Equal(input.Length, context.Scanner.Cursor.Offset);
+        if (expectedSuccess)
+        {
+            Assert.Equal(input, result.Value.ToString());
+        }
+        Assert.Equal(0, AllocatedBytes(generated, context));
+    }
+
+    private static string CreateInput(int count, bool separated) =>
+        separated ? string.Join(",", new string('x', count).ToCharArray()) : new string('x', count);
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<string>> ZeroStrings() => ZeroOrMany(Literals.Text("x"));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<string>> OneStrings() => OneOrMany(Literals.Text("x"));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<string>> SeparatedStrings() => Separated(Terms.Char(','), Terms.Text("x"));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<(int, string)>> ZeroTuples() =>
+        ZeroOrMany(Literals.Text("x").Then(static text => (1, text)));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<(int, string)>> OneTuples() =>
+        OneOrMany(Literals.Text("x").Then(static text => (1, text)));
+
+    [GenerateParser]
+    public static Parser<IReadOnlyList<(int, string)>> SeparatedTuples() =>
+        Separated(Literals.Char(','), Literals.Text("x").Then(static text => (1, text)));
+
+    [GenerateParser]
+    public static Parser<TextSpan> CaptureZero() => Capture(ZeroOrMany(Literals.Text("x")));
+
+    [GenerateParser]
+    public static Parser<TextSpan> CaptureOne() => Capture(OneOrMany(Literals.Text("x")));
+
+    [GenerateParser]
+    public static Parser<TextSpan> CaptureSeparated() => Capture(Separated(Literals.Char(','), Literals.Text("x")));
+}

--- a/test/Parlot.Tests/Parlot.Tests.csproj
+++ b/test/Parlot.Tests/Parlot.Tests.csproj
@@ -20,10 +20,6 @@
     <ProjectReference Include="..\..\src\Samples\Samples.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Compile Include="../../src/Parlot/Fluent/HybridList.cs" Link="HybridList.cs" />
-  </ItemGroup>
-
   <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
     <ProjectReference Include="../../test/Parlot.Benchmarks/Parlot.Benchmarks.csproj" />
   </ItemGroup>


### PR DESCRIPTION
Source-generated repetition parsers allocate a `List<T>` and backing array even for small results, while runtime parsers store up to four elements inline in `HybridList<T>`. Profiling NCalc exposed an extra 24 bytes per nonempty small collection in generated parsers.

## Approach

- Reuse `HybridList<T>` in the `ZeroOrMany`, `OneOrMany`, and `Separated` emitters. Finalize through `AsReadOnlyList()` after accumulation, preserving the runtime `List<T>` fast path for larger results.
- Make the existing sealed builder public, documented, and `EditorBrowsable(Never)` so generated code in consumer assemblies can access it without duplicating the implementation. Results remain exposed as `IReadOnlyList<T>`; callers should not depend on their concrete type.
- Preserve allocation-free empty/discarded results and existing parsing/backtracking behavior. Remove obsolete reflection fields and the unit tests' linked copy of the now-public builder.
- Add allocation/storage parity regressions for 0, 1, 4, 5, and 32 elements, reference and value-tuple elements, collection interface behavior, and separator backtracking. Add focused collection benchmarks and document the generation support type.

## Allocation impact

Small-result collection storage on ARM64, excluding parse context and enumeration:

| Element type, 1-4 elements | Generated before | Generated after | Runtime |
| --- | ---: | ---: | ---: |
| Reference | 88 B | 64 B | 64 B |
| `(int, reference)` | 120 B | 96 B | 96 B |

The original profiling established the extra backing-array cost; the new regressions verify exact generated/runtime allocation parity, including growth beyond four elements. NCalc integration below confirms that the extra end-to-end allocations are eliminated with the original grammar unchanged.

## Validation

- Source-generator suite: 326 passed.
- HybridList unit tests: 34 passed on each of .NET 8 and .NET 10, now exercising the shipped assembly rather than linked source.
- NuGet-only external consumer: generated code compiled for `net472`, `netstandard2.0`, `net8.0`, and `net10.0`; all 16 new collection tests passed on both runnable targets.
- All-target solution build passed with the existing SDK 11 sample warning CA1860 made nonfatal via command line; no unrelated sample code changed.
- Full runtime suites: 830 passed / 2 failed on .NET 10, 812 passed / 2 failed on .NET 8. The failures are decimal expected-value assertions in `SwitchShouldProvidePreviousResult` and `NumberParsesCustomDecimalSeparator`; both reproduce on unmodified main.

Consumer builds used `UseSharedCompilation=false` to prevent compiler-server reuse of previously loaded Parlot emission code when switching baseline/patched assemblies.

## NCalc integration results

All 639 NCalc tests passed against both local packages: unmodified main (`2.0.0-preview-737-allocationbaseline.1`, based on `3c158c4`) and this fix (`2.0.0-preview-737-allocationfix.1`). With the fixed package, NCalc.Core builds for `net462`, `netstandard2.0`, `net8.0`, `net9.0`, and `net10.0` with zero warnings or errors. The original grammar was unchanged; no direct-fold workaround was used. These were local validation packages, not published releases.

Compared with the previously profiled Feedz build 737, generated-parser allocation drops from **1112 to 1040 B/op** for the simple expression and **2968 to 2776 B/op** for the advanced expression, on both .NET 8 and .NET 10. Generated and runtime parsers now have matching reported allocations. Generated output and resolved package assets were checked to confirm use of the fixed `HybridList` implementation.

Reused-parser benchmarks with the fixed package (mean +/- 99.9% confidence interval halfwidth):

| Runtime | Expression | Runtime parser | Generated parser | Allocated, each path | Generated throughput ratio |
| --- | --- | ---: | ---: | ---: | ---: |
| .NET 8 | Simple | 2.418 +/- 0.0200 us | 1.763 +/- 0.0237 us | 1040 B/op | 1.37x |
| .NET 8 | Advanced | 6.061 +/- 0.0520 us | 4.649 +/- 0.0349 us | 2776 B/op | 1.30x |
| .NET 10 | Simple | 2.207 +/- 0.0116 us | 1.877 +/- 0.0099 us | 1040 B/op | 1.18x |
| .NET 10 | Advanced | 5.597 +/- 0.0406 us | 4.536 +/- 0.0349 us | 2776 B/op | 1.23x |

Environment: BenchmarkDotNet 0.15.8 default jobs, macOS 15.7.9, M4 Pro ARM64, SDK 11.0.100-rc.1.26413.103, runtimes 8.0.30 and 10.0.11. Non-shared compilation, no profiling instrumentation, and no concurrent upstream build/benchmark load. This is a shared workstation: the throughput ratios compare runtime and generated parsers within the same fixed-package run, not the isolated timing effect of this patch versus the earlier build 737 run.