### PR TITLE
Expose build context for the source generator IDE guard

### DIFF
--- a/docs/source-generation.md
+++ b/docs/source-generation.md
@@ -62,6 +62,21 @@ in consumer assemblies. It is a result builder, not a general-purpose collection
 - **Return type**: Must return `Parlot.Fluent.Parser<T>`.
 - **Partial class**: The containing class must be `partial`.
 
+## IDE and Design-Time Analysis
+
+Parlot skips parser generation, factory execution, and its generation diagnostics during recognized
+IDE/design-time analysis. The original parser factory remains available without generated interceptors.
+Other generators, such as PolySharp, still run normally in the IDE; Parlot does not load and execute
+them through `[IncludeGenerators]` during these runs.
+
+Command-line builds and explicit builds started inside Visual Studio still generate parsers and
+interceptors. Parlot skips generation when `DesignTimeBuild` is `true`, or when
+`BuildingInsideVisualStudio` is `true` and `BuildingProject` is explicitly `false`.
+Missing property values alone do not disable generation.
+
+The Parlot NuGet package exposes these properties to the compiler through its `buildTransitive` props.
+Keep those package assets enabled so the generator can distinguish live analysis from a real build.
+
 ## Parameterized Parsers
 
 Factory arguments configure a generated parser instance. The generator emits every branch once; the

--- a/src/Parlot/buildTransitive/Parlot.props
+++ b/src/Parlot/buildTransitive/Parlot.props
@@ -13,5 +13,9 @@
 
   <ItemGroup>
     <CompilerVisibleProperty Include="MSBuildProjectDirectory" />
+    <!-- Let the generator distinguish IDE analysis from explicit builds, including builds inside VS. -->
+    <CompilerVisibleProperty Include="DesignTimeBuild" />
+    <CompilerVisibleProperty Include="BuildingProject" />
+    <CompilerVisibleProperty Include="BuildingInsideVisualStudio" />
   </ItemGroup>
 </Project>

--- a/test/Parlot.SourceGenerator.Tests/BuildContextIntegrationTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/BuildContextIntegrationTests.cs
@@ -1,0 +1,266 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Parlot.SourceGenerator.Tests;
+
+public class BuildContextIntegrationTests
+{
+    [Fact]
+    public async Task Package_Exposes_Context_And_Preserves_Build_Edit_Transitions()
+    {
+        var repositoryRoot = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../"));
+        var configuration =
+#if DEBUG
+            "Debug";
+#else
+            "Release";
+#endif
+        var directory = Directory.CreateDirectory(Path.Combine(
+            Path.GetTempPath(), "Parlot.SourceGenerator.Tests", Guid.NewGuid().ToString("N"))).FullName;
+
+        try
+        {
+            var feed = Directory.CreateDirectory(Path.Combine(directory, "feed")).FullName;
+            var packages = Path.Combine(directory, "packages");
+            var version = "0.0.0-buildcontext." + Guid.NewGuid().ToString("N");
+            var project = Path.Combine(directory, "Consumer.csproj");
+            File.Copy(Path.Combine(repositoryRoot, "global.json"), Path.Combine(directory, "global.json"));
+
+            // Pack once from the matching full-build outputs. Never rebuild shared product outputs in this test.
+            await RunDotnet(repositoryRoot, "pack", "src/Parlot/Parlot.csproj", "--no-build", "--no-restore",
+                "--configuration", configuration, "--output", feed, "-p:PackageVersion=" + version,
+                "-p:IncludeSymbols=false", "-p:UseSharedCompilation=false");
+
+            using (var package = ZipFile.OpenRead(Path.Combine(feed, $"Parlot.{version}.nupkg")))
+            {
+                var entry = package.GetEntry("buildTransitive/Parlot.props");
+                Assert.NotNull(entry);
+                using var stream = entry.Open();
+                var props = XDocument.Load(stream);
+                var exposed = props.Descendants("CompilerVisibleProperty").Select(static item => (string)item.Attribute("Include"));
+                Assert.Contains("DesignTimeBuild", exposed);
+                Assert.Contains("BuildingProject", exposed);
+                Assert.Contains("BuildingInsideVisualStudio", exposed);
+            }
+
+            var versions = XDocument.Load(Path.Combine(repositoryRoot, "Directory.Packages.props"));
+            var polySharpVersion = (string)versions.Descendants("GlobalPackageReference")
+                .Single(static item => (string)item.Attribute("Include") == "PolySharp").Attribute("Version");
+            File.WriteAllText(project, ConsumerProject(version, polySharpVersion));
+            var sourcePath = Path.Combine(directory, "Grammar.cs");
+            File.WriteAllText(sourcePath, GrammarSource);
+
+            var cacheOutput = await RunDotnet(repositoryRoot, "nuget", "locals", "global-packages", "--list");
+            const string cachePrefix = "global-packages: ";
+            Assert.StartsWith(cachePrefix, cacheOutput.Trim(), StringComparison.Ordinal);
+            var dependencyCache = cacheOutput.Trim()[cachePrefix.Length..];
+
+            // Keep the unique package isolated, and reuse restored dependencies without network access.
+            await RunDotnet(directory, "restore", project, "--packages", packages,
+                "--source", feed, "-p:RestoreFallbackFolders=" + dependencyCache, "-p:NuGetAudit=false");
+
+            await CheckContext(isBuild: true, designTime: null, insideVisualStudio: null);
+            await CheckContext(isBuild: false, designTime: "true", insideVisualStudio: "true");
+            await CheckContext(isBuild: true, designTime: "false", insideVisualStudio: "true");
+            await CheckContext(isBuild: false, designTime: "false", insideVisualStudio: "true");
+            await CheckContext(isBuild: false, designTime: null, insideVisualStudio: "true");
+            await CheckContext(isBuild: true, designTime: null, insideVisualStudio: null);
+
+            async Task CheckContext(bool isBuild, string designTime, string insideVisualStudio)
+            {
+                var arguments = new List<string>
+                {
+                    "msbuild", project,
+                    isBuild ? "-t:Rebuild;CaptureBuildContext" : "-t:CaptureBuildContext",
+                    "-p:UseSharedCompilation=false", "-verbosity:quiet"
+                };
+                if (!isBuild)
+                {
+                    arguments.Add("-p:SkipCompilerExecution=true");
+                    arguments.Add("-p:ProvideCommandLineArgs=true");
+                }
+                if (designTime is not null)
+                {
+                    arguments.Add("-p:DesignTimeBuild=" + designTime);
+                }
+                if (insideVisualStudio is not null)
+                {
+                    arguments.Add("-p:BuildingInsideVisualStudio=" + insideVisualStudio);
+                }
+
+                await RunDotnet(directory, arguments.ToArray());
+
+                var properties = ReadProperties(Path.Combine(directory, "context.editorconfig"));
+                Assert.Equal(designTime ?? "", properties["build_property.DesignTimeBuild"]);
+                Assert.Equal(insideVisualStudio ?? "", properties["build_property.BuildingInsideVisualStudio"]);
+                Assert.Equal(isBuild ? "true" : "false", properties["build_property.BuildingProject"]);
+
+                var parseOptions = new CSharpParseOptions(LanguageVersion.Preview).WithFeatures(
+                    new[] { new KeyValuePair<string, string>("InterceptorsNamespaces", "Consumer") });
+                var compilation = CSharpCompilation.Create(
+                    "BuildContext" + Guid.NewGuid().ToString("N"),
+                    new[] { CSharpSyntaxTree.ParseText(GrammarSource, parseOptions, sourcePath, Encoding.UTF8) },
+                    File.ReadAllLines(Path.Combine(directory, "references.txt"))
+                        .Select(static path => MetadataReference.CreateFromImage(File.ReadAllBytes(path), filePath: path)),
+                    new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+                // The legacy reference set needs sibling generator output, even when Parlot must not run.
+                Assert.Null(compilation.GetTypeByMetadataName("System.Runtime.CompilerServices.IsExternalInit"));
+                Assert.Contains(compilation.GetDiagnostics(), static d => d.Id == "CS0518");
+                var analyzers = File.ReadAllLines(Path.Combine(directory, "analyzers.txt"));
+                var generatorPath = analyzers.Single(static path => Path.GetFileName(path) == "Parlot.SourceGenerator.dll");
+                var polySharpPath = analyzers.Single(static path => Path.GetFileName(path) == "PolySharp.SourceGenerators.dll");
+                var polySharp = Assembly.LoadFrom(polySharpPath).GetTypes()
+                    .Where(static type => !type.IsAbstract && typeof(IIncrementalGenerator).IsAssignableFrom(type))
+                    .Select(static type => ((IIncrementalGenerator)Activator.CreateInstance(type)).AsSourceGenerator())
+                    .ToArray();
+                Assert.NotEmpty(polySharp);
+
+                var (result, updatedCompilation) = GeneratorDiagnosticsTests.RunGenerator(
+                    compilation, properties, generatorPath, polySharp);
+                Assert.DoesNotContain(result.Diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+                Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+                Assert.NotNull(updatedCompilation.GetTypeByMetadataName("System.Runtime.CompilerServices.IsExternalInit"));
+
+                if (isBuild)
+                {
+                    GeneratorDiagnosticsTests.AssertGeneratedParser(result);
+                    var generatedFile = Assert.Single(Directory.GetFiles(
+                        Path.Combine(directory, "obj", "generated"), "*.Parlot.g.cs", SearchOption.AllDirectories));
+                    Assert.Contains("[global::System.Runtime.CompilerServices.InterceptsLocationAttribute(",
+                        File.ReadAllText(generatedFile), StringComparison.Ordinal);
+                }
+                else
+                {
+                    Assert.Empty(result.Results[0].Diagnostics);
+                    Assert.Empty(result.Results[0].GeneratedSources);
+                }
+            }
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    private static Dictionary<string, string> ReadProperties(string path)
+    {
+        var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var line in File.ReadLines(path))
+        {
+            if (line.StartsWith("build_property.", StringComparison.Ordinal))
+            {
+                var separator = line.IndexOf('=');
+                properties.Add(line[..separator].Trim(), line[(separator + 1)..].Trim());
+            }
+        }
+        return properties;
+    }
+
+    private static async Task<string> RunDotnet(string directory, params string[] arguments)
+    {
+        using var process = new Process
+        {
+            StartInfo = new ProcessStartInfo("dotnet")
+            {
+                WorkingDirectory = directory,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false
+            }
+        };
+        process.StartInfo.Environment["DOTNET_CLI_UI_LANGUAGE"] = "en-US";
+        process.StartInfo.Environment["DOTNET_NOLOGO"] = "true";
+        foreach (var argument in arguments)
+        {
+            process.StartInfo.ArgumentList.Add(argument);
+        }
+
+        Assert.True(process.Start());
+        var output = process.StandardOutput.ReadToEndAsync();
+        var error = process.StandardError.ReadToEndAsync();
+        using var timeout = CancellationTokenSource.CreateLinkedTokenSource(TestContext.Current.CancellationToken);
+        timeout.CancelAfter(TimeSpan.FromMinutes(2));
+        try
+        {
+            await process.WaitForExitAsync(timeout.Token);
+        }
+        catch (OperationCanceledException)
+        {
+            if (!process.HasExited)
+            {
+                process.Kill(entireProcessTree: true);
+            }
+            await process.WaitForExitAsync();
+            throw;
+        }
+
+        var stdout = await output;
+        var stderr = await error;
+        Assert.True(process.ExitCode == 0, $"dotnet {string.Join(" ", arguments)}{Environment.NewLine}{stdout}{stderr}");
+        return stdout;
+    }
+
+    private static string ConsumerProject(string version, string polySharpVersion) => $$"""
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>netstandard2.0</TargetFramework>
+            <LangVersion>latest</LangVersion>
+            <InterceptorsNamespaces>$(InterceptorsNamespaces);Consumer</InterceptorsNamespaces>
+            <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+            <CompilerGeneratedFilesOutputPath>obj/generated</CompilerGeneratedFilesOutputPath>
+          </PropertyGroup>
+          <ItemGroup>
+            <PackageReference Include="Parlot" Version="{{version}}" />
+            <PackageReference Include="PolySharp" Version="{{polySharpVersion}}" PrivateAssets="all" />
+          </ItemGroup>
+          <Target Name="CaptureBuildContext" DependsOnTargets="Compile">
+            <Copy SourceFiles="$(GeneratedMSBuildEditorConfigFile)" DestinationFiles="context.editorconfig" />
+            <WriteLinesToFile File="references.txt" Lines="@(ReferencePathWithRefAssemblies)" Overwrite="true" />
+            <WriteLinesToFile File="analyzers.txt" Lines="@(Analyzer)" Overwrite="true" />
+          </Target>
+        </Project>
+        """;
+
+    private const string GrammarSource = """
+        using Parlot.Fluent;
+        using Parlot.SourceGenerator;
+
+        namespace Consumer;
+
+        internal readonly record struct ParserKey(
+            bool AllowCharValues,
+            bool DisallowSingleEquals,
+            FloatingPointNumberType FloatingPointNumberType,
+            IntegerNumberType IntegerNumberType,
+            ArgumentSeparator ArgumentSeparator);
+
+        internal enum FloatingPointNumberType { Double }
+        internal enum IntegerNumberType { Int32 }
+        internal enum ArgumentSeparator { Comma }
+
+        internal static partial class Grammar
+        {
+            [GenerateParser]
+            [IncludeUsings("Consumer")]
+            [IncludeGenerators("PolySharp")]
+            private static Parser<string> CreateParserGrammar(ParserKey key) => Parsers.Terms.Text("ok");
+
+            private static Parser<string> CreateParser() => CreateParserGrammar(new ParserKey());
+
+            public static string Parse(string text) => CreateParser().Parse(text);
+        }
+        """;
+}

--- a/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/GeneratorDiagnosticsTests.cs
@@ -403,6 +403,105 @@ public static partial class VisualStudioGrammar
         Assert.Empty(result.Results.SelectMany(r => r.GeneratedSources));
     }
 
+    public static TheoryData<string, string, string, bool> BuildContexts
+    {
+        get
+        {
+            var data = new TheoryData<string, string, string, bool>();
+            var values = new[] { null, "false", "true" };
+
+            foreach (var designTimeBuild in values)
+            {
+                foreach (var buildingProject in values)
+                {
+                    foreach (var buildingInsideVisualStudio in values)
+                    {
+                        data.Add(designTimeBuild, buildingProject, buildingInsideVisualStudio,
+                            designTimeBuild == "true"
+                            || (buildingInsideVisualStudio == "true" && buildingProject == "false"));
+                    }
+                }
+            }
+
+            data.Add("", "", "", false);
+            data.Add("invalid", "true", "true", false);
+            data.Add("false", "", "true", false);
+            data.Add("false", "invalid", "true", false);
+            data.Add("false", "false", "invalid", false);
+            data.Add(" TRUE ", "true", "false", true);
+            data.Add("", " FALSE ", "TrUe", true);
+            data.Add("invalid", "false", "true", true);
+
+            return data;
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(BuildContexts))]
+    public void Build_Context_Preserves_Explicit_Builds(
+        string designTimeBuild,
+        string buildingProject,
+        string buildingInsideVisualStudio,
+        bool shouldSkip)
+    {
+        const string source = """
+            using Parlot.SourceGenerator;
+            using Parlot.Fluent;
+
+            namespace Parlot.SourceGenerator.Tests;
+
+            internal static partial class BuildContextGrammar
+            {
+                [GenerateParser]
+                private static Parser<string> Create() => Parsers.Terms.Text("ok");
+
+                public static Parser<string> Parser() => Create();
+            }
+            """;
+
+        var options = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        AddProperty("DesignTimeBuild", designTimeBuild);
+        AddProperty("BuildingProject", buildingProject);
+        AddProperty("BuildingInsideVisualStudio", buildingInsideVisualStudio);
+
+        var (result, updatedCompilation) = RunGenerator(
+            source,
+            "BuildContext" + Guid.NewGuid().ToString("N"),
+            options,
+            sourcePath: "BuildContextGrammar.cs",
+            interceptorsNamespace: "Parlot.SourceGenerator.Tests");
+
+        Assert.DoesNotContain(result.Diagnostics, static d => d.Severity == DiagnosticSeverity.Error);
+        Assert.DoesNotContain(updatedCompilation.GetDiagnostics(), static d => d.Severity == DiagnosticSeverity.Error);
+
+        if (shouldSkip)
+        {
+            Assert.Empty(result.Diagnostics);
+            Assert.Empty(result.Results.SelectMany(static r => r.GeneratedSources));
+        }
+        else
+        {
+            AssertGeneratedParser(result);
+        }
+
+        void AddProperty(string name, string value)
+        {
+            if (value is not null)
+            {
+                options["build_property." + name] = value;
+            }
+        }
+    }
+
+    internal static void AssertGeneratedParser(GeneratorDriverRunResult result)
+    {
+        var source = Assert.Single(result.Results[0].GeneratedSources,
+            static s => s.HintName.EndsWith(".Parlot.g.cs", StringComparison.Ordinal));
+        Assert.Contains("GeneratedParser_", source.SourceText.ToString(), StringComparison.Ordinal);
+        Assert.Contains("[global::System.Runtime.CompilerServices.InterceptsLocationAttribute(",
+            source.SourceText.ToString(), StringComparison.Ordinal);
+    }
+
     [Fact]
     public void IncludeFiles_Allows_Contained_Parent_Path()
     {
@@ -660,9 +759,16 @@ public static partial class VisualStudioGrammar
         string source,
         string assemblyName,
         IReadOnlyDictionary<string, string> globalOptions = null,
-        string sourcePath = "")
+        string sourcePath = "",
+        string interceptorsNamespace = null)
     {
         var parseOptions = new CSharpParseOptions(LanguageVersion.Preview);
+        if (interceptorsNamespace is not null)
+        {
+            parseOptions = parseOptions.WithFeatures(
+                new[] { new KeyValuePair<string, string>("InterceptorsNamespaces", interceptorsNamespace) });
+        }
+
         var syntaxTree = CSharpSyntaxTree.ParseText(source, parseOptions, sourcePath);
 
         var references = new List<MetadataReference>();
@@ -692,16 +798,29 @@ public static partial class VisualStudioGrammar
             references: references,
             options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
+        return RunGenerator(compilation, globalOptions);
+    }
+
+    internal static (GeneratorDriverRunResult result, CSharpCompilation updatedCompilation) RunGenerator(
+        CSharpCompilation compilation,
+        IReadOnlyDictionary<string, string> globalOptions,
+        string generatorPath = null,
+        IEnumerable<ISourceGenerator> additionalGenerators = null)
+    {
         var config = 
 #if DEBUG
             "Debug";
 #else
             "Release";
 #endif
-        var generatorPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/Parlot.SourceGenerator/bin", config, "netstandard2.0/Parlot.SourceGenerator.dll"));
+        var isPackagedGenerator = generatorPath is not null;
+        generatorPath ??= Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "../../../../../src/Parlot.SourceGenerator/bin", config, "netstandard2.0/Parlot.SourceGenerator.dll"));
         Assert.True(File.Exists(generatorPath), $"Generator assembly not found at {generatorPath}");
 
-        var generatorAssembly = Assembly.LoadFrom(generatorPath);
+        // Avoid reusing a same-identity assembly or locking a temporary package on Windows.
+        var generatorAssembly = isPackagedGenerator
+            ? Assembly.Load(File.ReadAllBytes(generatorPath))
+            : Assembly.LoadFrom(generatorPath);
         var generatorType = generatorAssembly.GetType("Parlot.SourceGenerator.ParserSourceGenerator", throwOnError: true)!;
         var generator = (IIncrementalGenerator)Activator.CreateInstance(generatorType)!;
 
@@ -710,7 +829,9 @@ public static partial class VisualStudioGrammar
             ? null
             : new TestAnalyzerConfigOptionsProvider(globalOptions);
 
-        var driver = CSharpGeneratorDriver.Create(new[] { sourceGenerator }, parseOptions: parseOptions, optionsProvider: optionsProvider)
+        var generators = new[] { sourceGenerator }.Concat(additionalGenerators ?? Array.Empty<ISourceGenerator>());
+        var parseOptions = (CSharpParseOptions)compilation.SyntaxTrees.First().Options;
+        var driver = CSharpGeneratorDriver.Create(generators, parseOptions: parseOptions, optionsProvider: optionsProvider)
             .RunGeneratorsAndUpdateCompilation(compilation, out var updatedCompilation, out var generatorDiagnostics);
 
         return (driver.GetRunResult(), (CSharpCompilation)updatedCompilation);


### PR DESCRIPTION
Parlot's existing IDE guard reads three MSBuild properties that its NuGet package does not make compiler-visible. This lets design-time analysis run factory execution and internal compilation despite the intended no-op policy, as investigated following the emit failure reported in [ncalc/ncalc#533](https://github.com/ncalc/ncalc/pull/533#issuecomment-5574811281).

## Approach

- Export `DesignTimeBuild`, `BuildingProject`, and `BuildingInsideVisualStudio` unconditionally through the packaged `buildTransitive` props. MSBuild evaluates their values at compilation time; the change does not assign defaults or freeze `BuildingProject` during project evaluation.
- Preserve the existing predicate and generator loader. CLI builds and explicit builds inside Visual Studio still generate parsers.
- Add 35 property-matrix cases and a real-package/MSBuild regression covering a legacy-target record, sibling PolySharp output, and six build/edit transitions. The package test failed against the old props and passes with these exports. Each fixture packs once, uses a unique unpublished version, and keeps candidate packages in temporary storage without replacing published cache entries.
- Document design-time behavior and the required package assets.

## Validation

- SDK 10.0.400: all-TFM build, all 1,646 Parlot test cases across net8.0/net10.0, and all 362 source-generator cases pass. Repository SDK and Roslyn 5.6.0 dependency settings are unchanged.
- SDK 11 RC: all 362 source-generator cases pass. Two unchanged decimal-expectation tests fail on each runtime TFM; the identical failures were reproduced on untouched commit `94fef136` with the same SDK/configuration.
- Builds use `UseSharedCompilation=false` and the local `WarningsNotAsErrors=CA1860` override for the existing sample warning. Repository warning settings and unrelated code remain unchanged.
- A locally packed candidate builds for net462, netstandard2.0, net8.0, and net10.0 under both CLI and explicit-VS build flags. Its actual design-time editorconfig produces no Parlot sources or diagnostics. Compiled modern/netstandard consumers use generated parsers and correctly accept/reject input.

## Remaining Windows acceptance

The missing-property defect is confirmed. A controlled Roslyn loader mismatch reproduces the reported five-line `IsExternalInit` internal emit error even while sibling PolySharp makes the final compilation valid; this does **not** establish the reporter's precise VS 2026 loader state.

Actual VS 2026 solution-load, edit, build, edit-again, and target-framework-switch confirmation remains pending on Windows. This PR does not change NCalc, add a handwritten polyfill, suppress emit errors, or redesign generator loading.