### PR TITLE
[release/1.x] Remove runtime Immutable dependency below .NET 10

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="System.Memory" Version="4.6.3" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.8" />
     <PackageVersion Include="FastExpressionCompiler.Internal.src" Version="5.4.1" />
     <!-- Benchmarks -->
     <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />

--- a/src/Parlot/CharMap.cs
+++ b/src/Parlot/CharMap.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+#if NET10_0_OR_GREATER
 using System.Collections.Frozen;
+#endif
 using System.Linq;
 using System.Runtime.CompilerServices;
 
@@ -13,7 +15,11 @@ namespace Parlot;
 internal sealed class CharMap<T> where T : class
 {
     private readonly T[] _asciiMap = new T[128];
+#if NET10_0_OR_GREATER
     private FrozenDictionary<uint, T>? _nonAsciiMap;
+#else
+    private Dictionary<uint, T>? _nonAsciiMap;
+#endif
 
     public CharMap()
     {
@@ -54,7 +60,11 @@ internal sealed class CharMap<T> where T : class
 
         if (nonAsciiMap != null)
         {
+#if NET10_0_OR_GREATER
             _nonAsciiMap = nonAsciiMap.ToFrozenDictionary();
+#else
+            _nonAsciiMap = nonAsciiMap;
+#endif
         }
     }
 
@@ -69,12 +79,18 @@ internal sealed class CharMap<T> where T : class
         }
         else
         {
+#if NET10_0_OR_GREATER
             Dictionary<uint, T> dic = _nonAsciiMap == null ? [] : new(_nonAsciiMap);
+#else
+            var dic = _nonAsciiMap ??= [];
+#endif
 
             if (!dic.ContainsKey(c))
             {
                 dic[c] = value;
+#if NET10_0_OR_GREATER
                 _nonAsciiMap = dic.ToFrozenDictionary();
+#endif
             }
         }
     }

--- a/src/Parlot/Parlot.csproj
+++ b/src/Parlot/Parlot.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Memory" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
-    <PackageReference Include="System.Collections.Immutable" Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))" />
     <PackageReference Include="FastExpressionCompiler.Internal.src" PrivateAssets="all" />
   </ItemGroup>
 

--- a/test/Parlot.Benchmarks/CharMapBenchmarks.cs
+++ b/test/Parlot.Benchmarks/CharMapBenchmarks.cs
@@ -1,0 +1,34 @@
+using BenchmarkDotNet.Attributes;
+using Parlot.Fluent;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, ShortRunJob]
+public class CharMapBenchmarks
+{
+    private Parser<char> _parser;
+    private ParseContext _context;
+
+    [Params("a", "\u00e9", "\u4e2d")]
+    public string Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _parser = OneOf(
+            Literals.Char('a'),
+            Literals.Char('\u00e9'),
+            Literals.Char('\u00f1'),
+            Literals.Char('\u03b1'));
+        _context = new ParseContext(new Scanner(Input));
+    }
+
+    [Benchmark]
+    public bool Lookup()
+    {
+        _context.Scanner.Cursor.ResetPosition(TextPosition.Start);
+        var result = new ParseResult<char>();
+        return _parser.Parse(_context, ref result);
+    }
+}

--- a/test/Parlot.Tests/BenchmarksTests.cs
+++ b/test/Parlot.Tests/BenchmarksTests.cs
@@ -10,6 +10,19 @@ public class BenchmarksTests
     const decimal _expected1 = (decimal)3.5;
     const decimal _expected2 = (decimal)-64.5;
 
+    [Theory]
+    [InlineData("a", true)]
+    [InlineData("\u00e9", true)]
+    [InlineData("\u4e2d", false)]
+    public void CharacterMapLookup(string input, bool success)
+    {
+        var benchmarks = new CharMapBenchmarks { Input = input };
+        benchmarks.Setup();
+
+        Assert.Equal(success, benchmarks.Lookup());
+        Assert.Equal(success, benchmarks.Lookup());
+    }
+
     [Fact]
     public void CreateCompiledSmallParser()
     {

--- a/test/Parlot.Tests/CharMapParserTests.cs
+++ b/test/Parlot.Tests/CharMapParserTests.cs
@@ -1,0 +1,113 @@
+using Parlot.Fluent;
+using Xunit;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Tests;
+
+public class CharMapParserTests
+{
+#if !NET10_0_OR_GREATER
+    [Fact]
+    public void RuntimeShouldNotReferenceImmutableCollections()
+    {
+        Assert.DoesNotContain(typeof(Parser<char>).Assembly.GetReferencedAssemblies(),
+            static assembly => assembly.Name == "System.Collections.Immutable");
+    }
+#endif
+
+    [Theory]
+    [InlineData("a", false)]
+    [InlineData("a", true)]
+    [InlineData("\u00e9a", false)]
+    [InlineData("\u00e9a", true)]
+    [InlineData("\u00e9b", false)]
+    [InlineData("\u00e9b", true)]
+    [InlineData("\u4e2d", false)]
+    [InlineData("\u4e2d", true)]
+    public void OneOfShouldMatchAsciiAndNonAsciiBranches(string input, bool compiled)
+    {
+        var parser = OneOf(
+            Literals.Text("a"),
+            Literals.Text("\u00e9a"),
+            Literals.Text("\u00e9b"),
+            Literals.Text("\u4e2d"));
+
+        if (compiled)
+        {
+            parser = parser.Compile();
+        }
+
+        Assert.True(parser.TryParse(input, out var value));
+        Assert.Equal(input, value);
+    }
+
+    [Theory]
+    [InlineData("z", false)]
+    [InlineData("z", true)]
+    [InlineData("\u4e2d", false)]
+    [InlineData("\u4e2d", true)]
+    [InlineData("\u00e9x", false)]
+    [InlineData("\u00e9x", true)]
+    public void OneOfShouldRestorePositionWhenLookupOrBranchFails(string input, bool compiled)
+    {
+        var parser = OneOf(Literals.Text("a"), Literals.Text("\u00e9a"), Literals.Text("\u00e9b"));
+        if (compiled)
+        {
+            parser = parser.Compile();
+        }
+
+        var context = new ParseContext(new Scanner("!" + input));
+        context.Scanner.Cursor.Advance();
+        var start = context.Scanner.Cursor.Position;
+        var result = new ParseResult<string>();
+
+        Assert.False(parser.Parse(context, ref result));
+        Assert.Equal(start, context.Scanner.Cursor.Position);
+    }
+
+    [Theory]
+    [InlineData("a", false)]
+    [InlineData("a", true)]
+    [InlineData("\u00e9", false)]
+    [InlineData("\u00e9", true)]
+    public void OneOfShouldPreserveBranchOrderForDuplicateKeys(string input, bool compiled)
+    {
+        var parser = OneOf(Literals.Text(input).Then(1), Literals.Text(input).Then(2));
+        if (compiled)
+        {
+            parser = parser.Compile();
+        }
+
+        Assert.Equal(1, parser.Parse(input));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void AnyOfShouldHandleDuplicateNonAsciiCharacters(bool compiled)
+    {
+        var parser = Literals.AnyOf("a\u00e9\u00e9\u4e2d");
+        if (compiled)
+        {
+            parser = parser.Compile();
+        }
+
+        Assert.Equal("a\u00e9\u4e2d\u00e9", parser.Parse("a\u00e9\u4e2d\u00e9!").ToString());
+        Assert.False(parser.TryParse("\u00f1", out _));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void NoneOfShouldHandleDuplicateNonAsciiCharacters(bool compiled)
+    {
+        var parser = Literals.NoneOf("a\u00e9\u00e9\u4e2d");
+        if (compiled)
+        {
+            parser = parser.Compile();
+        }
+
+        Assert.Equal("z\u00f1", parser.Parse("z\u00f1\u00e9").ToString());
+        Assert.False(parser.TryParse("\u4e2d", out _));
+    }
+}


### PR DESCRIPTION
Backport of #336.

Cherry-picked from `f9d0b89d3777da6fdb6d7b0567c6069ce40e9bbb` with release-branch adaptations.

## Changes

- Use `Dictionary<uint, T>` for non-ASCII `CharMap` entries on net8.0, net472 and netstandard2.0; retain framework `FrozenDictionary` on net10.0. Keep the ASCII array fast path and first-value duplicate semantics unchanged.
- Remove the published `System.Collections.Immutable` package reference and its now-unused central version. `FrozenDictionary` belongs to that assembly despite its `System.Collections.Frozen` namespace, so the implementation change is required before removing the package.
- Preserve release/1.x's `System.Memory` 4.6.3 floor and private `FastExpressionCompiler.Internal.src` 5.4.1 dependency. Do not introduce main's Roslyn/source-generation infrastructure or README documentation.
- Backport the focused character-map benchmark and parser regressions; extend regressions to interpreted and `Compile()` parsers, including ASCII duplicate branch order, Unicode lookup, nonzero-cursor rollback, and duplicate Unicode AnyOf/NoneOf inputs.

## Validation

Used SDK 10.0.400 via an external validation-directory global.json, with no repository SDK changes. This branch targets net8.0/net10.0 for tests, not net9.0.

- Full Release solution build across existing target frameworks: success, zero warnings/errors.
- Focused net8.0 character-map tests: 23 passed.
- Full Release suites: net8.0 887 passed; net10.0 917 passed.
- The first combined full-suite run hit an unrelated randomized duplicate key in `JsonBench.BuildObject`, surfaced by `BenchmarksTests.DecodeStringWithEscapes`. The unchanged net10.0 full-suite rerun passed all 917 tests; the randomized fixture was not modified.
- NuGet pack succeeded for net472, netstandard2.0, net8.0 and net10.0. Inspected dependency groups: net8.0/net10.0 empty; net472/netstandard2.0 only `System.Memory >= 4.6.3`.
- Isolated local-package consumers passed interpreted/compiled parsing on .NET 8 and .NET 10. Actual packaged net472 and netstandard2.0 DLLs also passed on a .NET 8 host, with assembly target identity asserted. This is not native .NET Framework execution.
- Consumer checks additionally exercised direct character-map construction/Set, ASCII and Unicode duplicate first-value behavior, sorted unique expected characters, out-of-range lookup, and absence of an Immutable assembly reference below net10.0.

## Performance context

Source-PR measurements only, not measurements of this release branch: BenchmarkDotNet 0.15.8, Apple M4 Pro, .NET 8.0.30, reused-parser lookup microbenchmarks, no per-operation allocations.

| Case | In-process Frozen → Dictionary | Separate-process ShortRun Frozen → Dictionary |
| --- | --- | --- |
| ASCII hit | 4.614 → 4.622 ns | 4.749 → 4.746 ns |
| Unicode hit | 5.614 → 6.709 ns | 5.913 → 5.440 ns |
| Unicode miss | 2.984 → 4.163 ns | 1.870 → 2.725 ns |

ASCII is effectively unchanged; Unicode misses cost about 1 ns more. Unicode hit results disagree by mode, so no reliable hit speedup/regression is claimed. These do not measure construction or end-to-end parsing costs.