### PR TITLE
Remove runtime Immutable dependency below .NET 10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.11" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/src/Parlot/CharMap.cs
+++ b/src/Parlot/CharMap.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if NET10_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -13,7 +15,11 @@ namespace Parlot;
 internal sealed class CharMap<T> where T : class
 {
     private readonly T[] _asciiMap = new T[128];
+#if NET10_0_OR_GREATER
     private FrozenDictionary<uint, T>? _nonAsciiMap;
+#else
+    private Dictionary<uint, T>? _nonAsciiMap;
+#endif
 
     public CharMap()
     {
@@ -54,7 +60,11 @@ internal sealed class CharMap<T> where T : class
 
         if (nonAsciiMap != null)
         {
+#if NET10_0_OR_GREATER
             _nonAsciiMap = nonAsciiMap.ToFrozenDictionary();
+#else
+            _nonAsciiMap = nonAsciiMap;
+#endif
         }
     }
 
@@ -69,12 +79,18 @@ internal sealed class CharMap<T> where T : class
         }
         else
         {
+#if NET10_0_OR_GREATER
             Dictionary<uint, T> dic = _nonAsciiMap == null ? [] : new(_nonAsciiMap);
+#else
+            var dic = _nonAsciiMap ??= [];
+#endif
 
             if (!dic.ContainsKey(c))
             {
                 dic[c] = value;
+#if NET10_0_OR_GREATER
                 _nonAsciiMap = dic.ToFrozenDictionary();
+#endif
             }
         }
     }

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))" />
     <!-- Build-time only dependency for source generation literal escaping - not shipped with the package -->
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" PrivateAssets="all" />
   </ItemGroup>

--- a/test/Parlot.Benchmarks/CharMapBenchmarks.cs
+++ b/test/Parlot.Benchmarks/CharMapBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using Parlot.Fluent;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, ShortRunJob]
+public class CharMapBenchmarks
+{
+    private Parser<char> _parser;
+    private ParseContext _context;
+
+    [Params("a", "\u00e9", "\u4e2d")]
+    public string Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _parser = OneOf(
+            Literals.Char('a'),
+            Literals.Char('\u00e9'),
+            Literals.Char('\u00f1'),
+            Literals.Char('\u03b1'));
+        _context = new ParseContext(new Scanner(Input));
+    }
+
+    [Benchmark]
+    public bool Lookup()
+    {
+        _context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<char>();
+        return _parser.Parse(_context, ref result);
+    }
+}

--- a/test/Parlot.Tests/BenchmarksTests.cs
+++ b/test/Parlot.Tests/BenchmarksTests.cs
@@ -10,6 +10,19 @@ public class BenchmarksTests
     const decimal _expected1 = (decimal)3.5;
     const decimal _expected2 = (decimal)-64.5;
 
+    [Theory]
+    [InlineData("a", true)]
+    [InlineData("\u00e9", true)]
+    [InlineData("\u4e2d", false)]
+    public void CharacterMapLookup(string input, bool success)
+    {
+        var benchmarks = new CharMapBenchmarks { Input = input };
+        benchmarks.Setup();
+
+        Assert.Equal(success, benchmarks.Lookup());
+        Assert.Equal(success, benchmarks.Lookup());
+    }
+
     [Fact]
     public void CursorMatchHello()
     {

--- a/test/Parlot.Tests/CharMapParserTests.cs
+++ b/test/Parlot.Tests/CharMapParserTests.cs
@@ -1,0 +1,76 @@
+using Parlot.Fluent;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Tests;
+
+public class CharMapParserTests
+{
+#if !NET10_0_OR_GREATER
+    [Fact]
+    public void RuntimeShouldNotReferenceImmutableCollections()
+    {
+        Assert.DoesNotContain(typeof(Parser<char>).Assembly.GetReferencedAssemblies(),
+            static assembly => assembly.Name == "System.Collections.Immutable");
+    }
+#endif
+
+    [Theory]
+    [InlineData("a")]
+    [InlineData("\u00e9a")]
+    [InlineData("\u00e9b")]
+    [InlineData("\u4e2d")]
+    public void OneOfShouldMatchAsciiAndNonAsciiBranches(string input)
+    {
+        var parser = OneOf(
+            Literals.Text("a"),
+            Literals.Text("\u00e9a"),
+            Literals.Text("\u00e9b"),
+            Literals.Text("\u4e2d"));
+
+        Assert.True(parser.TryParse(input, out var value));
+        Assert.Equal(input, value);
+    }
+
+    [Theory]
+    [InlineData("z")]
+    [InlineData("\u4e2d")]
+    [InlineData("\u00e9x")]
+    public void OneOfShouldRestorePositionWhenLookupOrBranchFails(string input)
+    {
+        var parser = OneOf(Literals.Text("a"), Literals.Text("\u00e9a"), Literals.Text("\u00e9b"));
+        var context = new ParseContext(new Scanner("!" + input));
+        context.Scanner.Cursor.Advance();
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>();
+
+        Assert.False(parser.Parse(context, ref result));
+        Assert.Equal(start, context.Scanner.Cursor.Position);
+    }
+
+    [Fact]
+    public void OneOfShouldPreserveBranchOrderForDuplicateNonAsciiKeys()
+    {
+        var parser = OneOf(Literals.Text("\u00e9").Then(1), Literals.Text("\u00e9").Then(2));
+
+        Assert.Equal(1, parser.Parse("\u00e9"));
+    }
+
+    [Fact]
+    public void AnyOfShouldHandleDuplicateNonAsciiCharacters()
+    {
+        var parser = Literals.AnyOf("a\u00e9\u00e9\u4e2d");
+
+        Assert.Equal("a\u00e9\u4e2d\u00e9", parser.Parse("a\u00e9\u4e2d\u00e9!").ToString());
+        Assert.False(parser.TryParse("\u00f1", out _));
+    }
+
+    [Fact]
+    public void NoneOfShouldHandleDuplicateNonAsciiCharacters()
+    {
+        var parser = Literals.NoneOf("a\u00e9\u00e9\u4e2d");
+
+        Assert.Equal("z\u00f1", parser.Parse("z\u00f1\u00e9").ToString());
+        Assert.False(parser.TryParse("\u4e2d", out _));
+    }
+}


### PR DESCRIPTION
## Summary

- Use `Dictionary<uint, T>` for non-ASCII character maps on `net8.0`, `net472`, and `netstandard2.0`; retain framework-provided `FrozenDictionary` on `net10.0`.
- Preserve the ASCII array lookup and first-match behavior. On downlevel targets, incremental character-map construction reuses the dictionary instead of repeatedly freezing it.
- Remove the direct `System.Collections.Immutable` package reference and its unused central version entry. Roslyn and `LiteralHelper` remain unchanged.
- Add regressions for ASCII/non-ASCII matches, duplicate keys, cursor restoration, and the absence of an Immutable assembly reference on older targets, plus a focused lookup benchmark.

## Published runtime dependencies

| Target | Dependencies |
| --- | --- |
| `net8.0`, `net10.0` | None |
| `net472`, `netstandard2.0` | `System.Memory >= 4.6.3` and its transitives |

Removing the package reference alone is not sufficient: `FrozenDictionary` belongs to the Immutable assembly and would leave the .NET 8 runtime bound to Immutable 10. The conditional implementation removes that assembly dependency rather than merely hiding it from NuGet.

## Validation

- Full solution build across all target frameworks using .NET SDK 10.0.400. Existing Roslyn version-conflict warnings in benchmark/test projects remain.
- Runtime suite: 825 passed on .NET 8; 845 passed on .NET 10.
- Source-generator suite: 326 passed.
- Inspected the packed NuGet dependency groups.
- Isolated package consumers exercised runtime and source-generated parsers, ASCII/non-ASCII success and failure, and duplicate character sets. The `net8.0` and `net10.0` assets ran on their respective runtimes; the `netstandard2.0` and `net472` assets were additionally exercised on a .NET 8 host (not a native .NET Framework execution).

## Performance

BenchmarkDotNet 0.15.8, Apple M4 Pro, .NET 8.0.30. Measurements use an already-constructed `OneOf` parser; construction and end-to-end grammar costs are not measured. Both benchmark modes are shown because non-ASCII hit results differ.

| Mode | Lookup | Before: FrozenDictionary | After: Dictionary | Change |
| --- | --- | ---: | ---: | ---: |
| In-process | ASCII hit | 4.614 ns | 4.622 ns | +0.2% |
| In-process | Non-ASCII hit | 5.614 ns | 6.709 ns | +19.5% |
| In-process | Non-ASCII miss | 2.984 ns | 4.163 ns | +39.5% |
| ShortRun, separate process | ASCII hit | 4.749 ns | 4.746 ns | -0.1% |
| ShortRun, separate process | Non-ASCII hit | 5.913 ns | 5.440 ns | -8.0% |
| ShortRun, separate process | Non-ASCII miss | 1.870 ns | 2.725 ns | +45.7% |

Positive percentages mean slower. All cases allocated 0 bytes per operation. ASCII throughput is unchanged; non-ASCII misses cost roughly one additional nanosecond in exchange for removing the dependency. The .NET 10 implementation is unchanged.