### PR TITLE
Reduce allocations in source-generated string parsers

### DIFF
--- a/docs/source-generation.md
+++ b/docs/source-generation.md
@@ -453,3 +453,9 @@ retain their own inlining hints.
 
 Measure representative grammars. Result models and callbacks can still allocate, and conversions such as
 `TextSpan.ToString()` intentionally create application-owned strings when the public result requires them.
+
+Custom string delimiters use the scanner's single-character overload without allocating a delimiter array
+per token. When `Capture` discards a string parser's decoded value, the generated parser still validates
+escape sequences but skips decoding and its string allocation. Callbacks and predicates that consume the
+value still receive decoded text and execute normally, even when their result is captured or discarded.
+Helpers are specialized by result mode so the same parser can be used both for capture and for its value.

--- a/src/Parlot/Fluent/Capture.cs
+++ b/src/Parlot/Fluent/Capture.cs
@@ -72,16 +72,10 @@ public sealed class Capture<T> : Parser<TextSpan>, ISeekable, ISourceable
         
         result.Body.Add($"var {startName} = {cursorName}.Position;");
 
-        // Set DiscardResult to true for the inner parser, as we only care about whether it succeeds
-        var ignoreResults = context.DiscardResult;
-        context.DiscardResult = true;
-
         // Use helper instead of inlining
-        var helperName = context.Helpers
+        var helperName = context.WithDiscardResult(true, () => context.Helpers
             .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_Capture", innerValueTypeName, () => sourceable.GenerateSource(context))
-            .MethodName;
-
-        context.DiscardResult = ignoreResults;
+            .MethodName);
 
         // if (Helper(context, out _))
         // {

--- a/src/Parlot/Fluent/LeftAssociative.cs
+++ b/src/Parlot/Fluent/LeftAssociative.cs
@@ -89,6 +89,12 @@ public sealed class LeftAssociative<T, TInput> : Parser<T>, ISourceable
     {
         ThrowHelper.ThrowIfNull(context, nameof(context));
 
+        // Each callback needs the accumulated value, even if the final value is discarded.
+        if (context.DiscardResult)
+        {
+            return context.WithDiscardResult(false, () => GenerateSource(context));
+        }
+
         if (_parser is not ISourceable parserSourceable)
         {
             throw new NotSupportedException("LeftAssociative requires the base parser to be source-generatable.");
@@ -286,6 +292,11 @@ public sealed class LeftAssociativeWithContext<T, TInput> : Parser<T>, ISourceab
     public SourceResult GenerateSource(SourceGenerationContext context)
     {
         ThrowHelper.ThrowIfNull(context, nameof(context));
+
+        if (context.DiscardResult)
+        {
+            return context.WithDiscardResult(false, () => GenerateSource(context));
+        }
 
         if (_parser is not ISourceable parserSourceable)
         {

--- a/src/Parlot/Fluent/StringLiteral.cs
+++ b/src/Parlot/Fluent/StringLiteral.cs
@@ -1,7 +1,6 @@
 using Parlot.Rewriting;
 using Parlot.SourceGeneration;
 using System;
-using System.Linq;
 using System.Reflection;
 
 namespace Parlot.Fluent;
@@ -110,7 +109,10 @@ public sealed class StringLiteral : Parser<TextSpan>, ISeekable, ISourceable
         var startName = $"start{context.NextNumber()}";
         var endName = $"end{context.NextNumber()}";
 
-        result.Body.Add($"var {startName} = {cursorName}.Offset;");
+        if (!context.DiscardResult)
+        {
+            result.Body.Add($"var {startName} = {cursorName}.Offset;");
+        }
 
         // Generate the appropriate read method call based on quote type
         var readMethod = _quotes switch
@@ -119,15 +121,18 @@ public sealed class StringLiteral : Parser<TextSpan>, ISeekable, ISourceable
             StringLiteralQuotes.Double => $"{scannerName}.ReadDoubleQuotedString()",
             StringLiteralQuotes.SingleOrDouble => $"{scannerName}.ReadQuotedString()",
             StringLiteralQuotes.Backtick => $"{scannerName}.ReadBacktickString()",
-            StringLiteralQuotes.Custom => $"{scannerName}.ReadQuotedString(new char[] {{ {string.Join(", ", ExpectedChars.Select(c => $"'{c}'"))} }})",
+            StringLiteralQuotes.Custom => $"{scannerName}.ReadQuotedString((char){(int)ExpectedChars[0]}, out _)",
             _ => throw new InvalidOperationException()
         };
 
         result.Body.Add($"if ({readMethod})");
         result.Body.Add("{");
-        result.Body.Add($"    var {endName} = {cursorName}.Offset;");
         result.Body.Add($"    {result.SuccessVariable} = true;");
-        result.Body.Add($"    {result.ValueVariable} = global::Parlot.Character.DecodeString({scannerName}.Buffer, {startName} + 1, {endName} - {startName} - 2);");
+        if (!context.DiscardResult)
+        {
+            result.Body.Add($"    var {endName} = {cursorName}.Offset;");
+            result.Body.Add($"    {result.ValueVariable} = global::Parlot.Character.DecodeString({scannerName}.Buffer, {startName} + 1, {endName} - {startName} - 2);");
+        }
         result.Body.Add("}");
 
         return result;

--- a/src/Parlot/Fluent/Switch.cs
+++ b/src/Parlot/Fluent/Switch.cs
@@ -90,9 +90,9 @@ public sealed class Switch<T, U> : Parser<U>, ISourceable
         var valueTypeName = SourceGenerationContext.GetTypeName(typeof(U));
 
         // Use helper instead of inlining
-        var helperName = context.Helpers
+        var helperName = context.WithDiscardResult(false, () => context.Helpers
             .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_Switch", previousValueTypeName, () => sourceable.GenerateSource(context))
-            .MethodName;
+            .MethodName);
 
         // Register the selector lambda
         var selectorLambda = context.RegisterLambda(_selector);

--- a/src/Parlot/Fluent/Then.cs
+++ b/src/Parlot/Fluent/Then.cs
@@ -126,9 +126,10 @@ public sealed class Then<T, U> : Parser<U>, ISeekable, ISourceable
 
         var innerValueTypeName = SourceGenerationContext.GetTypeName(GetParserValueType(sourceable));
         var helperKey = $"{context.MethodNamePrefix}_Then_{context.NextNumber()}";
-        var helperName = context.Helpers
+        // The callback still consumes the inner value when its own result is discarded.
+        var helperName = context.WithDiscardResult(false, () => context.Helpers
             .GetOrCreate(sourceable, helperKey, innerValueTypeName, () => sourceable.GenerateSource(context))
-            .MethodName;
+            .MethodName);
 
         result.Body.Add($"if ({helperName}({ctx}, out var {parsedName}Value))");
         result.Body.Add("{");

--- a/src/Parlot/Fluent/Unary.cs
+++ b/src/Parlot/Fluent/Unary.cs
@@ -86,6 +86,12 @@ public sealed class Unary<T, TInput> : Parser<T>, ISourceable
     {
         ThrowHelper.ThrowIfNull(context, nameof(context));
 
+        // Recursive callbacks must receive the value produced by the inner operator.
+        if (context.DiscardResult)
+        {
+            return context.WithDiscardResult(false, () => GenerateSource(context));
+        }
+
         if (_parser is not ISourceable parserSourceable)
         {
             throw new NotSupportedException("Unary requires the base parser to be source-generatable.");
@@ -279,6 +285,11 @@ public sealed class UnaryWithContext<T, TInput> : Parser<T>, ISourceable
     public SourceResult GenerateSource(SourceGenerationContext context)
     {
         ThrowHelper.ThrowIfNull(context, nameof(context));
+
+        if (context.DiscardResult)
+        {
+            return context.WithDiscardResult(false, () => GenerateSource(context));
+        }
 
         if (_parser is not ISourceable parserSourceable)
         {

--- a/src/Parlot/Fluent/When.cs
+++ b/src/Parlot/Fluent/When.cs
@@ -79,9 +79,9 @@ public sealed class When<T> : Parser<T>, ISeekable, ISourceable
         result.Body.Add($"var {startName} = {cursorName}.Position;");
 
         // Use helper instead of inlining
-        var helperName = context.Helpers
+        var helperName = context.WithDiscardResult(false, () => context.Helpers
             .GetOrCreate(sourceable, $"{context.MethodNamePrefix}_When", valueTypeName, () => sourceable.GenerateSource(context))
-            .MethodName;
+            .MethodName);
 
         // Register the action lambda
         var lambdaId = context.RegisterLambda(_action);

--- a/src/Parlot/SourceGeneration/ParserHelperRegistry.cs
+++ b/src/Parlot/SourceGeneration/ParserHelperRegistry.cs
@@ -9,8 +9,21 @@ namespace Parlot.SourceGeneration;
 /// </summary>
 public sealed class ParserHelperRegistry
 {
-    private readonly Dictionary<object, HelperEntry> _helpers = new();
+    private readonly Dictionary<(object Parser, bool DiscardResult), HelperEntry> _helpers = new();
+    private readonly SourceGenerationContext? _context;
     private int _nextId;
+
+    /// <summary>
+    /// Creates a registry for value-producing parser helpers.
+    /// </summary>
+    public ParserHelperRegistry()
+    {
+    }
+
+    internal ParserHelperRegistry(SourceGenerationContext context)
+    {
+        _context = context;
+    }
 
     public (string MethodName, string ValueTypeName, SourceResult Result, string? ParserName) GetOrCreate(
         object parser,
@@ -18,7 +31,8 @@ public sealed class ParserHelperRegistry
         string valueTypeName,
         Func<SourceResult> resultFactory)
     {
-        if (!_helpers.TryGetValue(parser, out var entry))
+        var key = (parser, _context?.DiscardResult ?? false);
+        if (!_helpers.TryGetValue(key, out var entry))
         {
             var methodName = suggestedName + "_" + _nextId++;
             var result = resultFactory();
@@ -32,7 +46,7 @@ public sealed class ParserHelperRegistry
             }
             
             entry = new HelperEntry(methodName, valueTypeName, result, parserName);
-            _helpers[parser] = entry;
+            _helpers[key] = entry;
         }
 
         return (entry.MethodName, entry.ValueTypeName, entry.Result, entry.ParserName);

--- a/src/Parlot/SourceGeneration/SourceGenerationContext.cs
+++ b/src/Parlot/SourceGeneration/SourceGenerationContext.cs
@@ -33,7 +33,7 @@ public sealed class SourceGenerationContext
         TargetFramework = targetFramework ?? TargetFrameworkInfo.Unknown;
         CSharpLanguageMajorVersion = csharpLanguageMajorVersion;
 
-        Helpers = new ParserHelperRegistry();
+        Helpers = new ParserHelperRegistry(this);
     }
 
     /// <summary>
@@ -113,7 +113,7 @@ public sealed class SourceGenerationContext
     public DeferredRegistry Deferred { get; } = new();
 
     /// <summary>
-    /// Registry of helper parser methods (e.g., OneOf buckets) to emit once per descriptor.
+    /// Registry of helper parser methods (e.g., OneOf buckets) to emit once per descriptor and result mode.
     /// </summary>
     public ParserHelperRegistry Helpers { get; }
 
@@ -123,8 +123,23 @@ public sealed class SourceGenerationContext
     /// <remarks>
     /// When set to true, the generated statements don't need to record and define the result value.
     /// This is done to optimize generated parsers that are usually used for pattern matching only (e.g., Capture).
+    /// Inputs consumed by callbacks must still be generated with this flag set to false.
     /// </remarks>
     public bool DiscardResult { get; set; }
+
+    internal TResult WithDiscardResult<TResult>(bool discardResult, Func<TResult> action)
+    {
+        var previous = DiscardResult;
+        DiscardResult = discardResult;
+        try
+        {
+            return action();
+        }
+        finally
+        {
+            DiscardResult = previous;
+        }
+    }
 
     /// <summary>
     /// Returns a new unique number for the current compilation.

--- a/test/Parlot.Benchmarks/GeneratedStringBenchmarks.cs
+++ b/test/Parlot.Benchmarks/GeneratedStringBenchmarks.cs
@@ -1,0 +1,39 @@
+using System;
+using BenchmarkDotNet.Attributes;
+
+namespace Parlot.Benchmarks;
+
+[MemoryDiagnoser, ShortRunJob]
+public partial class GeneratedStringBenchmarks
+{
+    [Params("%hello%", "%hello\\nworld%")]
+    public string Input { get; set; }
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        if (!TryParseCaptured(Input, out var captured) || captured != Input.Length
+            || !TryParseDecoded(Input, out var decoded) || decoded != (Input.Contains("\\n", StringComparison.Ordinal) ? 11 : 5)
+            || TryParseCaptured("%unterminated", out _) || TryParseDecoded("%unterminated", out _))
+        {
+            throw new InvalidOperationException("Unexpected generated string result.");
+        }
+    }
+
+    [Benchmark]
+    public int Captured()
+    {
+        _ = TryParseCaptured(Input, out var value);
+        return value;
+    }
+
+    [Benchmark]
+    public int Decoded()
+    {
+        _ = TryParseDecoded(Input, out var value);
+        return value;
+    }
+
+    private static partial bool TryParseCaptured(string input, out int value);
+    private static partial bool TryParseDecoded(string input, out int value);
+}

--- a/test/Parlot.Benchmarks/GeneratedStringBenchmarks.parlot.cs
+++ b/test/Parlot.Benchmarks/GeneratedStringBenchmarks.parlot.cs
@@ -1,0 +1,16 @@
+using Parlot.Fluent;
+using Parlot.SourceGenerator;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.Benchmarks;
+
+public partial class GeneratedStringBenchmarks
+{
+    [GenerateParser(nameof(TryParseCaptured))]
+    private static Parser<int> BuildCaptured() =>
+        Capture(new StringLiteral('%')).Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseDecoded))]
+    private static Parser<int> BuildDecoded() =>
+        new StringLiteral('%').Then(static span => span.Length).Eof();
+}

--- a/test/Parlot.SourceGenerator.Tests/SourceableParsersTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/SourceableParsersTests.cs
@@ -10,6 +10,56 @@ namespace Parlot.SourceGenerator.Tests;
 
 public class SourceableParsersTests
 {
+    [Theory]
+    [InlineData('%')]
+    [InlineData('\\')]
+    [InlineData('\n')]
+    [InlineData('\r')]
+    [InlineData('\0')]
+    [InlineData('\u2028')]
+    public void Custom_String_Emitter_Uses_The_Scalar_Quote_Overload(char quote)
+    {
+        var source = Generate(new StringLiteral(quote));
+        var generated = string.Join(Environment.NewLine, source.Body);
+
+        Assert.Contains($"scanner.ReadQuotedString((char){(int)quote}, out _)", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("new char[]", generated, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void String_Helpers_Are_Cached_Per_Result_Mode(bool discardFirst)
+    {
+        var context = new SourceGenerationContext { DiscardResult = discardFirst };
+        var parser = new StringLiteral('%');
+        var valueType = SourceGenerationContext.GetTypeName(typeof(TextSpan));
+        var first = context.Helpers.GetOrCreate(parser, "String", valueType, () => parser.GenerateSource(context));
+
+        context.DiscardResult = !discardFirst;
+        var second = context.Helpers.GetOrCreate(parser, "String", valueType, () => parser.GenerateSource(context));
+
+        Assert.NotEqual(first.MethodName, second.MethodName);
+        Assert.Equal(!discardFirst, first.Result.Body.Any(static line => line.Contains("DecodeString", StringComparison.Ordinal)));
+        Assert.Equal(discardFirst, second.Result.Body.Any(static line => line.Contains("DecodeString", StringComparison.Ordinal)));
+
+        context.DiscardResult = discardFirst;
+        var repeated = context.Helpers.GetOrCreate(parser, "String", valueType, () => parser.GenerateSource(context));
+        Assert.Equal(first.MethodName, repeated.MethodName);
+        Assert.Same(first.Result, repeated.Result);
+        Assert.Equal(2, context.Helpers.Enumerate().Count());
+    }
+
+    [Fact]
+    public void Capture_Restores_Result_Mode_When_Inner_Emission_Throws()
+    {
+        var context = new SourceGenerationContext();
+        var parser = Capture(new ThrowingSourceableParser());
+
+        Assert.Throws<NotSupportedException>(() => Assert.IsAssignableFrom<ISourceable>(parser).GenerateSource(context));
+        Assert.False(context.DiscardResult);
+    }
+
     [Fact]
     public void Text_Emitter_Produces_A_Direct_Cursor_Check()
     {
@@ -90,6 +140,15 @@ public class SourceableParsersTests
     private sealed class RuntimeOnlyParser : Parser<char>
     {
         public override bool Parse(ParseContext context, ref ParseResult<char> result) => false;
+    }
+
+    private sealed class ThrowingSourceableParser : Parser<char>, ISourceable
+    {
+        public override bool Parse(ParseContext context, ref ParseResult<char> result) =>
+            throw new NotSupportedException();
+
+        public SourceResult GenerateSource(SourceGenerationContext context) =>
+            throw new NotSupportedException();
     }
 
     private sealed class TestLongNumberLiteral : NumberLiteralBase<long>

--- a/test/Parlot.SourceGenerator.Tests/StringParserTests.cs
+++ b/test/Parlot.SourceGenerator.Tests/StringParserTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Parlot.SourceGenerator.Tests;
+
+public class StringParserTests
+{
+    [Theory]
+    [InlineData("'hello\\nworld'")]
+    [InlineData("\"hello\\u0041\"")]
+    public void Standard_Quoted_Strings_Can_Be_Captured_Without_Decoding(string input)
+    {
+        Assert.True(StringGrammars.TryParseCapturedStandard(input, out var length));
+        Assert.Equal(input.Length, length);
+    }
+
+    [Theory]
+    [InlineData("%%", "")]
+    [InlineData("%hello%", "hello")]
+    [InlineData("  %hello\\nworld%", "hello\nworld")]
+    [InlineData("%\\u0041\\x42%", "AB")]
+    public void Custom_Strings_Are_Decoded_Only_When_Returned(string input, string expected)
+    {
+        Assert.True(StringGrammars.TryParseDecoded(input, out var decoded));
+        Assert.Equal(expected, decoded);
+        Assert.True(StringGrammars.TryParseCaptured(input, out var length));
+        Assert.Equal(input.Length, length);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("'hello'")]
+    [InlineData("%unterminated")]
+    [InlineData("%hello%trailing")]
+    [InlineData("%bad\\q%")]
+    [InlineData("%bad\\u12%")]
+    [InlineData("%bad\\x%")]
+    public void Captured_And_Decoded_Strings_Reject_Invalid_Input(string input)
+    {
+        Assert.False(StringGrammars.TryParseDecoded(input, out var decoded));
+        Assert.Null(decoded);
+        Assert.False(StringGrammars.TryParseCaptured(input, out var length));
+        Assert.Equal(0, length);
+    }
+
+    [Theory]
+    [InlineData("  %bad\\q%")]
+    [InlineData("  %bad\\u12%")]
+    [InlineData("  %unterminated")]
+    [InlineData("  %hello%?")]
+    public void Failed_Captured_Strings_Restore_Input_For_The_Next_Alternative(string input)
+    {
+        Assert.True(StringGrammars.TryParseFallback(input, out var value));
+        Assert.Equal(input, value);
+    }
+
+    [Fact]
+    public void Shared_String_Parsers_Work_In_Both_Result_Mode_Orders()
+    {
+        Assert.True(StringGrammars.TryParseCapturedThenDecoded("%a\\n% %b\\t%", out var captureFirst));
+        Assert.Equal(("%a\\n%", "b\t"), captureFirst);
+        Assert.True(StringGrammars.TryParseDecodedThenCaptured("%a\\n% %b\\t%", out var decodeFirst));
+        Assert.Equal(("a\n", " %b\\t%"), decodeFirst);
+    }
+
+    [Theory]
+    [InlineData("Value")]
+    [InlineData("Context")]
+    [InlineData("Span")]
+    public void Captured_Then_Callbacks_Receive_Decoded_Values_And_Still_Run(string overload)
+    {
+        const string input = "%hello\\nworld%";
+        var state = new StringCallbackState();
+        var length = 0;
+        var success = overload switch
+        {
+            "Value" => StringGrammars.TryParseCapturedThen(input, state, out length),
+            "Context" => StringGrammars.TryParseCapturedThenContext(input, state, out length),
+            _ => StringGrammars.TryParseCapturedThenSpan(input, state, out length)
+        };
+
+        Assert.True(success);
+        Assert.Equal(input.Length, length);
+        Assert.Equal("hello\nworld", Assert.Single(state.Values));
+    }
+
+    [Fact]
+    public void Captured_Callback_Exceptions_Still_Propagate()
+    {
+        var state = new StringCallbackState { Throw = true };
+        Assert.Throws<InvalidOperationException>(() =>
+            StringGrammars.TryParseCapturedThen("%hello%", state, out _));
+    }
+
+    [Fact]
+    public void Captured_Predicates_And_Selectors_Receive_Decoded_Values()
+    {
+        Assert.True(StringGrammars.TryParseCapturedWhen("%a\\n%", out var length));
+        Assert.Equal(5, length);
+        Assert.False(StringGrammars.TryParseCapturedWhen("%other%", out _));
+        Assert.True(StringGrammars.TryParseCapturedSwitch("%a\\n%!", out length));
+        Assert.Equal(6, length);
+        Assert.False(StringGrammars.TryParseCapturedSwitch("%a\\n%?", out _));
+        Assert.True(StringGrammars.TryParseCapturedSwitch("%other%?", out _));
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void Captured_Operator_Callbacks_Receive_Intermediate_Values(bool withContext)
+    {
+        const string binary = "%a\\n%+%b%+%c%";
+        const string unary = "!!%a\\n%";
+        int binaryLength;
+        int unaryLength;
+        if (withContext)
+        {
+            Assert.True(StringGrammars.TryParseCapturedLeftAssociativeContext(binary, out binaryLength));
+            Assert.True(StringGrammars.TryParseCapturedUnaryContext(unary, out unaryLength));
+        }
+        else
+        {
+            Assert.True(StringGrammars.TryParseCapturedLeftAssociative(binary, out binaryLength));
+            Assert.True(StringGrammars.TryParseCapturedUnary(unary, out unaryLength));
+        }
+
+        Assert.Equal(binary.Length, binaryLength);
+        Assert.Equal(unary.Length, unaryLength);
+    }
+}
+
+public static partial class StringGrammars
+{
+    public static partial bool TryParseDecoded(string text, out string value);
+    public static partial bool TryParseCaptured(string text, out int value);
+    public static partial bool TryParseCapturedStandard(string text, out int value);
+    public static partial bool TryParseFallback(string text, out string value);
+    public static partial bool TryParseCapturedThenDecoded(string text, out (string, string) value);
+    public static partial bool TryParseDecodedThenCaptured(string text, out (string, string) value);
+    public static partial bool TryParseCapturedThen(string text, StringCallbackState state, out int value);
+    public static partial bool TryParseCapturedThenContext(string text, StringCallbackState state, out int value);
+    public static partial bool TryParseCapturedThenSpan(string text, StringCallbackState state, out int value);
+    public static partial bool TryParseCapturedWhen(string text, out int value);
+    public static partial bool TryParseCapturedSwitch(string text, out int value);
+    public static partial bool TryParseCapturedLeftAssociative(string text, out int value);
+    public static partial bool TryParseCapturedLeftAssociativeContext(string text, out int value);
+    public static partial bool TryParseCapturedUnary(string text, out int value);
+    public static partial bool TryParseCapturedUnaryContext(string text, out int value);
+}
+
+public sealed class StringCallbackState
+{
+    public List<string> Values { get; } = [];
+    public bool Throw { get; init; }
+
+    public int Record(string value)
+    {
+        if (Throw)
+        {
+            throw new InvalidOperationException("Callback failed.");
+        }
+
+        Values.Add(value);
+        return value.Length;
+    }
+}
+
+public static class StringParserCallbacks
+{
+    public static string Combine(string left, string right)
+    {
+        if ((left, right) is not ("a\n", "b") and not ("a\nb", "c"))
+        {
+            throw new InvalidOperationException("Incorrect accumulated value.");
+        }
+
+        return left + right;
+    }
+
+    public static string Prefix(string value)
+    {
+        if (value is not "a\n" and not "!a\n")
+        {
+            throw new InvalidOperationException("Incorrect recursive value.");
+        }
+
+        return "!" + value;
+    }
+}

--- a/test/Parlot.SourceGenerator.Tests/StringParserTests.parlot.cs
+++ b/test/Parlot.SourceGenerator.Tests/StringParserTests.parlot.cs
@@ -1,0 +1,94 @@
+using Parlot;
+using Parlot.Fluent;
+using Parlot.SourceGenerator;
+using static Parlot.Fluent.Parsers;
+
+namespace Parlot.SourceGenerator.Tests;
+
+public static partial class StringGrammars
+{
+    [GenerateParser(nameof(TryParseDecoded))]
+    private static Parser<string> BuildDecoded() =>
+        SkipWhiteSpace(new StringLiteral('%')).Then(static span => span.ToString()).Eof();
+
+    [GenerateParser(nameof(TryParseCaptured))]
+    private static Parser<int> BuildCaptured() =>
+        Capture(SkipWhiteSpace(new StringLiteral('%'))).Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedStandard))]
+    private static Parser<int> BuildCapturedStandard() =>
+        Capture(Literals.String()).Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseFallback))]
+    private static Parser<string> BuildFallback() =>
+        Capture(SkipWhiteSpace(new StringLiteral('%'))).AndSkip(Literals.Char('!'))
+            .Then(static span => span.ToString())
+            .Or(Literals.Pattern(static _ => true).Then(static span => span.ToString()))
+            .Eof();
+
+    [GenerateParser(nameof(TryParseCapturedThenDecoded))]
+    private static Parser<(string, string)> BuildCapturedThenDecoded()
+    {
+        var text = SkipWhiteSpace(new StringLiteral('%'));
+        return Capture(text).And(text)
+            .Then(static pair => (pair.Item1.ToString(), pair.Item2.ToString())).Eof();
+    }
+
+    [GenerateParser(nameof(TryParseDecodedThenCaptured))]
+    private static Parser<(string, string)> BuildDecodedThenCaptured()
+    {
+        var text = SkipWhiteSpace(new StringLiteral('%'));
+        return text.And(Capture(text))
+            .Then(static pair => (pair.Item1.ToString(), pair.Item2.ToString())).Eof();
+    }
+
+    [GenerateParser(nameof(TryParseCapturedThen))]
+    private static Parser<int> BuildCapturedThen(StringCallbackState state) =>
+        Capture(new StringLiteral('%').Then(span => state.Record(span.ToString())))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedThenContext))]
+    private static Parser<int> BuildCapturedThenContext(StringCallbackState state) =>
+        Capture(new StringLiteral('%').Then((_, span) => state.Record(span.ToString())))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedThenSpan))]
+    private static Parser<int> BuildCapturedThenSpan(StringCallbackState state) =>
+        Capture(new StringLiteral('%').Then((_, start, end, span) => state.Record(span.ToString())))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedWhen))]
+    private static Parser<int> BuildCapturedWhen() =>
+        Capture(new StringLiteral('%').When(static (_, span) => span.ToString() == "a\n"))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedSwitch))]
+    private static Parser<int> BuildCapturedSwitch() =>
+        Capture(new StringLiteral('%').Switch(static (_, span) => span.ToString() == "a\n" ? 0 : 1,
+            Literals.Char('!'), Literals.Char('?')))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedLeftAssociative))]
+    private static Parser<int> BuildCapturedLeftAssociative() =>
+        Capture(new StringLiteral('%').LeftAssociative((Literals.Char('+'),
+            static (left, right) => new TextSpan(StringParserCallbacks.Combine(left.ToString(), right.ToString())))))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedLeftAssociativeContext))]
+    private static Parser<int> BuildCapturedLeftAssociativeContext() =>
+        Capture(new StringLiteral('%').LeftAssociative((Literals.Char('+'),
+            static (_, left, right) => new TextSpan(StringParserCallbacks.Combine(left.ToString(), right.ToString())))))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedUnary))]
+    private static Parser<int> BuildCapturedUnary() =>
+        Capture(new StringLiteral('%').Unary((Literals.Char('!'),
+            static value => new TextSpan(StringParserCallbacks.Prefix(value.ToString())))))
+            .Then(static span => span.Length).Eof();
+
+    [GenerateParser(nameof(TryParseCapturedUnaryContext))]
+    private static Parser<int> BuildCapturedUnaryContext() =>
+        Capture(new StringLiteral('%').Unary((Literals.Char('!'),
+            static (_, value) => new TextSpan(StringParserCallbacks.Prefix(value.ToString())))))
+            .Then(static span => span.Length).Eof();
+}

--- a/test/Parlot.Tests/BenchmarksTests.cs
+++ b/test/Parlot.Tests/BenchmarksTests.cs
@@ -11,6 +11,18 @@ public class BenchmarksTests
     const decimal _expected2 = (decimal)-64.5;
 
     [Theory]
+    [InlineData("%hello%", 5)]
+    [InlineData("%hello\\nworld%", 11)]
+    public void GeneratedStrings(string input, int decodedLength)
+    {
+        var benchmarks = new GeneratedStringBenchmarks { Input = input };
+        benchmarks.Setup();
+
+        Assert.Equal(input.Length, benchmarks.Captured());
+        Assert.Equal(decodedLength, benchmarks.Decoded());
+    }
+
+    [Theory]
     [InlineData("a", true)]
     [InlineData("\u00e9", true)]
     [InlineData("\u4e2d", false)]


### PR DESCRIPTION
Generated custom-delimited strings allocate a delimiter array for every token, and `Capture` decodes strings whose decoded values are never used. This removes those allocations while preserving escape validation, backtracking, and callback behavior.

## Approach

- Emit `Scanner.ReadQuotedString(char, out _)` instead of allocating a `char[]` for custom delimiters.
- Skip string decoding when the generated value is discarded. Cache helpers by parser and result mode so capture-only and value-producing uses of the same parser remain independent.
- Preserve inputs consumed by `Then`, `When`, and `Switch`, and intermediate values needed by unary and left-associative callbacks. Restore the emission mode even when generation throws.

Includes regression coverage for shared-parser reuse in both orders, malformed strings, backtracking, callback execution and exceptions, and chained operators, plus persistent allocation benchmarks and documentation. No parsing-state redesign or internal helper inlining changes are included.

## Allocation results

BenchmarkDotNet, .NET 10.0.11, arm64, Apple M4 Pro. Before/after measurements use equivalent grammars in the same environment.

| Scenario | Before | After | Saved per parse |
|---|---:|---:|---:|
| Unescaped custom-delimited string | 224 B | 192 B | 32 B |
| Escaped custom-delimited string, decoded | 272 B | 240 B | 32 B |
| Escaped custom-delimited string, capture only | 272 B | 192 B | 80 B |

The fixed 192-byte parsing-state allocation remains. Shared-host timing varied, so this PR makes no general throughput claim.

## Validation

Using stable SDK 10.0.400:

- Full Release rebuild across all target frameworks succeeded.
- Runtime tests on net10.0: 860 passed.
- Source-generator tests: 228 passed.
- Standalone tests on net8.0 and net10.0: 30 passed.

The automatically selected .NET 11 RC SDK produced two failures in unchanged decimal-constant assertions; both passed with SDK 10.0.400. The repository's `global.json` is unchanged.